### PR TITLE
Simplify adrenaline visuals and remove vignette

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -63,21 +63,6 @@ local function drawAdrenalineGlow(self)
     love.graphics.rectangle("fill", 0, 0, self.screenWidth, self.screenHeight)
     love.graphics.setBlendMode("alpha")
 
-    local vignetteAlpha = 0.45 * glowStrength
-    local borderThickness = 120
-    local previousLineWidth = love.graphics.getLineWidth()
-    love.graphics.setColor(0, 0, 0, vignetteAlpha)
-    love.graphics.setLineWidth(borderThickness)
-    love.graphics.rectangle(
-        "line",
-        borderThickness / 2,
-        borderThickness / 2,
-        math.max(0, self.screenWidth - borderThickness),
-        math.max(0, self.screenHeight - borderThickness),
-        48,
-        48
-    )
-    love.graphics.setLineWidth(previousLineWidth)
     love.graphics.setColor(1, 1, 1, 1)
 end
 

--- a/snakedraw.lua
+++ b/snakedraw.lua
@@ -190,20 +190,14 @@ local function drawAdrenalineAura(trail, hx, hy, SEGMENT_SIZE, data)
     time = love.timer.getTime()
   end
 
-  local innerRadius = SEGMENT_SIZE * (0.45 + 0.25 * intensity)
-  local outerRadius = SEGMENT_SIZE * (0.95 + 0.35 * intensity)
+  local pulse = 0.9 + 0.1 * math.sin(time * 6)
+  local radius = SEGMENT_SIZE * (0.6 + 0.35 * intensity) * pulse
 
-  love.graphics.setColor(1, 0.6 + 0.25 * intensity, 0.2, 0.28 + 0.32 * intensity)
-  love.graphics.circle("fill", hx, hy, innerRadius)
+  love.graphics.setColor(1, 0.6 + 0.25 * intensity, 0.2, 0.35 + 0.4 * intensity)
+  love.graphics.circle("fill", hx, hy, radius)
 
-  local layers = 4
-  for i = 1, layers do
-    local t = i / layers
-    local radius = innerRadius + t * (outerRadius - innerRadius)
-    local fade = 1 - (i - 1) / layers
-    love.graphics.setColor(1, 0.52 + 0.3 * intensity, 0.18, (0.16 + 0.18 * intensity) * fade)
-    love.graphics.circle("line", hx, hy, radius)
-  end
+  love.graphics.setColor(1, 0.52 + 0.3 * intensity, 0.18, 0.2 + 0.25 * intensity)
+  love.graphics.circle("line", hx, hy, radius * 1.1)
 
   love.graphics.setColor(1, 1, 1, 1)
   love.graphics.setLineWidth(1)


### PR DESCRIPTION
## Summary
- simplify the adrenaline aura to a single pulsing glow for a cleaner surge effect
- remove the dark vignette overlay from the adrenaline glow rendering

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4c2e01abc832fb4852e8d56e30f36