### PR TITLE
Enhance Stone Skin upgrade interactions

### DIFF
--- a/movement.lua
+++ b/movement.lua
@@ -134,12 +134,18 @@ function Movement:update(dt)
         local sawHit = Saws:checkCollision(headX, headY, SEGMENT_SIZE, SEGMENT_SIZE)
 
         if sawHit then
-                if Snake:consumeCrashShield() then
+                local shielded = Snake:consumeCrashShield()
+                local survivedSaw = shielded
+
+                if not survivedSaw and Snake.consumeStoneSkinSawGrace then
+                        survivedSaw = Snake:consumeStoneSkinSawGrace()
+                end
+
+                if survivedSaw then
                         Particles:spawnBurst(headX, headY, {
                                 count = 8, speed = 40, life = 0.35, size = 3,
                                 color = {0.9,0.7,0.3,1}, spread = math.pi*2
                         })
-                        -- shield consumed -> survive
                         if Snake.onShieldConsumed then
                                 Snake:onShieldConsumed(headX, headY, "saw")
                         end

--- a/snake.lua
+++ b/snake.lua
@@ -31,6 +31,7 @@ Snake.extraGrowth = 0
 Snake.shieldBurst = nil
 Snake.shieldFlashTimer = 0
 Snake.stonebreakerStacks = 0
+Snake.stoneSkinSawGrace = 0
 
 -- getters / mutators (safe API for upgrades)
 function Snake:getSpeed()
@@ -63,6 +64,7 @@ function Snake:resetModifiers()
     self.shieldBurst  = nil
     self.shieldFlashTimer = 0
     self.stonebreakerStacks = 0
+    self.stoneSkinSawGrace = 0
     if self.adrenaline then
         self.adrenaline.active = false
         self.adrenaline.timer = 0
@@ -110,6 +112,21 @@ function Snake:onShieldConsumed(x, y, cause)
             cause = cause or "unknown",
         })
     end
+end
+
+function Snake:addStoneSkinSawGrace(n)
+    n = n or 1
+    if n <= 0 then return end
+    self.stoneSkinSawGrace = (self.stoneSkinSawGrace or 0) + n
+end
+
+function Snake:consumeStoneSkinSawGrace()
+    if (self.stoneSkinSawGrace or 0) > 0 then
+        self.stoneSkinSawGrace = self.stoneSkinSawGrace - 1
+        self.shieldFlashTimer = SHIELD_FLASH_DURATION
+        return true
+    end
+    return false
 end
 
 -- >>> Small integration note:

--- a/upgrades.lua
+++ b/upgrades.lua
@@ -74,6 +74,16 @@ local function getEventPosition(data)
     return nil, nil
 end
 
+local function stoneSkinShieldHandler(data, state)
+    if not state then return end
+    if (state.takenSet and (state.takenSet["stone_skin"] or 0) <= 0) then return end
+    if not data or data.cause ~= "rock" then return end
+    if not Rocks or not Rocks.shatterNearest then return end
+
+    local fx, fy = getEventPosition(data)
+    Rocks:shatterNearest(fx or 0, fy or 0, 1)
+end
+
 local function newRunState()
     return {
         takenOrder = {},
@@ -111,12 +121,19 @@ local pool = {
     register({
         id = "stone_skin",
         name = "Stone Skin",
-        desc = "Gain a crash shield.",
+        desc = "Gain a crash shield that shatters rocks and shrugs off a saw clip.",
         rarity = "common",
         allowDuplicates = true,
         maxStacks = 4,
         onAcquire = function(state)
             Snake:addCrashShields(1)
+            if Snake.addStoneSkinSawGrace then
+                Snake:addStoneSkinSawGrace(1)
+            end
+            if not state.counters.stoneSkinHandlerRegistered then
+                state.counters.stoneSkinHandlerRegistered = true
+                Upgrades:addEventHandler("shieldConsumed", stoneSkinShieldHandler)
+            end
         end,
     }),
     register({


### PR DESCRIPTION
## Summary
- make Stone Skin grant a saw grace charge in addition to a crash shield
- shatter the impacted rock whenever a Stone Skin shield is spent on a collision
- expose helper APIs on the snake to track and consume the new grace charges

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d4cc376528832f9aa42763277d3c9f