### PR TITLE
Clean up unused utilities and streamline helpers

### DIFF
--- a/audio.lua
+++ b/audio.lua
@@ -64,14 +64,4 @@ function Audio:stopMusic()
     end
 end
 
-function Audio:update(dt)
-    if self.movementTimer > 0 then
-        self.movementTimer = self.movementTimer - dt
-    end
-end
-
-function Audio:saveSettings()
-    Settings:save()
-end
-
 return Audio

--- a/drawword.lua
+++ b/drawword.lua
@@ -31,28 +31,6 @@ local letters = {
 	}
 }
 
-local function drawLetter(letterDef, ox, oy, cellSize)
-  local trail = {}
-  for i, pt in ipairs(letterDef) do
-    trail[#trail+1] = {
-      x = ox + pt[1] * cellSize,
-      y = oy + pt[2] * cellSize,
-    }
-  end
-
-  local function getHead()
-    return trail[#trail].x, trail[#trail].y
-  end
-
-for _, p in ipairs(trail) do
-  love.graphics.setColor(1, 0, 0)
-  love.graphics.circle("fill", p.x, p.y, 3)
-end
-
-
-  drawSnake(trail, #trail, cellSize, 0, getHead)
-end
-
 local function drawWord(word, ox, oy, cellSize, spacing)
   local x = ox
   local fullTrail = {}

--- a/fruit.lua
+++ b/fruit.lua
@@ -49,11 +49,6 @@ local lastCollectedType = fruitTypes[1]
 local function clamp(a, lo, hi) if a < lo then return lo elseif a > hi then return hi else return a end end
 
 local function easeOutQuad(t)  return 1 - (1 - t)^2 end
-local function easeOutBack(t)
-    local c1 = 1.70158; local c3 = c1 + 1
-    return 1 + c3 * (t - 1)^3 + c1 * (t - 1)^2
-end
-
 -- Helpers
 local function chooseFruitType()
     local total = 0

--- a/saws.lua
+++ b/saws.lua
@@ -1,6 +1,5 @@
 local Particles = require("particles")
 local Theme = require("theme")
-local Arena = require("arena")
 
 local Saws = {}
 local current = {}
@@ -26,12 +25,6 @@ local function getMoveSpeed()
 end
 
 -- Easing similar to Rocks
-local function easeOutBack(t)
-    local c1 = 1.70158
-    local c3 = c1 + 1
-    return 1 + c3 * (t - 1)^3 + c1 * (t - 1)^2
-end
-
 -- Spawn a saw on a track
 function Saws:spawn(x, y, radius, teeth, dir, side)
     table.insert(current, {

--- a/score.lua
+++ b/score.lua
@@ -1,8 +1,6 @@
 local PlayerStats = require("playerstats")
 local Achievements = require("achievements")
 local GameModes = require("gamemodes")
-local Snake = require("snake")
-
 local Score = {}
 
 Score.current = 0

--- a/snake.lua
+++ b/snake.lua
@@ -142,14 +142,6 @@ local function findCircleIntersection(px, py, qx, qy, cx, cy, radius)
     return px + t * dx, py + t * dy
 end
 
-local function cloneSegment(seg)
-    local copy = {}
-    for k, v in pairs(seg) do
-        copy[k] = v
-    end
-    return copy
-end
-
 local function trimHoleSegments(hole)
     if not hole or not trail or #trail == 0 then
         return

--- a/ui.lua
+++ b/ui.lua
@@ -1,7 +1,6 @@
 local Score = require("score")
 local Audio = require("audio")
 local Theme = require("theme")
-local Fruit = require("fruit")
 
 local UI = {}
 
@@ -437,31 +436,6 @@ local function drawComboIndicator(self)
     love.graphics.rectangle("line", x + barPadding - 2, barY - 2, barWidth + 4, barHeight + 4, 8, 8)
 
     love.graphics.pop()
-end
-
-local function drawFruitIcon(fruit, x, y, size, scale)
-    local r = size / 2
-    scale = scale or 1
-
-    -- shadow
-    love.graphics.setColor(0, 0, 0, 0.25)
-    love.graphics.ellipse("fill", x+2, y+2, r*scale, r*scale*0.85, 24)
-
-    -- body
-    love.graphics.setColor(fruit.color[1], fruit.color[2], fruit.color[3], 1)
-    love.graphics.ellipse("fill", x, y, r*scale, r*scale*0.85, 24)
-
-    -- outline
-    love.graphics.setColor(0, 0, 0, 1)
-    love.graphics.setLineWidth(2)
-    love.graphics.ellipse("line", x, y, r*scale, r*scale*0.85, 24)
-
-    -- dragonfruit glow
-    if fruit.name == "Dragonfruit" then
-        local pulse = 0.5 + 0.5 * math.sin(love.timer.getTime() * 6.0)
-        love.graphics.setColor(1, 0, 1, 0.25 * pulse)
-        love.graphics.circle("line", x, y, r*scale + 3*pulse)
-    end
 end
 
 function UI:drawFruitSockets()


### PR DESCRIPTION
## Summary
- remove unused helper functions and requires across the audio, UI, score, and snake modules
- consolidate `SnakeUtils.getSafeSpawn` into a single safe-zone aware implementation and drop the legacy trim stub
- delete unused easing helpers from fruit and saws modules

## Testing
- ⚠️ `for f in audio.lua drawword.lua fruit.lua saws.lua score.lua snake.lua snakeutils.lua ui.lua; do luac -p "$f"; done` *(fails: `luac` is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d498cc3170832f942ed015b5f79a0d