### PR TITLE
Add roguelike upgrade depth and persistent effects

### DIFF
--- a/gameutils.lua
+++ b/gameutils.lua
@@ -13,20 +13,20 @@ local UI = require("ui")
 local GameUtils = {}
 
 function GameUtils:prepareGame(sw, sh)
-	Snake:load(sw, sh)
-	Snake:resetModifiers()
-	PauseMenu:load(sw, sh)
-	Movement:reset()
-	Score:reset()
-	FloatingText:reset()
-	Particles:reset()
-	Rocks:reset()
-	Saws:reset()
-	UI:reset()
+        Snake:load(sw, sh)
+        Snake:resetModifiers()
+        PauseMenu:load(sw, sh)
+        Movement:reset()
+        Score:reset()
+        FloatingText:reset()
+        Particles:reset()
+        Rocks:reset()
+        Saws:reset()
+        UI:reset()
 
-	--SnakeUtils.initOccupancy()
+        --SnakeUtils.initOccupancy()
 
-	Fruit:spawn(Snake:getSegments(), Rocks)
+        Fruit:spawn(Snake:getSegments(), Rocks)
 end
 
 return GameUtils

--- a/score.lua
+++ b/score.lua
@@ -11,6 +11,7 @@ Score.saveFile = "scores.lua"
 Score.fruitBonus = 0
 Score.jackpotChance = 0
 Score.jackpotReward = 0
