### PR TITLE
Keep saw slots and let shields break rocks

### DIFF
--- a/movement.lua
+++ b/movement.lua
@@ -118,7 +118,8 @@ function Movement:update(dt)
                                         count = 8, speed = 40, life = 0.4, size = 3,
                                         color = {0.9, 0.8, 0.5, 1}, spread = math.pi*2
                                 })
-                                -- optionally mark rock as destroyed or not; I'm leaving it intact
+                                Rocks:destroy(rock, { spawnFX = false })
+                                -- clear the shattered rock so the next frame doesn't collide again
                                 if Snake.onShieldConsumed then
                                         local centerX = rock.x + rock.w / 2
                                         local centerY = rock.y + rock.h / 2

--- a/rocks.lua
+++ b/rocks.lua
@@ -89,6 +89,43 @@ local function spawnShatterFX(x, y)
     })
 end
 
+local function removeRockAt(index, spawnFX)
+    if not index then return nil end
+
+    local rock = table.remove(current, index)
+    if not rock then return nil end
+
+    releaseOccupancy(rock)
+
+    if spawnFX ~= false then
+        spawnShatterFX(rock.x, rock.y)
+    end
+
+    return rock
+end
+
+function Rocks:destroy(target, opts)
+    if not target then return nil end
+
+    opts = opts or {}
+    local spawnFX = opts.spawnFX
+    if spawnFX == nil then
+        spawnFX = true
+    end
+
+    if type(target) == "number" then
+        return removeRockAt(target, spawnFX)
+    end
+
+    for index, rock in ipairs(current) do
+        if rock == target then
+            return removeRockAt(index, spawnFX)
+        end
+    end
+
+    return nil
+end
+
 function Rocks:shatterNearest(x, y, count)
     count = count or 1
     if count <= 0 or #current == 0 then return end
@@ -109,11 +146,7 @@ function Rocks:shatterNearest(x, y, count)
 
         if not bestIndex then break end
 
-        local shattered = table.remove(current, bestIndex)
-        if shattered then
-            spawnShatterFX(shattered.x, shattered.y)
-            releaseOccupancy(shattered)
-        end
+        removeRockAt(bestIndex, true)
     end
 end
 


### PR DESCRIPTION
## Summary
- keep a list of saw track slots so the groove continues to render after a blade is destroyed
- add a reusable rock destruction helper and ensure shields remove rocks they shatter

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d4e795edb0832fafb19637d59a622a