### PR TITLE
Limit menu word faces to final letter

### DIFF
--- a/drawword.lua
+++ b/drawword.lua
@@ -34,15 +34,28 @@ local letters = {
 local function drawWord(word, ox, oy, cellSize, spacing)
   local x = ox
   local fullTrail = {}
+
+  local letterCount = 0
+  for i = 1, #word do
+    if letters[word:sub(i, i)] then
+      letterCount = letterCount + 1
+    end
+  end
+
+  local drawnLetters = 0
   for i = 1, #word do
     local ch = word:sub(i,i)
     local def = letters[ch]
     if def then
+      drawnLetters = drawnLetters + 1
       local letterTrail = {}
       for _, pt in ipairs(def) do
         table.insert(letterTrail, {x = x + pt[1] * cellSize, y = oy + pt[2] * cellSize})
       end
-      drawSnake(letterTrail, #letterTrail, cellSize)
+
+      local showFace = (drawnLetters == letterCount)
+      drawSnake(letterTrail, #letterTrail, cellSize, nil, nil, nil, nil, nil, showFace)
+
       for _, p in ipairs(letterTrail) do table.insert(fullTrail, p) end
 
       x = x + (3 * cellSize) + spacing

--- a/snakedraw.lua
+++ b/snakedraw.lua
@@ -209,7 +209,7 @@ local function drawAdrenalineAura(trail, hx, hy, SEGMENT_SIZE, data)
   love.graphics.setLineWidth(1)
 end
 
-local function drawSnake(trail, segmentCount, SEGMENT_SIZE, popTimer, getHead, shieldCount, shieldFlashTimer, upgradeVisuals)
+local function drawSnake(trail, segmentCount, SEGMENT_SIZE, popTimer, getHead, shieldCount, shieldFlashTimer, upgradeVisuals, drawFace)
   if not trail or #trail == 0 then return end
 
   --local thickness = SEGMENT_SIZE * 0.75
@@ -259,7 +259,7 @@ local function drawSnake(trail, segmentCount, SEGMENT_SIZE, popTimer, getHead, s
     love.graphics.circle("fill", hx, hy, half)
   end
 
-  if hx and hy then
+  if hx and hy and drawFace ~= false then
     if upgradeVisuals and upgradeVisuals.adrenaline then
       drawAdrenalineAura(trail, hx, hy, SEGMENT_SIZE, upgradeVisuals.adrenaline)
     end


### PR DESCRIPTION
## Summary
- add an optional flag to the snake renderer so faces can be suppressed when desired
- update the menu word drawing helper to only display a face on the final letter, keeping the one on the bottom of the "l"

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4bb412518832f8c48d8fc71d985f3