+Score.comboBonusMult = 1
 
 local function updateAchievementChecks(self)
         Achievements:checkAll({
@@ -25,6 +26,7 @@ function Score:load()
         self.highscores = {}
         self.jackpotChance = 0
         self.jackpotReward = 0
+        self.comboBonusMult = 1
 
         -- Load from file
 	if love.filesystem.getInfo(self.saveFile) then
@@ -70,6 +72,7 @@ function Score:reset(mode)
         self.fruitBonus = 0
         self.jackpotChance = 0
         self.jackpotReward = 0
+        self.comboBonusMult = 1
 	elseif mode == "all" then
 		self.highscores = {}
 		self:save()
@@ -123,6 +126,16 @@ function Score:addJackpotChance(chance, reward)
         if reward and reward > 0 then
                 self.jackpotReward = (self.jackpotReward or 0) + reward
         end
+end
+
+function Score:setComboBonusMultiplier(mult)
+        mult = mult or 1
+        if mult < 0 then mult = 0 end
+        self.comboBonusMult = mult
+end
+
+function Score:getComboBonusMultiplier()
+        return self.comboBonusMult or 1
 end
 
 function Score:getJackpotChance()

--- a/shop.lua
+++ b/shop.lua
@@ -1,14 +1,51 @@
 local UI = require("ui")
-local Shop = {}
 local Upgrades = require("upgrades")
 
-function Shop:start()
-    self.cards = Upgrades:getRandom(3)
+local Shop = {}
+
+function Shop:start(currentFloor)
+    self.floor = currentFloor or 1
+    self.cards = Upgrades:getRandom(3, { floor = self.floor }) or {}
     self.selected = nil
 end
 
 function Shop:update(dt)
-    -- could add animations later
+    -- reserved for future animations
+end
+
+local rarityBorderAlpha = 0.85
+
+local function drawCard(card, x, y, w, h, hovered)
+    local bgColor = hovered and {0.28, 0.35, 0.28, 1} or {0.2, 0.2, 0.2, 1}
+    love.graphics.setColor(bgColor)
+    love.graphics.rectangle("fill", x, y, w, h, 12, 12)
+
+    local borderColor = card.rarityColor or {1, 1, 1, rarityBorderAlpha}
+    love.graphics.setColor(borderColor[1], borderColor[2], borderColor[3], rarityBorderAlpha)
+    love.graphics.setLineWidth(4)
+    love.graphics.rectangle("line", x, y, w, h, 12, 12)
+
+    love.graphics.setColor(1, 1, 1, 1)
+    love.graphics.setFont(UI.fonts.button)
+    love.graphics.printf(card.name, x + 14, y + 24, w - 28, "center")
+
+    if card.rarityLabel then
+        love.graphics.setFont(UI.fonts.body)
+        love.graphics.setColor(borderColor[1], borderColor[2], borderColor[3], 0.9)
+        love.graphics.printf(card.rarityLabel, x + 14, y + 64, w - 28, "center")
+        love.graphics.setColor(1, 1, 1, 0.3)
+        love.graphics.setLineWidth(2)
+        love.graphics.line(x + 24, y + 92, x + w - 24, y + 92)
+    else
+        love.graphics.setColor(1, 1, 1, 0.3)
+        love.graphics.setLineWidth(2)
+        love.graphics.line(x + 24, y + 68, x + w - 24, y + 68)
+    end
+
+    love.graphics.setFont(UI.fonts.body)
+    love.graphics.setColor(0.92, 0.92, 0.92, 1)
+    local descY = card.rarityLabel and (y + 108) or (y + 80)
+    love.graphics.printf(card.desc or "", x + 18, descY, w - 36, "center")
 end
 
 function Shop:draw(screenW, screenH)
@@ -16,81 +53,52 @@ function Shop:draw(screenW, screenH)
     love.graphics.setFont(UI.fonts.title)
     love.graphics.printf("Choose an Upgrade", 0, screenH * 0.15, screenW, "center")
 
-    -- Card dimensions
-    local cardWidth, cardHeight = 220, 300
-    local spacing = 40
-
-    -- Center the row of cards
-    local totalWidth = (#self.cards * cardWidth) + ((#self.cards - 1) * spacing)
+    local cardWidth, cardHeight = 240, 320
+    local spacing = 48
+    local totalWidth = (#self.cards * cardWidth) + math.max(0, (#self.cards - 1)) * spacing
     local startX = (screenW - totalWidth) / 2
-    local y = screenH * 0.35
+    local y = screenH * 0.34
 
     local mx, my = love.mouse.getPosition()
 
     for i, card in ipairs(self.cards) do
-        local x = startX + (i-1) * (cardWidth + spacing)
-
-        -- Hover check
+        local x = startX + (i - 1) * (cardWidth + spacing)
         local hovered = mx >= x and mx <= x + cardWidth and my >= y and my <= y + cardHeight
-
-        -- Background
-        if hovered then
-            love.graphics.setColor(0.35, 0.65, 0.35, 1)
-        else
-            love.graphics.setColor(0.2, 0.2, 0.2, 1)
-        end
-        love.graphics.rectangle("fill", x, y, cardWidth, cardHeight, 12, 12)
-
-        -- Border
-        love.graphics.setColor(1, 1, 1, 0.9)
-        love.graphics.setLineWidth(3)
-        love.graphics.rectangle("line", x, y, cardWidth, cardHeight, 12, 12)
-
-        -- Title
-        love.graphics.setFont(UI.fonts.button)
-        love.graphics.setColor(1, 1, 1)
-        love.graphics.printf(card.name, x + 10, y + 20, cardWidth - 20, "center")
-
-        -- Separator line
-        love.graphics.setColor(1, 1, 1, 0.3)
-        love.graphics.setLineWidth(2)
-        love.graphics.line(x + 20, y + 60, x + cardWidth - 20, y + 60)
-
-        -- Description
-        love.graphics.setFont(UI.fonts.body)
-        love.graphics.setColor(0.9, 0.9, 0.9)
-        love.graphics.printf(card.desc, x + 15, y + 80, cardWidth - 30, "center")
-
-        -- Save bounds for clicking
-        card.bounds = {x = x, y = y, w = cardWidth, h = cardHeight}
+        drawCard(card, x, y, cardWidth, cardHeight, hovered)
+        card.bounds = { x = x, y = y, w = cardWidth, h = cardHeight }
     end
 end
 
+local function pickIndexFromKey(key)
+    if key == "1" or key == "kp1" then return 1 end
+    if key == "2" or key == "kp2" then return 2 end
+    if key == "3" or key == "kp3" then return 3 end
+end
+
 function Shop:keypressed(key)
-    if key == "1" or key == "kp1" then return self:pick(1) end
-    if key == "2" or key == "kp2" then return self:pick(2) end
-    if key == "3" or key == "kp3" then return self:pick(3) end
+    local index = pickIndexFromKey(key)
+    if index then
+        return self:pick(index)
+    end
 end
 
 function Shop:mousepressed(x, y, button)
-    if button == 1 then
-        for i, card in ipairs(self.cards) do
-            local b = card.bounds
-            if b and x >= b.x and x <= b.x+b.w and y >= b.y and y <= b.y+b.h then
-                return self:pick(i)
-            end
+    if button ~= 1 then return end
+    for i, card in ipairs(self.cards) do
+        local b = card.bounds
+        if b and x >= b.x and x <= b.x + b.w and y >= b.y and y <= b.y + b.h then
+            return self:pick(i)
         end
     end
 end
 
 function Shop:pick(i)
     local card = self.cards[i]
-    if card then
-        card.apply()
-        self.selected = card
-        return true
-    end
-    return false
+    if not card then return false end
+
+    Upgrades:acquire(card, { floor = self.floor })
+    self.selected = card
+    return true
 end
 
 return Shop

--- a/ui.lua
+++ b/ui.lua
@@ -193,6 +193,23 @@ function UI:setFruitGoal(required)
         self.fruitSockets = {} -- clear collected fruit sockets each floor
 end
 
+function UI:adjustFruitGoal(delta)
+    if not delta or delta == 0 then return end
+
+    local newGoal = math.max(1, (self.fruitRequired or 0) + delta)
+    self.fruitRequired = newGoal
+
+    if (self.fruitCollected or 0) > newGoal then
+        self.fruitCollected = newGoal
+    end
+
+    if type(self.fruitSockets) == "table" then
+        while #self.fruitSockets > newGoal do
+            table.remove(self.fruitSockets)
+        end
+    end
+end
+
 function UI:getFruitGoal(required)
     return self.fruitRequired
 end


### PR DESCRIPTION
## Summary
- overhaul the upgrade system with rarities, persistent run state, and new event-driven perks that apply across floors
- refresh the shop UI to present weighted upgrade cards with rarity styling and to pipe selections through the new upgrade manager
- extend combo scoring, UI fruit goal controls, and floor setup so upgrades influence gameplay and fruit collection dynamically

## Testing
- `luac -p upgrades.lua` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d48522bac8832fb3875ea913cf7b53