### PR TITLE
Fix achievements circular dependency with snake

### DIFF
--- a/achievements.lua
+++ b/achievements.lua
@@ -1,7 +1,7 @@
 local Audio = require("audio")
 local Localization = require("localization")
 local PlayerStats = require("playerstats")
-local Snake = require("snake")
+local Snake
 
 local Achievements = {
     definitions = {},
@@ -122,6 +122,16 @@ function Achievements:_ensureInitialized()
         end)
 
         self:registerStateProvider(function()
+            if not Snake then
+                local ok, module = pcall(require, "snake")
+                if ok then
+                    Snake = module
+                else
+                    print("[achievements] failed to require snake:", module)
+                    return nil
+                end
+            end
+
             if Snake and Snake.getLength then
                 local length = Snake:getLength()
                 if length then


### PR DESCRIPTION
## Summary
- avoid requiring the snake module at achievements load time to stop the circular dependency
- lazily load snake inside the default state provider and cache the result
- add logging when the snake module fails to load for achievements state providers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d584f29684832fbf5fc60742ea701b