### PR TITLE
Guide snake into exit hole

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -95,12 +95,14 @@ end
 function Game:startDescending(holeX, holeY, holeRadius)
     self.state = "descending"
     self.hole = {x = holeX, y = holeY, radius = holeRadius or 24}
+    Snake:startDescending(self.hole.x, self.hole.y, self.hole.radius)
 end
 
 -- start a floor transition
 function Game:startFloorTransition(advance, skipFade)
-	self.state = "transition"
-	self.transitionPhase = "fadeout"   -- new
+        Snake:finishDescending()
+        self.state = "transition"
+        self.transitionPhase = "fadeout"   -- new
 	self.transitionTimer = 0
 	self.transitionDuration = skipFade and 0 or 1.0
 	self.transitionAdvance = advance
@@ -166,6 +168,7 @@ function Game:update(dt)
             local dx, dy = tail.drawX - self.hole.x, tail.drawY - self.hole.y
             local dist = math.sqrt(dx*dx + dy*dy)
             if dist < self.hole.radius then
+                Snake:finishDescending()
                 self:startFloorTransition(true) -- will advance to next floor when finished
             end
         end

--- a/snake.lua
+++ b/snake.lua
@@ -8,6 +8,7 @@ local screenW, screenH
 local direction = { x = 1, y = 0 }
 local pendingDir = { x = 1, y = 0 }
 local trail = {}
+local descendingHole = nil
 local segmentCount = 1
 local reverseControls = false
 local popTimer = 0
@@ -66,6 +67,43 @@ local function toCell(x, y)
     return math.floor(x / SEGMENT_SPACING + 0.5), math.floor(y / SEGMENT_SPACING + 0.5)
 end
 
+local function findCircleIntersection(px, py, qx, qy, cx, cy, radius)
+    local dx = qx - px
+    local dy = qy - py
+    local fx = px - cx
+    local fy = py - cy
+
+    local a = dx * dx + dy * dy
+    if a == 0 then
+        return nil, nil
+    end
+
+    local b = 2 * (fx * dx + fy * dy)
+    local c = fx * fx + fy * fy - radius * radius
+    local discriminant = b * b - 4 * a * c
+
+    if discriminant < 0 then
+        return nil, nil
+    end
+
+    discriminant = math.sqrt(discriminant)
+    local t1 = (-b - discriminant) / (2 * a)
+    local t2 = (-b + discriminant) / (2 * a)
+
+    local t
+    if t1 >= 0 and t1 <= 1 then
+        t = t1
+    elseif t2 >= 0 and t2 <= 1 then
+        t = t2
+    end
+
+    if not t then
+        return nil, nil
+    end
+
+    return px + t * dx, py + t * dy
+end
+
 -- Build initial trail aligned to CELL CENTERS
 local function buildInitialTrail()
     local t = {}
@@ -95,6 +133,7 @@ function Snake:load(w, h)
     isDead = false
     self.reverseState = false
     trail = buildInitialTrail()
+    descendingHole = nil
 end
 
 function Snake:setReverseControls(state)
@@ -150,7 +189,42 @@ function Snake:drawClipped(hx, hy, hr)
     end
 
     local headX, headY = self:getHead()
