### PR TITLE
Destroy saws when shields absorb them

### DIFF
--- a/movement.lua
+++ b/movement.lua
@@ -142,6 +142,8 @@ function Movement:update(dt)
                 end
 
                 if survivedSaw then
+                        Saws:destroy(sawHit)
+
                         Particles:spawnBurst(headX, headY, {
                                 count = 8, speed = 40, life = 0.35, size = 3,
                                 color = {0.9,0.7,0.3,1}, spread = math.pi*2


### PR DESCRIPTION
## Summary
- make saw collision checks return the blade that was struck so we can react to it directly
- destroy saws when shields or similar effects absorb the impact to prevent instant follow-up deaths
- centralize saw center calculations and add burst feedback for shattered blades

## Testing
- not run (logic change only)


------
https://chatgpt.com/codex/tasks/task_e_68d4e53f521c832f83034c81f0c1533e