### PR TITLE
Refine transition drawing between game states

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -508,6 +508,24 @@ function Game:drawTransition()
         end
 end
 
+function Game:drawStateTransition(direction, progress, eased, alpha)
+        local isFloorTransition = (self.state == "transition")
+
+        if direction == "out" and not isFloorTransition then
+                return nil
+        end
+
+        self:draw()
+
+        love.graphics.setColor(1, 1, 1, 1)
+
+        if isFloorTransition then
+                return { skipOverlay = true }
+        end
+
+        return true
+end
+
 function Game:drawDescending()
         if not self.hole then
                 Snake:draw()


### PR DESCRIPTION
## Summary
- allow game states to override the default transition drawing
- add a game-specific override so floor transitions render without the extra global fade overlay

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6139a30b0832f892fd5cb25734488