### PR TITLE
Add shield-driven relics and shield event hooks

### DIFF
--- a/movement.lua
+++ b/movement.lua
@@ -48,7 +48,9 @@ function Movement:update(dt)
                                 })
                                 -- optionally mark rock as destroyed or not; I'm leaving it intact
                                 if Snake.onShieldConsumed then
-                                        Snake:onShieldConsumed(rock.x, rock.y, "rock")
+                                        local centerX = rock.x + rock.w / 2
+                                        local centerY = rock.y + rock.h / 2
+                                        Snake:onShieldConsumed(centerX, centerY, "rock")
                                 end
                         else
                                 return "dead", "rock"


### PR DESCRIPTION
## Summary
- emit a new shieldConsumed event so defensive relics can react to crash saves
- create the Aegis Recycler, Molting Reflex, and Luminous Cache upgrades with bespoke effects and VFX
- ensure shield impacts (including self-collisions) broadcast coordinates for flavorful feedback

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d4a8b73d44832f8bfaa2254a6f669f