### PR TITLE
Introduce floor traits and UI to deepen roguelike progression

### DIFF
--- a/floors.lua
+++ b/floors.lua
@@ -24,14 +24,15 @@ local Floors = {
 	[1] = {
 		name = "Verdant Garden",
 		flavor = "The sun is warm, the air sweet with life.",
-		palette = {
-			bgColor     = {0.20, 0.28, 0.20, 1}, -- darker forest green backdrop
-			arenaBG     = {0.42, 0.62, 0.35, 1}, -- still bright, grassy playfield
-			arenaBorder = {0.55, 0.75, 0.4, 1},  -- leafy, slightly lighter edge
-			snake       = {0.12, 0.9, 0.48, 1},  -- vivid spring green snake
-			rock        = {0.68, 0.58, 0.42, 1}, -- warm tan stone
-		}
-	},
+                palette = {
+                        bgColor     = {0.20, 0.28, 0.20, 1}, -- darker forest green backdrop
+                        arenaBG     = {0.42, 0.62, 0.35, 1}, -- still bright, grassy playfield
+                        arenaBorder = {0.55, 0.75, 0.4, 1},  -- leafy, slightly lighter edge
+                        snake       = {0.12, 0.9, 0.48, 1},  -- vivid spring green snake
+                        rock        = {0.68, 0.58, 0.42, 1}, -- warm tan stone
+                },
+                traits = {"lushGrowth"},
+        },
     [2] = {
         name = "Echoing Caverns",
         flavor = "The air cools; faint echoes linger in the dark.",
@@ -41,7 +42,8 @@ local Floors = {
             arenaBorder= {0.2, 0.28, 0.42, 1},  -- cool blue edge
             snake      = {0.6, 0.65, 0.7, 1},   -- pale stone
             rock       = {0.25, 0.28, 0.32, 1}, -- sheen
-        }
+        },
+        traits = {"restlessEarth"},
     },
     [3] = {
         name = "Mushroom Grotto",
@@ -53,7 +55,8 @@ local Floors = {
             snake      = {0.45, 0.95, 0.75, 1}, -- neon cyan-green
             rock       = {0.25, 0.2, 0.3, 1},   -- fungus stone
             sawColor   = {0.85, 0.6, 0.9, 1},   -- bright fungal pink-pop
-        }
+        },
+        traits = {"glowingSpores"},
     },
     [4] = {
         name = "Ancient Ruins",
@@ -65,7 +68,8 @@ local Floors = {
             snake      = {0.95, 0.85, 0.55, 1}, -- faded gold
             rock       = {0.3, 0.25, 0.2, 1},   -- collapsed stone
             sawColor   = {0.7, 0.7, 0.75, 1},   -- pale tarnished steel
-        }
+        },
+        traits = {"ancientMachinery"},
     },
     [5] = {
         name = "Crystal Hollows",
@@ -77,7 +81,8 @@ local Floors = {
             snake      = {0.75, 0.9, 1.0, 1},   -- icy shine
             rock       = {0.3, 0.35, 0.5, 1},   -- tinted crystal gray
             sawColor   = {0.65, 0.85, 1.0, 1},  -- crystalline edges
-        }
+        },
+        traits = {"crystallineResonance"},
     },
     [6] = {
         name = "The Abyss",
@@ -89,7 +94,8 @@ local Floors = {
             snake      = {0.7, 0.35, 0.85, 1},  -- glowing violet
             rock       = {0.08, 0.1, 0.14, 1},  -- deep obsidian
             sawColor   = {0.55, 0.25, 0.6, 1},  -- eerie violet shimmer
-        }
+        },
+        traits = {"echoingStillness", "restlessEarth"},
     },
     [7] = {
         name = "Inferno Gates",
@@ -101,7 +107,8 @@ local Floors = {
             snake      = {1.0, 0.55, 0.25, 1},  -- ember orange
             rock       = {0.35, 0.15, 0.1, 1},  -- brimstone
             sawColor   = {1.0, 0.25, 0.25, 1},  -- glowing hot red
-        }
+        },
+        traits = {"infernalPressure"},
     },
     [8] = {
         name = "The Underworld",
@@ -113,7 +120,8 @@ local Floors = {
             snake      = {0.9, 0.15, 0.25, 1},  -- crimson glow
             rock       = {0.18, 0.15, 0.15, 1}, -- ashstone
             sawColor   = {1.0, 0.1, 0.2, 1},    -- hellsteel
-        }
+        },
+        traits = {"ashenTithe", "glowingSpores"},
     },
 }
 

