### PR TITLE
Add design notes for fruit and tail length

### DIFF
--- a/Docs/fruit_tail_design.md
+++ b/Docs/fruit_tail_design.md
@@ -1,0 +1,24 @@
+# Fruit & Tail Length Design Notes
+
+## Why Fruit Matter
+- **Score Economy:** Fruit are the primary score drivers, so their value communicates moment-to-moment progress. Each pickup should feel rewarding through audio, particles, and floating text to reinforce that fruits are the heartbeat of the run.
+- **Risk vs Reward:** Placing fruit near hazards or along tricky movement lines nudges players into deliberate risk. Reward escalators (streak multipliers, combo timers) can amplify this tension without overwhelming new players.
+- **Pacing Levers:** Spawn cadence and variety in fruit types let us modulate tempo. Slow phases can feature fewer but higher-value fruit, while high-intensity waves can rain smaller, chainable pickups to create flow.
+- **Progression Hooks:** Fruit count can feed achievements, quests, or cosmetic unlocks. Highlighting milestones (e.g., "100 fruit collected" popups) gives players medium-term goals beyond raw score.
+
+## Why Tail Length Matters
+- **Spatial Challenge:** A longer tail constrains navigation, forcing smarter routing and introducing self-made obstacles. This turns continued success into an escalating puzzle rather than a static loop.
+- **Visual Feedback:** Tail length is a living health bar—players instantly read how well they are doing. Lean into this by brightening or animating the tail as it grows to celebrate progress.
+- **Mechanical Unlocks:** Tail thresholds can trigger new abilities (shield burst, speed toggle) or modifiers (heavier turning radius) that keep late-game runs fresh.
+- **Failure Drama:** Colliding with your own tail is a signature snake tension moment. Telegraphed near-misses, tail flickers, or slow-motion when you're about to clip yourself deepen that drama.
+
+## Interplay & Future Polish Ideas
+1. **Fruit Streak Meter:** Collect fruit consecutively to charge a meter that briefly shrinks the tail or grants a score multiplier. Missing or colliding resets the chain, adding a rhythmic challenge.
+2. **Tail Weight Modes:** Different game modes can alter how tail length behaves—endless mode could slowly decay tail segments, while challenge modes might lock the tail, demanding precise play.
+3. **Event-Driven Fruit:** Trigger special fruit after clearing hazards or surviving for set intervals. These could temporarily freeze tail growth or spawn trailing fruit lines to chase.
+4. **Feedback Enhancements:** Tie tail length to dynamic audio layers (longer tail adds harmonies) and use HUD callouts when fruit milestones are approaching.
+
+## Action Items
+- Prototype UI callouts that highlight fruit streaks and tail thresholds.
+- Audit spawn tables to ensure fruit placement creates intentional risk pockets.
+- Explore cosmetic rewards tied to extreme tail lengths to celebrate mastery.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@
 - [ ] Allow keyboard rebinding or arrow/WASD toggle
 - [x] Add volume sliders instead of just mute toggle
 
+## 🎯 Design & Balance
+- [x] Document why fruit value and tail length matter to the game loop
+- [ ] Prototype fruit streak systems that interact with tail length
+- [ ] Evaluate cosmetic unlocks tied to extreme tail milestones
+
 ## 🏁 Final Touches / Launch Polish
 - [x] Add game version to main menu
 - [ ] Add credits screen (can be simple)


### PR DESCRIPTION
## Summary
- add a design note document outlining why fruit pickups and tail length matter to pacing
- extend the polish checklist with design and balance tasks related to fruit streaks and tail-based rewards

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d47fb5fa80832f816d3a376c81ffc3