### PR TITLE
Refactor app bootstrap into centralized controller

### DIFF
--- a/app.lua
+++ b/app.lua
@@ -1,0 +1,134 @@
+local GameState = require("gamestate")
+local Screen = require("screen")
+local Settings = require("settings")
+local Audio = require("audio")
+local Achievements = require("achievements")
+local Score = require("score")
+local PlayerStats = require("playerstats")
+local GameModes = require("gamemodes")
+local UI = require("ui")
+
+local App = {
+    stateModules = {
+        menu = "menu",
+        modeselect = "modeselect",
+        game = "game",
+        gameover = "gameover",
+        achievementsmenu = "achievementsmenu",
+        settings = "settingsscreen",
+    }
+}
+
+local function clearStates()
+    for key in pairs(GameState.states) do
+        GameState.states[key] = nil
+    end
+end
+
+function App:registerStates()
+    clearStates()
+
+    for stateName, modulePath in pairs(self.stateModules) do
+        GameState.states[stateName] = require(modulePath)
+    end
+end
+
+function App:loadSubsystems()
+    Screen:update()
+    Settings:load()
+    Audio:load()
+    Achievements:load()
+    Score:load()
+    PlayerStats:load()
+    GameModes:loadUnlocks()
+end
+
+function App:resolveAction(action)
+    if not action then return end
+
+    if type(action) == "table" then
+        local stateName = action.state
+        if stateName and GameState.states[stateName] then
+            GameState:switch(stateName, action.data)
+        end
+        return
+    end
+
+    if type(action) ~= "string" then return end
+
+    if action == "quit" then
+        love.event.quit()
+        return
+    end
+
+    if GameState.states[action] then
+        GameState:switch(action)
+    end
+end
+
+function App:dispatch(eventName, ...)
+    local handler = GameState[eventName]
+    if not handler then return end
+
+    local result = handler(GameState, ...)
+    self:resolveAction(result)
+
+    return result
+end
+
+function App:load()
+    love.window.setMode(0, 0, {fullscreen = true, fullscreentype = "desktop"})
+
+    self:registerStates()
+    self:loadSubsystems()
+    GameState:switch("menu")
+end
+
+function App:update(dt)
+    local action = GameState:update(dt)
+    self:resolveAction(action)
+    UI:update(dt)
+end
+
+function App:draw()
+    GameState:draw()
+end
+
+function App:mousepressed(x, y, button)
+    return self:dispatch("mousepressed", x, y, button)
+end
+
+function App:mousereleased(x, y, button)
+    return self:dispatch("mousereleased", x, y, button)
+end
+
+function App:keypressed(key)
+    if key == "printscreen" then
+        local time = os.date("%Y-%m-%d_%H-%M-%S")
+        love.graphics.captureScreenshot("screenshot_" .. time .. ".png")
+    end
+
+    return self:dispatch("keypressed", key)
+end
+
+function App:joystickpressed(joystick, button)
+    return self:dispatch("joystickpressed", joystick, button)
+end
+
+function App:joystickreleased(joystick, button)
+    return self:dispatch("joystickreleased", joystick, button)
+end
+
+function App:gamepadpressed(joystick, button)
+    return self:dispatch("gamepadpressed", joystick, button)
+end
+
+function App:gamepadreleased(joystick, button)
+    return self:dispatch("gamepadreleased", joystick, button)
+end
+
+function App:resize()
+    Screen:update()
+end
+
+return App

--- a/main.lua
+++ b/main.lua
@@ -1,94 +1,45 @@
-local GameState = require("gamestate")
-local Menu = require("menu")
-local ModeSelect = require("modeselect")
-local Game = require("game")
-local GameOver = require("gameover")
-local GameModes = require("gamemodes")
-local AchievementsMenu = require("achievementsmenu")
-local Achievements = require("achievements")
-local Settings = require("settings")
-local SettingsScreen = require("settingsscreen")
-local Audio = require("audio")
-local Screen = require("screen")
-local Score = require("score")
-local PlayerStats = require("playerstats")
-local UI = require("ui")
-
--- Register states
-GameState.states.menu = Menu
-GameState.states.modeselect = ModeSelect
-GameState.states.game = Game
-GameState.states.gameover = GameOver
-GameState.states.achievementsmenu = AchievementsMenu
-GameState.states.settings = SettingsScreen
+local App = require("app")
 
 function love.load()
-	love.window.setMode(0, 0, {fullscreen = true, fullscreentype = "desktop"})
-
-	Screen:update()
-	Settings:load()
-	Audio:load()
-	Achievements:load()
-	Score:load()
-	PlayerStats:load()
-	GameModes:loadUnlocks()
-    GameState:switch("menu")
-
-	--[[for _, joystick in ipairs(love.joystick.getJoysticks()) do
-		print("Joystick found:", joystick:getName(), joystick:isGamepad() and "(Gamepad)" or "(Joystick)")
-	end]]
+    App:load()
 end
 
 function love.update(dt)
-	GameState:update(dt)
-	UI:update(dt)
+    App:update(dt)
 end
 
 function love.draw()
-	GameState:draw()
-end
-
-local function handleAction(action)
-	if action == "quit" then
-		love.event.quit()
-	elseif action then
-		GameState:switch(action)
-	end
+    App:draw()
 end
 
 function love.mousepressed(x, y, button)
-	handleAction(GameState:mousepressed(x, y, button))
+    App:mousepressed(x, y, button)
 end
 
 function love.mousereleased(x, y, button)
-	handleAction(GameState:mousereleased(x, y, button))
+    App:mousereleased(x, y, button)
 end
 
 function love.keypressed(key)
-	if key == "printscreen" then
-		local time = os.date("%Y-%m-%d_%H-%M-%S")
-		love.graphics.captureScreenshot("screenshot_" .. time .. ".png")
-	end
-
-	handleAction(GameState:keypressed(key))
+    App:keypressed(key)
 end
 
 function love.joystickpressed(joystick, button)
-	handleAction(GameState:joystickpressed(joystick, button))
+    App:joystickpressed(joystick, button)
 end
 
 function love.joystickreleased(joystick, button)
-	GameState:joystickreleased(joystick, button)
+    App:joystickreleased(joystick, button)
 end
 
 function love.gamepadpressed(joystick, button)
-	handleAction(GameState:gamepadpressed(joystick, button))
+    App:gamepadpressed(joystick, button)
 end
 
 function love.gamepadreleased(joystick, button)
-	GameState:gamepadreleased(joystick, button)
+    App:gamepadreleased(joystick, button)
 end
 
 function love.resize(w, h)
-	Screen:update()
+    App:resize(w, h)
 end


### PR DESCRIPTION
## Summary
- add a new `app` module that centralizes state registration, subsystem loading, and input dispatching
- simplify `GameState` so it focuses on state transitions and exposes a generic dispatcher while leaving action routing to the app layer
- trim `main.lua` down to a thin bridge that forwards Love callbacks to the new application coordinator

## Testing
- `lua -p main.lua app.lua gamestate.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d44f28ec54832fa4e8421b80fc4d94