### PR TITLE
Enhance state and gameplay transitions

### DIFF
--- a/gamestate.lua
+++ b/gamestate.lua
@@ -3,11 +3,14 @@ local GameState = {}
 GameState.states = {}
 GameState.current = nil
 GameState.next = nil
+GameState.transitionFrom = nil
 GameState.transitionTime = 0
-GameState.transitionDuration = 1.2
+GameState.transitionDuration = 1.0
 GameState.transitioning = false
 GameState.transitionDirection = 1 -- 1 = fade out, -1 = fade in
 GameState.pendingData = nil
+GameState.queuedState = nil
+GameState.queuedData = nil
 
 local transitionBlockedEvents = {
     mousepressed = true,
@@ -57,9 +60,35 @@ local function shouldBlockDuringTransition(eventName)
 end
 
 function GameState:switch(stateName, data)
-    local currentState = getCurrentState(self)
-    if currentState and currentState.leave then
-        currentState:leave()
+    if self.transitioning then
+        self.queuedState = stateName
+        self.queuedData = data
+        return
+    end
+
+    if self.current == nil or self.transitionDuration <= 0 then
+        local previous = getCurrentState(self)
+        if previous and previous.leave then
+            previous:leave()
+        end
+
+        self.current = stateName
+        self.transitionFrom = nil
+        self.transitionTime = 0
+        self.transitioning = false
+        self.transitionDirection = -1
+        self.pendingData = nil
+
+        local nextState = getCurrentState(self)
+        if nextState and nextState.enter then
+            nextState:enter(data)
+        end
+
+        if nextState and nextState.onTransitionEnd then
+            nextState:onTransitionEnd("in", nil)
+        end
+
+        return
     end
 
     self.next = stateName
@@ -67,44 +96,116 @@ function GameState:switch(stateName, data)
     self.transitioning = true
     self.transitionDirection = 1
     self.transitionTime = 0
+    self.transitionFrom = self.current
+
+    local currentState = getCurrentState(self)
+    if currentState and currentState.onTransitionStart then
+        currentState:onTransitionStart("out", stateName)
+    end
 end
 
 function GameState:update(dt)
     if self.transitioning then
-        self.transitionTime = self.transitionTime + dt / self.transitionDuration
+        self.transitionTime = math.min(1, self.transitionTime + dt / self.transitionDuration)
 
         if self.transitionDirection == 1 and self.transitionTime >= 1 then
-            -- Switch state at peak
-            self.transitionDirection = -1
-            self.transitionTime = 0
+            local previousState = getCurrentState(self)
+            if previousState and previousState.onTransitionEnd then
+                previousState:onTransitionEnd("out", self.next)
+            end
+            if previousState and previousState.leave then
+                previousState:leave()
+            end
+
             self.current = self.next
             self.next = nil
+            self.transitionDirection = -1
+            self.transitionTime = 0
 
             local nextState = getCurrentState(self)
             if nextState and nextState.enter then
                 nextState:enter(self.pendingData)
             end
+            if nextState and nextState.onTransitionStart then
+                nextState:onTransitionStart("in", self.transitionFrom)
+            end
 
             self.pendingData = nil
         elseif self.transitionDirection == -1 and self.transitionTime >= 1 then
+            local activeState = getCurrentState(self)
+            if activeState and activeState.onTransitionEnd then
+                activeState:onTransitionEnd("in", self.transitionFrom)
+            end
+
             self.transitioning = false
             self.transitionTime = 0
+            self.transitionFrom = nil
+
+            if self.queuedState then
+                local queuedState, queuedData = self.queuedState, self.queuedData
+                self.queuedState, self.queuedData = nil, nil
+                self:switch(queuedState, queuedData)
+            end
         end
 
-        return
+        return callCurrentState(self, "transitionUpdate", dt, self.transitionDirection, self.transitionTime)
     end
 
     return callCurrentState(self, "update", dt)
 end
 
 function GameState:draw()
-    callCurrentState(self, "draw")
+    local handledTransitionDraw = false
 
-    -- Fade overlay with easing
     if self.transitioning then
+        local stateName = self.transitionDirection == 1 and self.transitionFrom or self.current
+        local state = stateName and self.states[stateName]
+
+        if state and state.draw then
+            handledTransitionDraw = true
+
+            local width = love.graphics.getWidth()
+            local height = love.graphics.getHeight()
+            local progress = math.min(math.max(self.transitionTime, 0), 1)
+            local eased = easeInOutCubic(progress)
+            local scale, offsetY
+
+            if self.transitionDirection == 1 then
+                scale = 1 - 0.05 * eased
+                offsetY = 24 * eased
+            else
+                local inv = 1 - eased
+                scale = 1 + 0.05 * inv
+                offsetY = 32 * inv
+            end
+
+            love.graphics.push()
+            love.graphics.translate(width / 2, height / 2 + offsetY)
+            love.graphics.scale(scale, scale)
+            love.graphics.translate(-width / 2, -height / 2)
+            state:draw()
+            love.graphics.pop()
+        end
+    end
+
+    if not handledTransitionDraw then
+        callCurrentState(self, "draw")
+    end
+
+    -- Fade overlay with easing and subtle bloom
+    if self.transitioning then
+        local width = love.graphics.getWidth()
+        local height = love.graphics.getHeight()
         local alpha = getTransitionAlpha(self.transitionTime, self.transitionDirection)
-        love.graphics.setColor(0, 0, 0, alpha)
-        love.graphics.rectangle("fill", 0, 0, love.graphics.getWidth(), love.graphics.getHeight())
+
+        love.graphics.setColor(0, 0, 0, alpha * 0.85)
+        love.graphics.rectangle("fill", 0, 0, width, height)
+
+        love.graphics.setBlendMode("add")
+        love.graphics.setColor(1, 1, 1, alpha * 0.2)
+        local radius = math.sqrt(width * width + height * height) * 0.75
+        love.graphics.circle("fill", width / 2, height / 2, radius, 64)
+        love.graphics.setBlendMode("alpha")
         love.graphics.setColor(1, 1, 1, 1)
     end
 end


### PR DESCRIPTION
## Summary
- rework the shared GameState transition flow to keep outgoing scenes alive through eased fades, add bloom overlays, and support queued transitions
- add easing helpers and motion/scale effects to fade, shop, and floor intro phases inside the main game to make transitions feel livelier

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5d372624c832fa823c600bbdbd1d6