--- a/floortraits.lua
+++ b/floortraits.lua
@@ -1,0 +1,121 @@
+local Rocks = require("rocks")
+local Saws = require("saws")
+local FruitEvents = require("fruitevents")
+
+local FloorTraits = {}
+
+local traits = {
+    lushGrowth = {
+        name = "Lush Growth",
+        desc = "Fruit goal reduced by 2 and one fewer rock at start.",
+        apply = function(ctx)
+            if ctx.fruitGoal then
+                ctx.fruitGoal = math.max(1, ctx.fruitGoal - 2)
+            end
+            if ctx.rocks then
+                ctx.rocks = math.max(0, ctx.rocks - 1)
+            end
+        end
+    },
+    restlessEarth = {
+        name = "Restless Earth",
+        desc = "More rocks rumble in; they also fall more often after fruit.",
+        apply = function(ctx)
+            if ctx.rocks then
+                ctx.rocks = math.min(40, math.floor((ctx.rocks * 1.3) + 0.5))
+            end
+            local chance = Rocks:getSpawnChance()
+            Rocks.spawnChance = math.min(0.85, chance + 0.15)
+        end
+    },
+    glowingSpores = {
+        name = "Glowing Spores",
+        desc = "Saws stall for 1.2s after each fruit.",
+        apply = function()
+            local current = Saws:getStallOnFruit()
+            Saws:setStallOnFruit(math.max(current, 1.2))
+        end
+    },
+    ancientMachinery = {
+        name = "Ancient Machinery",
+        desc = "One extra saw awakens to guard the ruins.",
+        apply = function(ctx)
+            if ctx.saws then
+                ctx.saws = math.min(8, ctx.saws + 1)
+            end
+            Saws.spinMult = (Saws.spinMult or 1) * 1.1
+        end
+    },
+    crystallineResonance = {
+        name = "Crystalline Resonance",
+        desc = "Saws move 15% slower and one fewer spawns.",
+        apply = function(ctx)
+            if ctx.saws then
+                ctx.saws = math.max(0, ctx.saws - 1)
+            end
+            Saws.speedMult = (Saws.speedMult or 1) * 0.85
+            Saws.spinMult = (Saws.spinMult or 1) * 0.9
+        end
+    },
+    echoingStillness = {
+        name = "Echoing Stillness",
+        desc = "Combo timer lasts 1 second longer.",
+        apply = function()
+            local base = FruitEvents:getDefaultComboWindow()
+            FruitEvents:setComboWindow(base + 1)
+        end
+    },
+    infernalPressure = {
+        name = "Infernal Pressure",
+        desc = "An extra saw joins the hunt and blades move 15% faster.",
+        apply = function(ctx)
+            if ctx.saws then
+                ctx.saws = math.min(8, ctx.saws + 1)
+            end
+            Saws.speedMult = (Saws.speedMult or 1) * 1.15
+        end
+    },
+    ashenTithe = {
+        name = "Ashen Tithe",
+        desc = "Fruit goal +3 but fruits shatter a nearby rock.",
+        apply = function(ctx)
+            if ctx.fruitGoal then
+                ctx.fruitGoal = math.max(1, ctx.fruitGoal + 3)
+            end
+            Rocks:addShatterOnFruit(1)
+        end
+    },
+}
+
+function FloorTraits:apply(list, context)
+    local applied = {}
+    local ctx = context or {}
+
+    if type(list) ~= "table" then
+        return ctx, applied
+    end
+
+    for _, id in ipairs(list) do
+        local trait = traits[id]
+        if trait then
+            if trait.apply then
+                trait.apply(ctx)
+            end
+            table.insert(applied, { name = trait.name, desc = trait.desc })
+        end
+    end
+
+    if ctx.rocks then
+        ctx.rocks = math.max(0, math.min(40, math.floor(ctx.rocks + 0.5)))
+    end
+    if ctx.saws then
+        ctx.saws = math.max(0, math.min(8, math.floor(ctx.saws + 0.5)))
+    end
+    if ctx.fruitGoal then
+        ctx.fruitGoal = math.max(1, math.floor(ctx.fruitGoal + 0.5))
+    end
+
+    return ctx, applied
+end
+
+return FloorTraits

--- a/fruitevents.lua
+++ b/fruitevents.lua
@@ -16,10 +16,12 @@ local Achievements = require("achievements")
 
 local FruitEvents = {}
 
