### PR TITLE
Add fruit combo streak effects and HUD indicator

### DIFF
--- a/fruitevents.lua
+++ b/fruitevents.lua
@@ -16,11 +16,88 @@ local Achievements = require("achievements")
 
 local FruitEvents = {}
 
+local comboState = {
+    count = 0,
+    timer = 0,
+    window = 2.25,
+}
+
+local function comboTagline(count)
+    if count >= 6 then
+        return "Unstoppable!"
+    elseif count >= 5 then
+        return "Blazing!"
+    elseif count >= 4 then
+        return "Hot Streak!"
+    elseif count >= 3 then
+        return "Juicy!"
+    else
+        return "Keep it going!"
+    end
+end
+
+local function applyComboReward(x, y)
+    if comboState.timer > 0 then
+        comboState.count = comboState.count + 1
+    else
+        comboState.count = 1
+    end
+
+    comboState.timer = comboState.window
+
+    local comboCount = comboState.count
+    UI:setCombo(comboCount, comboState.timer, comboState.window)
+
+    if comboCount < 2 then
+        return
+    end
+
+    local burstColor = {1, 0.82, 0.3, 1}
+    local bonus = math.min((comboCount - 1) * 2, 10)
+
+    FloatingText:add(comboTagline(comboCount), x, y - 32, burstColor, 1.3, 55)
+
+    if bonus > 0 then
+        Score:addBonus(bonus)
+        FloatingText:add("+" .. tostring(bonus) .. " bonus", x, y - 64, {1, 0.95, 0.6, 1}, 1.1, 50)
+    end
+
+    Particles:spawnBurst(x, y, {
+        count = love.math.random(10, 14) + comboCount,
+        speed = 90 + comboCount * 12,
+        life = 0.6,
+        size = 4,
+        color = burstColor,
+        spread = math.pi * 2,
+        gravity = 30,
+        drag = 2.5,
+        fadeTo = 0
+    })
+end
+
+function FruitEvents.reset()
+    comboState.count = 0
+    comboState.timer = 0
+    UI:setCombo(0, 0, comboState.window)
+end
+
+function FruitEvents.update(dt)
+    if comboState.timer > 0 then
+        comboState.timer = math.max(0, comboState.timer - dt)
+
+        if comboState.timer == 0 then
+            comboState.count = 0
+        end
+
+        UI:setCombo(comboState.count, comboState.timer, comboState.window)
+    end
+end
+
 function FruitEvents.handleConsumption(x, y)
     local points = Fruit:getPoints()
     local name = Fruit:getTypeName()
-	local FruitType = Fruit:getType()
-	local col, row = Fruit:getTile()
+    local fruitType = Fruit:getType()
+    local col, row = Fruit:getTile()
 
     Snake:grow()
     Face:set("happy", 2)
@@ -38,37 +115,37 @@ function FruitEvents.handleConsumption(x, y)
         spread = math.pi * 2
     })
 
-	if col and row then
-		SnakeUtils.setOccupied(col, row, false)
-	end
+    if col and row then
+        SnakeUtils.setOccupied(col, row, false)
+    end
 
-	if name == "Dragonfruit" then
-		Achievements:unlock("dragonHunter")
-	end
+    if name == "Dragonfruit" then
+        Achievements:unlock("dragonHunter")
+    end
 
     Fruit:spawn(Snake:getSegments(), Rocks)
 
     if love.math.random() < Rocks:getSpawnChance() then
-        local fx, fy, col, row = SnakeUtils.getSafeSpawn(Snake:getSegments(), Fruit, Rocks)
+        local fx, fy, tileCol, tileRow = SnakeUtils.getSafeSpawn(Snake:getSegments(), Fruit, Rocks)
         if fx then
-            --Rocks:spawn(fx, fy)
-                        Rocks:spawn(fx, fy, "small")
-
-            SnakeUtils.setOccupied(col, row, true)
+            Rocks:spawn(fx, fy, "small")
+            SnakeUtils.setOccupied(tileCol, tileRow, true)
         end
     end
 
     UI:triggerScorePulse()
-        UI:addFruit(FruitType)
-        Saws:onFruitCollected()
-        if Rocks.onFruitCollected then
-                Rocks:onFruitCollected(x, y)
-        end
+    UI:addFruit(fruitType)
+    Saws:onFruitCollected()
+    if Rocks.onFruitCollected then
+        Rocks:onFruitCollected(x, y)
+    end
 
-        if Snake.adrenaline then
-                Snake.adrenaline.active = true
-                Snake.adrenaline.timer = Snake.adrenaline.duration
-        end
+    applyComboReward(x, y)
+
+    if Snake.adrenaline then
+        Snake.adrenaline.active = true
+        Snake.adrenaline.timer = Snake.adrenaline.duration
+    end
 
     local jackpotChance = Score.getJackpotChance and Score:getJackpotChance() or 0
     if jackpotChance > 0 then

--- a/game.lua
+++ b/game.lua
@@ -114,15 +114,17 @@ end
 function Game:update(dt)
 	--if self.state == "gameover" then return end
 
