### PR TITLE
Adjust shop selection pacing

### DIFF
--- a/shop.lua
+++ b/shop.lua
@@ -68,7 +68,7 @@ function Shop:start(currentFloor)
     self.time = 0
     self.selectionProgress = 0
     self.selectionTimer = 0
-    self.selectionHoldDuration = 1.35
+    self.selectionHoldDuration = 1.85
     self.selectionComplete = false
     for i = 1, #self.cards do
         self.cardStates[i] = {


### PR DESCRIPTION
## Summary
- increase the selection hold duration for shop upgrade cards to give the presentation more time

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d616d81640832fb23879ae17e6acd5