### PR TITLE
Add scroll support to achievements menu

### DIFF
--- a/app.lua
+++ b/app.lua
@@ -104,6 +104,10 @@ function App:mousereleased(x, y, button)
     return self:dispatch("mousereleased", x, y, button)
 end
 
+function App:wheelmoved(dx, dy)
+    return self:dispatch("wheelmoved", dx, dy)
+end
+
 function App:keypressed(key)
     if key == "printscreen" then
         local time = os.date("%Y-%m-%d_%H-%M-%S")

--- a/main.lua
+++ b/main.lua
@@ -20,6 +20,10 @@ function love.mousereleased(x, y, button)
     App:mousereleased(x, y, button)
 end
 
+function love.wheelmoved(dx, dy)
+    App:wheelmoved(dx, dy)
+end
+
 function love.keypressed(key)
     App:keypressed(key)
 end


### PR DESCRIPTION
## Summary
- add scroll offset handling, clamping, and clipping to achievements menu rendering
- dispatch mouse wheel events through the app and main entry point

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5ac98135c832fa18593330a4ca98c