### PR TITLE
Refine streak messaging and floor intro pacing

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -298,20 +298,41 @@ function Game:drawTransition()
         if self.transitionPhase == "floorintro" then
                 local data = self.transitionFloorData or self.currentFloorData
                 if data then
-                        local progress = (self.transitionDuration <= 0) and 1 or math.min(1, self.transitionTimer / self.transitionDuration)
-                        love.graphics.setColor(1, 1, 1, progress)
-                        love.graphics.setFont(UI.fonts.title)
-                        love.graphics.printf(data.name, 0, self.screenHeight / 2 - 80, self.screenWidth, "center")
-                        love.graphics.setFont(UI.fonts.button)
-                        love.graphics.printf(data.flavor, 0, self.screenHeight / 2, self.screenWidth, "center")
+                        local timer = self.transitionTimer or 0
+                        local progress = (self.transitionDuration <= 0) and 1 or math.min(1, timer / self.transitionDuration)
+
+                        local function fadeAlpha(delay, duration)
+                                local t = math.max(0, math.min(1, (timer - delay) / (duration or 0.35)))
+                                return progress * t
+                        end
+
+                        local nameAlpha = fadeAlpha(0.0, 0.4)
+                        if nameAlpha > 0 then
+                                love.graphics.setFont(UI.fonts.title)
+                                love.graphics.setColor(1, 1, 1, nameAlpha)
+                                love.graphics.printf(data.name, 0, self.screenHeight / 2 - 80, self.screenWidth, "center")
+                        end
+
+                        if data.flavor and data.flavor ~= "" then
+                                local flavorAlpha = fadeAlpha(0.45, 0.4)
+                                if flavorAlpha > 0 then
+                                        love.graphics.setFont(UI.fonts.button)
+                                        love.graphics.setColor(1, 1, 1, flavorAlpha)
+                                        love.graphics.printf(data.flavor, 0, self.screenHeight / 2, self.screenWidth, "center")
+                                end
+                        end
 
                         local traits = self.transitionTraits or self.activeFloorTraits
                         if traits and #traits > 0 then
                                 love.graphics.setFont(UI.fonts.body)
                                 local y = self.screenHeight / 2 + 64
                                 for i, trait in ipairs(traits) do
-                                        local text = trait.name .. ": " .. trait.desc
-                                        love.graphics.printf(text, self.screenWidth * 0.2, y + (i - 1) * 36, self.screenWidth * 0.6, "center")
+                                        local traitAlpha = fadeAlpha(1.0 + (i - 1) * 0.25, 0.35)
+                                        if traitAlpha > 0 then
+                                                love.graphics.setColor(1, 1, 1, traitAlpha)
+                                                local text = trait.name .. ": " .. trait.desc
+                                                love.graphics.printf(text, self.screenWidth * 0.2, y + (i - 1) * 36, self.screenWidth * 0.6, "center")
+                                        end
                                 end
                         end
                 end

--- a/ui.lua
+++ b/ui.lua
@@ -361,15 +361,15 @@ function UI:setCombo(count, timer, duration, tailBonus, tailLabel, tailWindowBon
         end
 
         if combo.count >= 6 then
-            combo.tagline = "Unstoppable!"
+            combo.tagline = "Max streak bonus!"
         elseif combo.count >= 5 then
-            combo.tagline = "Blazing!"
+            combo.tagline = "Huge streak bonus!"
         elseif combo.count >= 4 then
-            combo.tagline = "Hot Streak!"
+            combo.tagline = "Bigger streak bonus!"
         elseif combo.count >= 3 then
-            combo.tagline = "Juicy!"
+            combo.tagline = "Streak bonus active!"
         else
-            combo.tagline = "Keep it going!"
+            combo.tagline = nil
         end
     else
         if previous >= 2 then


### PR DESCRIPTION
## Summary
- replace combo tagline text with clearer streak bonus messaging and remove the redundant "Keep it going!"
- stagger the floor intro screen elements so the floor name, flavor line, and modifiers fade in sequentially

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d4b8ee0abc832fb27061d23dd1255f