### PR TITLE
Tune stonebreaker upgrade and add upgrade visuals

### DIFF
--- a/rocks.lua
+++ b/rocks.lua
@@ -8,6 +8,7 @@ local current = {}
 
 Rocks.spawnChance = 0.25
 Rocks.shatterOnFruit = 0
+Rocks.shatterProgress = 0
 
 local ROCK_SIZE = 24
 local SPAWN_DURATION = 0.3
@@ -74,6 +75,7 @@ function Rocks:reset()
     current = {}
     self.spawnChance = 0.25
     self.shatterOnFruit = 0
+    self.shatterProgress = 0
 end
 
 local function spawnShatterFX(x, y)
@@ -121,9 +123,30 @@ function Rocks:addShatterOnFruit(count)
 end
 
 function Rocks:onFruitCollected(x, y)
-    local count = math.floor(self.shatterOnFruit or 0)
+    local rate = self.shatterOnFruit or 0
+    if rate <= 0 then
+        self.shatterProgress = 0
+        return
+    end
+
+    self.shatterProgress = (self.shatterProgress or 0) + rate
+    local count = math.floor(self.shatterProgress or 0)
     if count <= 0 then return end
+
+    self.shatterProgress = (self.shatterProgress or 0) - count
+    if self.shatterProgress < 0 then
+        self.shatterProgress = 0
+    end
+
     self:shatterNearest(x or 0, y or 0, count)
+end
+
+function Rocks:getShatterProgress()
+    return self.shatterProgress or 0
+end
+
+function Rocks:getShatterRate()
+    return self.shatterOnFruit or 0
 end
 
 function Rocks:update(dt)

--- a/upgrades.lua
+++ b/upgrades.lua
@@ -305,10 +305,16 @@ local pool = {
     register({
         id = "stonebreaker_hymn",
         name = "Stonebreaker Hymn",
-        desc = "Each fruit shatters the nearest rock.",
+        desc = "Every other fruit shatters the nearest rock. Stacks to every fruit.",
         rarity = "uncommon",
+        allowDuplicates = true,
+        maxStacks = 2,
         onAcquire = function(state)
-            state.effects.rockShatter = (state.effects.rockShatter or 0) + 1
+            state.effects.rockShatter = (state.effects.rockShatter or 0) + 0.5
+            state.counters.stonebreakerStacks = (state.counters.stonebreakerStacks or 0) + 1
+            if Snake.setStonebreakerStacks then
+                Snake:setStonebreakerStacks(state.counters.stonebreakerStacks)
+            end
         end,
     }),
     register({
@@ -709,6 +715,17 @@ function Upgrades:applyPersistentEffects(rebaseline)
     local rockChance = math.max(0.02, rockBase * (effects.rockSpawnMult or 1) + (effects.rockSpawnFlat or 0))
     Rocks.spawnChance = rockChance
     Rocks.shatterOnFruit = (base.rockShatter or 0) + (effects.rockShatter or 0)
+    if Snake.setStonebreakerStacks then
+        local stacks = 0
+        if state and state.counters then
+            stacks = state.counters.stonebreakerStacks or 0
+        end
+        if stacks <= 0 and effects.rockShatter then
+            local perStack = 0.5
+            stacks = math.floor(((effects.rockShatter or 0) / perStack) + 0.5)
+        end
+        Snake:setStonebreakerStacks(stacks)
+    end
 
     local comboBase = base.comboBonusMult or 1
     local comboMult = comboBase * (effects.comboBonusMult or 1)


### PR DESCRIPTION
## Summary
- weaken Stonebreaker Hymn so it shatters rocks every other fruit and stacks to hit every fruit
- track stonebreaker stacks and rock shatter progress to drive in-game feedback
- add new head auras for adrenaline bursts and stonebreaker readiness

## Testing
- `luacheck snake.lua snakedraw.lua rocks.lua upgrades.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d4b616ed14832facc1eb538699bf2a