-    local clipRadius = (hr or 0) * 0.5
+    local clipRadius = hr or 0
+    local renderTrail = trail
+
+    if clipRadius > 0 then
+        local radiusSq = clipRadius * clipRadius
+        local trimmed = {}
+
+        for i = 1, #trail do
+            local seg = trail[i]
+            local x = seg.drawX or seg.x
+            local y = seg.drawY or seg.y
+
+            if x and y then
+                local dx = x - hx
+                local dy = y - hy
+                if dx * dx + dy * dy <= radiusSq then
+                    if i > 1 then
+                        local prev = trail[i - 1]
+                        local px = prev.drawX or prev.x
+                        local py = prev.drawY or prev.y
+                        if px and py then
+                            local ix, iy = findCircleIntersection(px, py, x, y, hx, hy, clipRadius)
+                            if ix and iy then
+                                trimmed[#trimmed + 1] = { drawX = ix, drawY = iy }
+                            end
+                        end
+                    end
+                    renderTrail = trimmed
+                    break
+                end
+            end
+
+            trimmed[#trimmed + 1] = seg
+            renderTrail = trimmed
+        end
+    end
 
     love.graphics.push("all")
 
@@ -161,7 +235,7 @@ function Snake:drawClipped(hx, hy, hr)
         love.graphics.setStencilTest("equal", 0)
     end
 
-    DrawSnake(trail, segmentCount, SEGMENT_SIZE, popTimer, function()
+    DrawSnake(renderTrail, segmentCount, SEGMENT_SIZE, popTimer, function()
         if headX and headY and clipRadius > 0 then
             local dx = headX - hx
             local dy = headY - hy
@@ -176,12 +250,36 @@ function Snake:drawClipped(hx, hy, hr)
     love.graphics.pop()
 end
 
+function Snake:startDescending(hx, hy, hr)
+    descendingHole = {
+        x = hx,
+        y = hy,
+        radius = hr or 0
+    }
+end
+
+function Snake:finishDescending()
+    descendingHole = nil
+end
+
 function Snake:update(dt)
     if isDead then return false end
 
     -- base speed with upgrades/modifiers
     local head = trail[1]
     local speed = self:getSpeed()
+
+    local hole = descendingHole
+    if hole and head then
+        local dx = hole.x - head.drawX
+        local dy = hole.y - head.drawY
+        local dist = math.sqrt(dx * dx + dy * dy)
+        if dist > 1e-4 then
+            local nx, ny = dx / dist, dy / dist
+            direction = { x = nx, y = ny }
+            pendingDir = { x = nx, y = ny }
+        end
+    end
 
     -- adrenaline boost check
     if self.adrenaline and self.adrenaline.active then
@@ -192,29 +290,35 @@ function Snake:update(dt)
         end
     end
 
-    local newX = head.drawX + direction.x * speed * dt
-    local newY = head.drawY + direction.y * speed * dt
+    local stepX = direction.x * speed * dt
+    local stepY = direction.y * speed * dt
+    local newX = head.drawX + stepX
+    local newY = head.drawY + stepY
 
     -- advance cell clock, maybe snap & commit queued direction
     local snappedThisTick = false
     local moveInterval
-    if speed > 0 then
+    if speed > 0 and not hole then
         moveInterval = SEGMENT_SPACING / speed
     end
 
-    moveTimer = moveTimer + dt
-    local snaps = 0
-    while moveInterval and moveTimer >= moveInterval do
-        moveTimer = moveTimer - moveInterval
-        snaps = snaps + 1
-    end
-    if snaps > 0 then
-        -- snap to the nearest grid center
-        newX = snapToCenter(newX)
-        newY = snapToCenter(newY)
-        -- commit queued direction
-        direction = { x = pendingDir.x, y = pendingDir.y }
-        snappedThisTick = true
+    if hole then
+        moveTimer = 0
+    else
+        moveTimer = moveTimer + dt
+        local snaps = 0
+        while moveInterval and moveTimer >= moveInterval do
+            moveTimer = moveTimer - moveInterval
+            snaps = snaps + 1
+        end
+        if snaps > 0 then
+            -- snap to the nearest grid center
+            newX = snapToCenter(newX)
+            newY = snapToCenter(newY)
+            -- commit queued direction
+            direction = { x = pendingDir.x, y = pendingDir.y }
+            snappedThisTick = true
+        end
     end
 
     -- spatially uniform sampling along the motion path


### PR DESCRIPTION
## Summary
- guide the snake automatically toward the exit hole during the descent sequence so it no longer shoots through the portal
- skip grid snapping while descending and clamp rendering to the trimmed trail so body segments disappear into the hole
- coordinate the descent lifecycle from the game state to start and stop the guidance logic cleanly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d45b569f50832f8672c49f68303165