-	-- pause
-	if self.state == "paused" then
-		PauseMenu:update(dt, true)
-		return
-	else
-		PauseMenu:update(dt, false)
-	end
+        -- pause
+        if self.state == "paused" then
+                PauseMenu:update(dt, true)
+                return
+        else
+                PauseMenu:update(dt, false)
+        end
 
-	if self.state == "transition" then
+        FruitEvents.update(dt)
+
+        if self.state == "transition" then
 		self.transitionTimer = self.transitionTimer + dt
 
 		if self.transitionPhase == "fadeout" then
@@ -215,11 +217,11 @@ function Game:update(dt)
 	Rocks:update(dt)
 	Saws:update(dt)
 	Arena:update(dt)
-	Particles:update(dt)
-	Achievements:update(dt)
-	FloatingText:update(dt)
+        Particles:update(dt)
+        Achievements:update(dt)
+        FloatingText:update(dt)
 
-	if self.state == "dying" then
+        if self.state == "dying" then
 		Death:update(dt)
 		if Death:isFinished() then
 			Achievements:save()
@@ -233,6 +235,8 @@ end
 
 function Game:setupFloor(floorNum)
     self.currentFloorData = Floors[floorNum] or Floors[1]
+
+    FruitEvents.reset()
 
     if self.currentFloorData.palette then
         for k, v in pairs(self.currentFloorData.palette) do

--- a/particles.lua
+++ b/particles.lua
@@ -2,48 +2,70 @@ local Particles = {}
 Particles.list = {}
 
 function Particles:spawnBurst(x, y, options)
-	local list = self.list
-	local count = options.count or 6
-	local speed = options.speed or 60
-	local life = options.life or 0.4
-	local baseSize = options.size or 4
-	local color = options.color or {1, 1, 1, 1}
-	local spread = options.spread or math.pi * 2
+        local list = self.list
+        local count = options.count or 6
+        local speed = options.speed or 60
+        local life = options.life or 0.4
+        local baseSize = options.size or 4
+        local color = options.color or {1, 1, 1, 1}
+        local spread = options.spread or math.pi * 2
+        local drag = options.drag or 0
+        local gravity = options.gravity or 0
+        local fadeTo = options.fadeTo
 
-	for i = 1, count do
-		local angle = spread * (i / count) + (love.math.random() - 0.5) * 0.2
-		local velocity = speed + love.math.random() * 20
-		local vx = math.cos(angle) * velocity
-		local vy = math.sin(angle) * velocity
-		local scale = 0.6 + love.math.random() * 0.8
+        for i = 1, count do
+                local angle = spread * (i / count) + (love.math.random() - 0.5) * 0.2
+                local velocity = speed + love.math.random() * 20
+                local vx = math.cos(angle) * velocity
+                local vy = math.sin(angle) * velocity
+                local scale = 0.6 + love.math.random() * 0.8
 
-		table.insert(list, {
-			x = x,
-			y = y,
-			vx = vx,
-			vy = vy,
-			baseSize = baseSize * scale,
-			life = life,
-			age = 0,
-			color = {unpack(color)}
-		})
-	end
+                table.insert(list, {
+                        x = x,
+                        y = y,
+                        vx = vx,
+                        vy = vy,
+                        baseSize = baseSize * scale,
+                        life = life,
+                        age = 0,
+                        color = {unpack(color)},
+                        drag = drag,
+                        gravity = gravity,
+                        fadeTo = fadeTo,
+                        startAlpha = color[4] or 1
+                })
+        end
 end
 
 function Particles:update(dt)
-	for i = #self.list, 1, -1 do
-		local p = self.list[i]
-		p.age = p.age + dt
-		if p.age >= p.life then
-			table.remove(self.list, i)
-		else
-			p.x = p.x + p.vx * dt
-			p.y = p.y + p.vy * dt
+        for i = #self.list, 1, -1 do
+                local p = self.list[i]
+                p.age = p.age + dt
+                if p.age >= p.life then
+                        table.remove(self.list, i)
+                else
+                        p.x = p.x + p.vx * dt
+                        p.y = p.y + p.vy * dt
 
-			local t = 1 - (p.age / p.life)
-			p.color[4] = t
-		end
-	end
+                        if p.drag and p.drag > 0 then
+                                local dragFactor = math.max(0, 1 - dt * p.drag)
+                                p.vx = p.vx * dragFactor
+                                p.vy = p.vy * dragFactor
+                        end
+
+                        if p.gravity and p.gravity ~= 0 then
+                                p.vy = p.vy + p.gravity * dt
+                        end
+
+                        local t = 1 - (p.age / p.life)
+                        local endAlpha = p.fadeTo
+                        if endAlpha == nil then
+                                p.color[4] = t
+                        else
+                                p.color[4] = (p.startAlpha or 1) * t + endAlpha * (1 - t)
+                        end
+                end
+        end
 end
 
 function Particles:draw()


### PR DESCRIPTION
## Summary
- add a combo streak system for quick fruit chains that awards bonus score, particles, and floating text feedback
- expose combo data to the HUD with a new animated indicator and adjust particles to support gravity, drag, and fade targets
- ensure combo state resets correctly between floors and keeps counting down during transitions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4763a6514832f8aca2915239e3da8