### PR TITLE
Remove tail rhythm combo modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,9 @@
 - [x] Prototype fruit streak systems that interact with tail length
 - [ ] Evaluate cosmetic unlocks tied to extreme tail milestones
 
-### Tail Rhythm Streaks
-- Fruit combos now scale with the snake's body length via Tail Rhythm tiers.
-- Longer tails extend the combo window and add extra "Tail Flow" bonus points when streaking.
-- Each tier pops celebratory floating text so players understand when their tail powers up.
+### Combo Updates
+- Removed Tail Rhythm tiers so fruit streaks no longer depend on tail length.
+- Simplified combo messaging to focus on the current streak without "Tail Flow" bonuses.
 
 ## 🏁 Final Touches / Launch Polish
 - [x] Add game version to main menu

--- a/ui.lua
+++ b/ui.lua
@@ -24,9 +24,6 @@ UI.combo = {
     duration = 0,
     pop = 0,
     tagline = nil,
-    tailBonus = 0,
-    tailLabel = nil,
-    tailWindowBonus = 0,
 }
 
 -- Button states
@@ -175,9 +172,6 @@ function UI:reset()
     self.combo.duration = 0
     self.combo.pop = 0
     self.combo.tagline = nil
-    self.combo.tailBonus = 0
-    self.combo.tailLabel = nil
-    self.combo.tailWindowBonus = 0
     self.floorModifiers = {}
 end
 
@@ -338,7 +332,7 @@ function UI:update(dt)
     end
 end
 
-function UI:setCombo(count, timer, duration, tailBonus, tailLabel, tailWindowBonus)
+function UI:setCombo(count, timer, duration)
     local combo = self.combo
     local previous = combo.count or 0
 
@@ -350,10 +344,6 @@ function UI:setCombo(count, timer, duration, tailBonus, tailLabel, tailWindowBon
     elseif not combo.duration then
         combo.duration = 0
     end
-
-    combo.tailBonus = tailBonus or 0
-    combo.tailLabel = tailLabel
-    combo.tailWindowBonus = tailWindowBonus or 0
 
     if combo.count >= 2 then
         if combo.count > previous then
@@ -420,24 +410,6 @@ local function drawComboIndicator(self)
         UI.setFont("small")
         love.graphics.setColor(1, 0.9, 0.65, 0.9)
         love.graphics.printf(combo.tagline, x, y + 30, width, "center")
-    end
-
-    if combo.tailBonus and combo.tailBonus > 0 then
-        UI.setFont("small")
-        love.graphics.setColor(0.65, 0.85, 1, 0.9)
-        local label
-        if combo.tailLabel then
-            label = string.format("%s · +%d Tail Flow", combo.tailLabel, combo.tailBonus)
-        else
-            label = "Tail Flow +" .. tostring(combo.tailBonus)
-        end
-        love.graphics.printf(label, x, y + 44, width, "center")
-    elseif combo.tailWindowBonus and math.abs(combo.tailWindowBonus) > 0.05 then
-        UI.setFont("small")
-        local color = combo.tailWindowBonus > 0 and {0.7, 0.9, 1, 0.75} or {1, 0.6, 0.6, 0.85}
-        love.graphics.setColor(color)
-        local sign = combo.tailWindowBonus > 0 and "+" or ""
-        love.graphics.printf("Window " .. sign .. string.format("%.1fs", combo.tailWindowBonus), x, y + 44, width, "center")
     end
 
     local barPadding = 18


### PR DESCRIPTION
## Summary
- remove the Tail Rhythm tier table and tail-length-driven combo bonuses
- simplify the combo HUD so it only reflects streak count and taglines
- update the README to describe the streamlined combo system

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d4c58aff94832f910f3bffb82f04ed