+local DEFAULT_COMBO_WINDOW = 2.25
+
 local comboState = {
     count = 0,
     timer = 0,
-    window = 2.25,
+    window = DEFAULT_COMBO_WINDOW,
 }
 
 local function comboTagline(count)
@@ -78,7 +80,22 @@ end
 function FruitEvents.reset()
     comboState.count = 0
     comboState.timer = 0
+    comboState.window = DEFAULT_COMBO_WINDOW
     UI:setCombo(0, 0, comboState.window)
+end
+
+function FruitEvents:getComboWindow()
+    return comboState.window or DEFAULT_COMBO_WINDOW
+end
+
+function FruitEvents:getDefaultComboWindow()
+    return DEFAULT_COMBO_WINDOW
+end
+
+function FruitEvents:setComboWindow(window)
+    comboState.window = math.max(0.5, window or DEFAULT_COMBO_WINDOW)
+    comboState.timer = math.min(comboState.timer or 0, comboState.window)
+    UI:setCombo(comboState.count or 0, comboState.timer, comboState.window)
 end
 
 function FruitEvents.update(dt)

--- a/ui.lua
+++ b/ui.lua
@@ -17,6 +17,8 @@ UI.socketSize = 26
 UI.goalReachedAnim = 0
 UI.goalCelebrated = false
 
+UI.floorModifiers = {}
+
 UI.combo = {
     count = 0,
     timer = 0,
@@ -171,6 +173,7 @@ function UI:reset()
     self.combo.duration = 0
     self.combo.pop = 0
     self.combo.tagline = nil
+    self.floorModifiers = {}
 end
 
 function UI:triggerScorePulse()
@@ -181,7 +184,7 @@ end
 function UI:setFruitGoal(required)
     self.fruitRequired = required
     self.fruitCollected = 0
-	self.fruitSockets = {} -- clear collected fruit sockets each floor
+        self.fruitSockets = {} -- clear collected fruit sockets each floor
 end
 
 function UI:getFruitGoal(required)
@@ -190,6 +193,49 @@ end
 
 function UI:addFruit()
     self.fruitCollected = math.min(self.fruitCollected + 1, self.fruitRequired)
+end
+
+function UI:setFloorModifiers(modifiers)
+    if type(modifiers) == "table" then
+        self.floorModifiers = modifiers
+    else
+        self.floorModifiers = {}
+    end
+end
+
+function UI:drawFloorModifiers()
+    local modifiers = self.floorModifiers
+    if not modifiers or #modifiers == 0 then return end
+
+    local margin = 20
+    local width = 280
+    local x = love.graphics.getWidth() - width - margin
+    local y = margin
+
+    local lineHeight = UI.fonts.body:getHeight()
+    local height = 56 + (#modifiers * (lineHeight * 2))
+
+    love.graphics.setColor(Theme.panelColor)
+    love.graphics.rectangle("fill", x, y, width, height, 12, 12)
+
+    love.graphics.setColor(Theme.panelBorder)
+    love.graphics.setLineWidth(3)
+    love.graphics.rectangle("line", x, y, width, height, 12, 12)
+
+    love.graphics.setColor(Theme.textColor)
+    UI.setFont("button")
+    love.graphics.printf("Floor Traits", x + 16, y + 16, width - 32, "left")
+
+    UI.setFont("body")
+    local textY = y + 48
+    for _, trait in ipairs(modifiers) do
+        love.graphics.setColor(Theme.textColor)
+        love.graphics.printf(trait.name, x + 16, textY, width - 32, "left")
+        textY = textY + lineHeight
+        love.graphics.setColor(Theme.textColor[1], Theme.textColor[2], Theme.textColor[3], 0.75)
+        love.graphics.printf(trait.desc, x + 16, textY, width - 32, "left")
+        textY = textY + lineHeight + 8
+    end
 end
 
 function UI:isGoalReached()
@@ -450,6 +496,8 @@ function UI:draw()
             200, "left"
         )
     end
+
+    self:drawFloorModifiers()
 end
 
 return UI


### PR DESCRIPTION
## Summary
- add a floor trait system that can modify spawn counts, combo timing, and hazards between floors
- assign themed trait combinations to every floor and surface them in the intro banner and a new HUD panel
- expose combo window tuning utilities so traits can stretch the streak timer when needed

## Testing
- ⚠️ `luac -p floortraits.lua fruitevents.lua game.lua ui.lua floors.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d47cd22680832f841abc030e222550