### PR TITLE
Fix achievements scroll wheel handling

### DIFF
--- a/achievementsmenu.lua
+++ b/achievementsmenu.lua
@@ -226,7 +226,12 @@ function AchievementsMenu:mousereleased(x, y, button)
     return action
 end
 
-function AchievementsMenu:wheelmoved(_, dy)
+function AchievementsMenu:wheelmoved(dx, dy)
+    -- The colon syntax implicitly passes `self` as the first argument.
+    -- The previous signature treated that implicit parameter as the
+    -- horizontal scroll delta, so `dy` was always zero and scrolling
+    -- never occurred. Accept the real horizontal delta explicitly and
+    -- ignore it instead.
     if dy == 0 then
         return
     end


### PR DESCRIPTION
## Summary
- correct the AchievementsMenu wheel handler to accept both scroll deltas
- prevent the implicit self parameter from overriding the vertical scroll amount

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5ae71c9f0832f910235451acb6517