### PR TITLE
Add dynamic background effects

### DIFF
--- a/achievementsmenu.lua
+++ b/achievementsmenu.lua
@@ -5,6 +5,7 @@ local Theme = require("theme")
 local UI = require("ui")
 local ButtonList = require("buttonlist")
 local Localization = require("localization")
+local Backdrop = require("backdrop")
 
 local AchievementsMenu = {}
 
@@ -17,6 +18,8 @@ function AchievementsMenu:enter()
     UI.clearButtons()
 
     local sw, sh = Screen:get()
+    Backdrop:resize(sw, sh)
+    Backdrop:onPaletteChanged()
 
     buttonList:reset({
         {
@@ -50,13 +53,19 @@ function AchievementsMenu:enter()
 end
 
 function AchievementsMenu:update(dt)
+    local sw, sh = Screen:get()
+    Backdrop:update(dt, sw, sh)
+
     local mx, my = love.mouse.getPosition()
     buttonList:updateHover(mx, my)
 end
 
 function AchievementsMenu:draw()
     local sw, sh = Screen:get()
-    love.graphics.clear(Theme.bgColor)
+    local bg = Theme.bgColor or {0, 0, 0, 1}
+    love.graphics.clear(bg[1] or 0, bg[2] or 0, bg[3] or 0, bg[4] or 1)
+
+    Backdrop:drawBase(sw, sh)
 
     love.graphics.setFont(UI.fonts.title)
     love.graphics.setColor(1, 1, 1)
@@ -158,6 +167,8 @@ function AchievementsMenu:draw()
     end
 
     buttonList:draw()
+
+    Backdrop:drawVignette(sw, sh)
 end
 
 function AchievementsMenu:mousepressed(x, y, button)

--- a/arena.lua
+++ b/arena.lua
@@ -111,6 +111,20 @@ function Arena:drawBackground()
     love.graphics.setColor(Theme.arenaBG)
     love.graphics.rectangle("fill", ax, ay, aw, ah)
 
+    love.graphics.push("all")
+    love.graphics.setScissor(ax, ay, aw, ah)
+    love.graphics.setBlendMode("add")
+
+    local glow = Theme.arenaHighlight or {1, 1, 1, 0.12}
+    love.graphics.setColor(glow[1], glow[2], glow[3], glow[4] or 0.12)
+    love.graphics.ellipse("fill", ax + aw / 2, ay + ah / 2, aw * 0.48, ah * 0.44, 96)
+
+    local horizon = Theme.arenaHorizon or {0.6, 0.45, 0.7, 0.12}
+    love.graphics.setColor(horizon[1], horizon[2], horizon[3], horizon[4] or 0.12)
+    love.graphics.rectangle("fill", ax, ay + ah * 0.55, aw, ah * 0.45)
+
+    love.graphics.pop()
+
     love.graphics.setColor(1, 1, 1, 1)
 end
 

--- a/backdrop.lua
+++ b/backdrop.lua
@@ -1,0 +1,286 @@
+local Theme = require("theme")
+
+local Backdrop = {
+    width = 0,
+    height = 0,
+    gradientMesh = nil,
+    vignetteMesh = nil,
+    orbs = {},
+    time = 0,
+    scanTimer = 0,
+    cachedTop = nil,
+    cachedBottom = nil,
+    cachedVignetteColor = nil,
+    cachedAccentA = nil,
+    cachedAccentB = nil,
+}
+
+local ORB_COUNT = 14
+
+local function copyColor(color, fallback)
+    local src = color or fallback or {0, 0, 0, 1}
+    return {src[1] or 0, src[2] or 0, src[3] or 0, src[4] or src[4] == 0 and 0 or 1}
+end
+
+local function colorChanged(a, b)
+    if not a then return true end
+
+    for i = 1, 4 do
+        local av = a[i] or 0
+        local bv = b[i] or 0
+        if math.abs(av - bv) > 0.001 then
+            return true
+        end
+    end
+
+    return false
+end
+
+function Backdrop:resetGeometry()
+    self.gradientMesh = nil
+    self.vignetteMesh = nil
+    self.cachedTop = nil
+    self.cachedBottom = nil
+    self.cachedVignetteColor = nil
+end
+
+function Backdrop:initializeOrbs(width, height, force)
+    if not force and #self.orbs > 0 then return end
+
+    self.orbs = {}
+    for i = 1, ORB_COUNT do
+        local radius = love.math.random(40, 120)
+        local speed = (love.math.random() * 12 + 6) * (love.math.random() < 0.5 and -1 or 1)
+        self.orbs[i] = {
+            x = love.math.random() * width,
+            baseY = love.math.random() * height,
+            radius = radius,
+            speed = speed,
+            waveSpeed = love.math.random() * 0.4 + 0.2,
+            waveOffset = love.math.random() * math.pi * 2,
+            driftSpeed = love.math.random() * 0.3 + 0.1,
+            colorMix = love.math.random(),
+        }
+    end
+
+    self.cachedAccentA = copyColor(Theme.bgAccent, {0.95, 0.6, 0.75, 0.12})
+    self.cachedAccentB = copyColor(Theme.bgAccentSecondary, {0.4, 0.65, 0.9, 0.1})
+end
+
+function Backdrop:onPaletteChanged()
+    self:resetGeometry()
+    self:initializeOrbs(self.width, self.height, true)
+end
+
+function Backdrop:resize(width, height)
+    if width <= 0 or height <= 0 then return end
+
+    if self.width ~= width or self.height ~= height then
+        self.width = width
+        self.height = height
+        self:resetGeometry()
+        self:initializeOrbs(width, height, true)
+    end
+end
+
+function Backdrop:update(dt, width, height)
+    width = width or self.width
+    height = height or self.height
+
+    if not width or not height then return end
+
+    if self.width ~= width or self.height ~= height then
+        self:resize(width, height)
+    end
+
+    if #self.orbs == 0 then
+        self:initializeOrbs(width, height, true)
+    end
+
+    self.time = (self.time or 0) + dt
+    self.scanTimer = (self.scanTimer or 0) + dt
+
+    for _, orb in ipairs(self.orbs) do
+        orb.x = orb.x + orb.speed * dt
+        if orb.x < -orb.radius then
+            orb.x = width + orb.radius
+        elseif orb.x > width + orb.radius then
+            orb.x = -orb.radius
+        end
+
+        local drift = math.sin(self.time * orb.driftSpeed + orb.waveOffset) * 18 * dt
+        orb.baseY = orb.baseY + drift
+        if orb.baseY < -orb.radius then
+            orb.baseY = height + orb.radius
+        elseif orb.baseY > height + orb.radius then
+            orb.baseY = -orb.radius
+        end
+    end
+end
+
+function Backdrop:refreshGradient(width, height)
+    local top = copyColor(Theme.bgGradientTop, Theme.bgColor)
+    local bottom = copyColor(Theme.bgGradientBottom, Theme.bgColor)
+
+    if not self.gradientMesh or self.width ~= width or self.height ~= height or
+       colorChanged(self.cachedTop, top) or colorChanged(self.cachedBottom, bottom) then
+        self.gradientMesh = love.graphics.newMesh({
+            {0,      0,      0, 0, top[1],    top[2],    top[3],    top[4]},
+            {width,  0,      1, 0, top[1],    top[2],    top[3],    top[4]},
+            {width,  height, 1, 1, bottom[1], bottom[2], bottom[3], bottom[4]},
+            {0,      height, 0, 1, bottom[1], bottom[2], bottom[3], bottom[4]},
+        }, "fan", "static")
+
+        self.cachedTop = top
+        self.cachedBottom = bottom
+    end
+end
+
+function Backdrop:refreshVignette(width, height)
+    local vignette = copyColor(Theme.vignetteColor, {0, 0, 0, 0.7})
+
+    if not self.vignetteMesh or self.width ~= width or self.height ~= height or colorChanged(self.cachedVignetteColor, vignette) then
+        local alpha = vignette[4] or 0.7
+        self.vignetteMesh = love.graphics.newMesh({
+            {width / 2, height / 2, 0.5, 0.5, vignette[1], vignette[2], vignette[3], 0},
+            {0,         0,          0,   0,  vignette[1], vignette[2], vignette[3], alpha},
+            {width,     0,          1,   0,  vignette[1], vignette[2], vignette[3], alpha},
+            {width,     height,     1,   1,  vignette[1], vignette[2], vignette[3], alpha},
+            {0,         height,     0,   1,  vignette[1], vignette[2], vignette[3], alpha},
+        }, "fan", "static")
+
+        self.cachedVignetteColor = vignette
+    end
+end
+
+function Backdrop:drawGradient(width, height)
+    self:refreshGradient(width, height)
+    if not self.gradientMesh then return end
+
+    love.graphics.setColor(1, 1, 1, 1)
+    love.graphics.draw(self.gradientMesh)
+end
+
+local function lerpColor(a, b, t)
+    return a[1] * t + b[1] * (1 - t),
+           a[2] * t + b[2] * (1 - t),
+           a[3] * t + b[3] * (1 - t),
+           (a[4] or 0) * t + (b[4] or 0) * (1 - t)
+end
+
+function Backdrop:drawOrbs(width, height)
+    if #self.orbs == 0 then return end
+
+    local accentA = copyColor(Theme.bgAccent, self.cachedAccentA)
+    local accentB = copyColor(Theme.bgAccentSecondary, self.cachedAccentB)
+
+    love.graphics.push("all")
+    love.graphics.setBlendMode("add")
+
+    for _, orb in ipairs(self.orbs) do
+        local y = orb.baseY + math.sin(self.time * orb.waveSpeed + orb.waveOffset) * orb.radius * 0.2
+        local x = orb.x
+        local t = orb.colorMix
+        local r, g, b, a = lerpColor(accentA, accentB, t)
+        local pulse = 0.6 + 0.4 * math.sin(self.time * 1.2 + orb.waveOffset * 1.7)
+        local alpha = (a or 0.1) * pulse
+
+        love.graphics.setColor(r, g, b, alpha)
+        love.graphics.circle("fill", x, y, orb.radius, 64)
+
+        love.graphics.setLineWidth(2)
+        love.graphics.setColor(r, g, b, alpha * 0.6)
+        love.graphics.circle("line", x, y, orb.radius * 1.15, 64)
+    end
+
+    love.graphics.pop()
+end
+
+function Backdrop:drawScanlines(width, height)
+    local color = copyColor(Theme.scanlineColor, {0.95, 0.75, 1.0, 0.08})
+    local bandHeight = height * 0.18
+    local y = (self.scanTimer * 45) % (height + bandHeight) - bandHeight
+
+    love.graphics.push("all")
+    love.graphics.setBlendMode("add")
+
+    love.graphics.setColor(color[1], color[2], color[3], color[4])
+    love.graphics.rectangle("fill", 0, y, width, bandHeight)
+
+    love.graphics.setColor(color[1], color[2], color[3], color[4] * 0.6)
+    love.graphics.rectangle("fill", 0, y - bandHeight * 0.25, width, bandHeight * 0.25)
+    love.graphics.rectangle("fill", 0, y + bandHeight, width, bandHeight * 0.25)
+
+    love.graphics.pop()
+end
+
+function Backdrop:drawBase(width, height)
+    if not width or not height then return end
+
+    self:drawGradient(width, height)
+    self:drawOrbs(width, height)
+    self:drawScanlines(width, height)
+end
+
+function Backdrop:drawArenaGlow(arena)
+    if not arena then return end
+
+    local ax, ay, aw, ah = arena:getBounds()
+    local glow = copyColor(Theme.arenaHighlight, {1, 0.8, 1, 0.18})
+    local inner = copyColor(Theme.arenaHorizon, {0.7, 0.5, 0.8, 0.12})
+
+    love.graphics.push("all")
+    love.graphics.setBlendMode("add")
+
+    love.graphics.setColor(glow[1], glow[2], glow[3], glow[4])
+    love.graphics.ellipse("fill", ax + aw / 2, ay + ah / 2, aw * 0.52, ah * 0.5, 96)
+
+    love.graphics.setColor(inner[1], inner[2], inner[3], inner[4])
+    love.graphics.ellipse("fill", ax + aw / 2, ay + ah * 0.45, aw * 0.45, ah * 0.35, 96)
+
+    love.graphics.pop()
+end
+
+function Backdrop:drawArenaGrid(arena)
+    if not arena then return end
+
+    local ax, ay, aw, ah = arena:getBounds()
+    local primary = copyColor(Theme.arenaGridPrimary, {1, 1, 1, 0.04})
+    local highlight = copyColor(Theme.arenaGridHighlight, {0.9, 0.6, 0.85, 0.08})
+
+    love.graphics.push("all")
+    love.graphics.setScissor(ax, ay, aw, ah)
+
+    love.graphics.setLineWidth(1)
+    love.graphics.setColor(primary[1], primary[2], primary[3], primary[4])
+
+    local step = arena.tileSize
+    for x = ax + step, ax + aw - step, step do
+        love.graphics.line(x, ay, x, ay + ah)
+    end
+    for y = ay + step, ay + ah - step, step do
+        love.graphics.line(ax, y, ax + aw, y)
+    end
+
+    local pulse = 0.5 + 0.5 * math.sin(self.time * 1.4)
+    love.graphics.setColor(highlight[1], highlight[2], highlight[3], (highlight[4] or 0.08) * pulse)
+
+    local diagStep = step * 2
+    for x = ax - ah, ax + aw, diagStep do
+        love.graphics.line(x, ay, x + ah, ay + ah)
+    end
+
+    love.graphics.pop()
+end
+
+function Backdrop:drawVignette(width, height)
+    if not width or not height then return end
+
+    self:refreshVignette(width, height)
+    if not self.vignetteMesh then return end
+
+    love.graphics.setColor(1, 1, 1, 1)
+    love.graphics.draw(self.vignetteMesh)
+end
+
+return Backdrop

--- a/game.lua
+++ b/game.lua
@@ -27,6 +27,7 @@ local Death = require("death")
 local Floors = require("floors")
 local Shop = require("shop")
 local Upgrades = require("upgrades")
+local Backdrop = require("backdrop")
 
 local Game = {}
 local TRACK_LENGTH = 120
@@ -90,6 +91,7 @@ function Game:load()
         Screen:update()
         self.screenWidth, self.screenHeight = Screen:get()
         Arena:updateScreenBounds(self.screenWidth, self.screenHeight)
+        Backdrop:resize(self.screenWidth, self.screenHeight)
 
         Score:load()
         Upgrades:beginRun()
@@ -441,6 +443,8 @@ function Game:drawDescending()
 end
 
 function Game:update(dt)
+        Backdrop:update(dt, self.screenWidth, self.screenHeight)
+
         if self.state == "paused" then
                 PauseMenu:update(dt, true)
                 return
@@ -485,6 +489,8 @@ function Game:setupFloor(floorNum)
             Theme[k] = v
         end
     end
+
+    Backdrop:onPaletteChanged()
 
     -- reset entities
     Arena:resetExit()
@@ -569,18 +575,21 @@ function Game:setupFloor(floorNum)
 end
 
 function Game:draw()
-        love.graphics.clear()
+        local bg = Theme.bgColor or {0, 0, 0, 1}
+        love.graphics.clear(bg[1] or 0, bg[2] or 0, bg[3] or 0, bg[4] or 1)
 
-        love.graphics.setColor(Theme.bgColor)
-        love.graphics.rectangle("fill", 0, 0, self.screenWidth, self.screenHeight)
+        Backdrop:drawBase(self.screenWidth, self.screenHeight)
 
         if self.state == "transition" then
                 self:drawTransition()
+                Backdrop:drawVignette(self.screenWidth, self.screenHeight)
                 return
         end
 
         Arena:drawBackground()
+        Backdrop:drawArenaGlow(Arena)
         Death:applyShake()
+        Backdrop:drawArenaGrid(Arena)
 
         Fruit:draw()
         Rocks:draw()
@@ -610,6 +619,8 @@ function Game:draw()
         if self.mode and self.mode.draw then
                 self.mode.draw(self, self.screenWidth, self.screenHeight)
         end
+
+        Backdrop:drawVignette(self.screenWidth, self.screenHeight)
 end
 
 function Game:keypressed(key)

--- a/gameover.lua
+++ b/gameover.lua
@@ -5,6 +5,7 @@ local Theme = require("theme")
 local UI = require("ui")
 local ButtonList = require("buttonlist")
 local Localization = require("localization")
+local Backdrop = require("backdrop")
 
 local GameOver = {}
 
@@ -67,6 +68,8 @@ function GameOver:enter(data)
 
     -- Build buttons
     local sw, sh = Screen:get()
+    Backdrop:resize(sw, sh)
+    Backdrop:onPaletteChanged()
     local startY = math.floor(sh * 0.55)
     local centerX = sw / 2 - BUTTON_WIDTH / 2
 
@@ -89,11 +92,17 @@ function GameOver:enter(data)
     buttonList:reset(defs)
 end
 
+function GameOver:update(dt)
+    local sw, sh = Screen:get()
+    Backdrop:update(dt, sw, sh)
+end
+
 function GameOver:draw()
     local sw, sh = Screen:get()
+    local bg = Theme.bgColor or {0, 0, 0, 1}
+    love.graphics.clear(bg[1] or 0, bg[2] or 0, bg[3] or 0, bg[4] or 1)
 
-    love.graphics.setColor(Theme.bgColor)
-    love.graphics.rectangle("fill", 0, 0, sw, sh)
+    Backdrop:drawBase(sw, sh)
 
     -- Title
     love.graphics.setFont(fontLarge)
@@ -126,6 +135,8 @@ function GameOver:draw()
     end
 
     buttonList:draw()
+
+    Backdrop:drawVignette(sw, sh)
 end
 
 function GameOver:mousepressed(x, y, button)

--- a/menu.lua
+++ b/menu.lua
@@ -6,6 +6,7 @@ local drawWord = require("drawword")
 local Face = require("face")
 local ButtonList = require("buttonlist")
 local Localization = require("localization")
+local Backdrop = require("backdrop")
 
 local Menu = {}
 
@@ -21,6 +22,8 @@ function Menu:enter()
     Screen:update()
 
     local sw, sh = Screen:get()
+    Backdrop:resize(sw, sh)
+    Backdrop:onPaletteChanged()
     local centerX = sw / 2
     local startY = sh / 2 - ((UI.spacing.buttonHeight + UI.spacing.buttonSpacing) * 2.5)
 
@@ -59,6 +62,9 @@ end
 function Menu:update(dt)
     t = t + dt
 
+    local sw, sh = Screen:get()
+    Backdrop:update(dt, sw, sh)
+
     local mx, my = love.mouse.getPosition()
     buttonList:updateHover(mx, my)
 
@@ -80,9 +86,10 @@ end
 
 function Menu:draw()
     local sw, sh = Screen:get()
+    local bg = Theme.bgColor or {0, 0, 0, 1}
+    love.graphics.clear(bg[1] or 0, bg[2] or 0, bg[3] or 0, bg[4] or 1)
 
-    love.graphics.setColor(Theme.bgColor)
-    love.graphics.rectangle("fill", 0, 0, sw, sh)
+    Backdrop:drawBase(sw, sh)
 
     local cellSize = 20
     local word = Localization:get("menu.title_word")
@@ -123,6 +130,8 @@ function Menu:draw()
     love.graphics.setFont(UI.fonts.small)
     love.graphics.setColor(Theme.textColor)
     love.graphics.print(Localization:get("menu.version"), 10, sh - 24)
+
+    Backdrop:drawVignette(sw, sh)
 end
 
 function Menu:mousepressed(x, y, button)

--- a/modeselect.lua
+++ b/modeselect.lua
@@ -6,6 +6,7 @@ local UI = require("ui")
 local Theme = require("theme")
 local ButtonList = require("buttonlist")
 local Localization = require("localization")
+local Backdrop = require("backdrop")
 
 local ModeSelect = {}
 
@@ -16,6 +17,8 @@ function ModeSelect:enter()
     UI.clearButtons()
 
     local sw, sh = Screen:get()
+    Backdrop:resize(sw, sh)
+    Backdrop:onPaletteChanged()
     local centerX = sw / 2
 
     local buttonWidth = math.min(600, sw - 100)
@@ -70,15 +73,19 @@ function ModeSelect:enter()
 end
 
 function ModeSelect:update(dt)
+    local sw, sh = Screen:get()
+    Backdrop:update(dt, sw, sh)
+
     local mx, my = love.mouse.getPosition()
     buttonList:updateHover(mx, my)
 end
 
 function ModeSelect:draw()
     local sw, sh = Screen:get()
+    local bg = Theme.bgColor or {0, 0, 0, 1}
+    love.graphics.clear(bg[1] or 0, bg[2] or 0, bg[3] or 0, bg[4] or 1)
 
-    love.graphics.setColor(Theme.bgColor)
-    love.graphics.rectangle("fill", 0, 0, sw, sh)
+    Backdrop:drawBase(sw, sh)
 
     love.graphics.setFont(UI.fonts.title)
     love.graphics.setColor(Theme.textColor)
@@ -122,6 +129,8 @@ function ModeSelect:draw()
             love.graphics.print(scoreText, btn.x + btn.w - tw - 20, btn.y + 12)
         end
     end
+
+    Backdrop:drawVignette(sw, sh)
 end
 
 function ModeSelect:mousepressed(x, y, button)

--- a/settingsscreen.lua
+++ b/settingsscreen.lua
@@ -4,6 +4,7 @@ local UI = require("ui")
 local Theme = require("theme")
 local Settings = require("settings")
 local Localization = require("localization")
+local Backdrop = require("backdrop")
 
 local SettingsScreen = {}
 
@@ -28,6 +29,8 @@ local focusedIndex = 1
 function SettingsScreen:enter()
     Screen:update()
     local sw, sh = Screen:get()
+    Backdrop:resize(sw, sh)
+    Backdrop:onPaletteChanged()
     local centerX = sw / 2
     local totalHeight = (#options) * (UI.spacing.buttonHeight + UI.spacing.buttonSpacing) - UI.spacing.buttonSpacing
     local startY = sh / 2 - totalHeight / 2
@@ -78,6 +81,9 @@ function SettingsScreen:update(dt)
     local mx, my = love.mouse.getPosition()
     hoveredIndex = nil
 
+    local sw, sh = Screen:get()
+    Backdrop:update(dt, sw, sh)
+
     for i, btn in ipairs(buttons) do
         local opt = btn.option
         btn.hovered = UI.isHovered(btn.x, btn.y, btn.w, btn.h, mx, my)
@@ -101,8 +107,11 @@ function SettingsScreen:update(dt)
 end
 
 function SettingsScreen:draw()
-    local sw, _ = Screen:get()
-    love.graphics.clear(Theme.bgColor)
+    local sw, sh = Screen:get()
+    local bg = Theme.bgColor or {0, 0, 0, 1}
+    love.graphics.clear(bg[1] or 0, bg[2] or 0, bg[3] or 0, bg[4] or 1)
+
+    Backdrop:drawBase(sw, sh)
 
     love.graphics.setFont(UI.fonts.title)
     love.graphics.setColor(1, 1, 1)
@@ -168,6 +177,8 @@ function SettingsScreen:draw()
             UI.drawButton(btn.id)
         end
     end
+
+    Backdrop:drawVignette(sw, sh)
 end
 
 function SettingsScreen:updateFocusVisuals()

--- a/theme.lua
+++ b/theme.lua
@@ -130,6 +130,12 @@ local Theme = {
 
     -- General background
     bgColor         = {0.08, 0.08, 0.1, 1}, -- Deep slate gray
+    bgGradientTop    = {0.16, 0.12, 0.24, 1}, -- Rich indigo highlight
+    bgGradientBottom = {0.04, 0.05, 0.1, 1},  -- Midnight base
+    bgAccent         = {0.9, 0.55, 0.75, 0.16}, -- Soft magenta glow
+    bgAccentSecondary= {0.45, 0.7, 0.9, 0.12},  -- Cool cyan accent
+    scanlineColor    = {0.95, 0.75, 1.0, 0.1},  -- Moving light band
+    vignetteColor    = {0.02, 0.01, 0.06, 0.82}, -- Dark edge vignette
     shadowColor     = {0, 0, 0, 0.4},       -- Stronger shadow for depth
     highlightColor  = {1, 1, 1, 0.05},      -- Very subtle sheen
 
@@ -141,6 +147,12 @@ local Theme = {
     -- Panels
     panelColor      = {0.18, 0.18, 0.22, 0.9}, -- Dark slate
     panelBorder     = {0.35, 0.3, 0.5, 1},     -- Dusty periwinkle
+
+    -- Arena accents
+    arenaHighlight   = {0.95, 0.7, 0.95, 0.2},  -- Central glow
+    arenaHorizon     = {0.55, 0.45, 0.75, 0.14}, -- Horizon bloom
+    arenaGridPrimary = {1, 1, 1, 0.05},         -- Base grid lines
+    arenaGridHighlight = {0.9, 0.6, 0.85, 0.1}, -- Animated diagonals
 
     -- Text
     textColor       = {0.85, 0.85, 0.9, 1}, -- Soft off-white


### PR DESCRIPTION
## Summary
- add a reusable Backdrop module that renders gradient fills, floating lights, scanlines, arena glow, and vignette layers
- integrate the new backdrop across gameplay, menus, settings, achievements, and game over screens for a unified visual style
- extend the base theme palette and arena background to support the new lighting accents

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d59fcbdf1c832fb1744a3e0acfc6c2