### PR TITLE
Extend upgrade selection hold duration

### DIFF
--- a/shop.lua
+++ b/shop.lua
@@ -68,7 +68,7 @@ function Shop:start(currentFloor)
     self.time = 0
     self.selectionProgress = 0
     self.selectionTimer = 0
-    self.selectionHoldDuration = 0.85
+    self.selectionHoldDuration = 1.35
     self.selectionComplete = false
     for i = 1, #self.cards do
         self.cardStates[i] = {


### PR DESCRIPTION
## Summary
- increase the time the selected upgrade card remains focused before closing the shop

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5a4874db0832f915c48dbc99810fd