### PR TITLE
Smooth screen metrics and transition context

### DIFF
--- a/app.lua
+++ b/app.lua
@@ -84,6 +84,7 @@ function App:forwardEvent(eventName, ...)
 end
 
 function App:update(dt)
+    Screen:update(dt)
     local action = GameState:update(dt)
     self:resolveAction(action)
     UI:update(dt)

--- a/screen.lua
+++ b/screen.lua
@@ -1,9 +1,66 @@
-local Screen = {}
+local Screen = {
+    width = nil,
+    height = nil,
+    targetWidth = nil,
+    targetHeight = nil,
+    smoothingSpeed = 12,
+    snapThreshold = 0,
+}
 
-function Screen:update()
-    self.width, self.height = love.graphics.getDimensions()
-    self.cx = self.width / 2
-    self.cy = self.height / 2
+local function updateCenter(self)
+    self.cx = self.width * 0.5
+    self.cy = self.height * 0.5
+end
+
+local function shouldSnapImmediately(self, dt, instant)
+    if instant == true then
+        return true
+    end
+
+    if self.width == nil or self.height == nil then
+        return true
+    end
+
+    if dt == nil or dt <= 0 then
+        return true
+    end
+
+    if self.smoothingSpeed <= 0 then
+        return true
+    end
+
+    return false
+end
+
+function Screen:update(dt, instant)
+    local actualWidth, actualHeight = love.graphics.getDimensions()
+    self.targetWidth, self.targetHeight = actualWidth, actualHeight
+
+    if shouldSnapImmediately(self, dt, instant) then
+        self.width, self.height = actualWidth, actualHeight
+        updateCenter(self)
+        return self.width, self.height
+    end
+
+    local deltaWidth = actualWidth - self.width
+    local deltaHeight = actualHeight - self.height
+    local snapThreshold = self.snapThreshold
+
+    if snapThreshold and snapThreshold > 0 then
+        if math.abs(deltaWidth) > snapThreshold or math.abs(deltaHeight) > snapThreshold then
+            self.width, self.height = actualWidth, actualHeight
+            updateCenter(self)
+            return self.width, self.height
+        end
+    end
+
+    local alpha = 1 - math.exp(-self.smoothingSpeed * dt)
+    self.width = self.width + deltaWidth * alpha
+    self.height = self.height + deltaHeight * alpha
+
+    updateCenter(self)
+
+    return self.width, self.height
 end
 
 function Screen:get()
@@ -18,8 +75,25 @@ function Screen:getHeight()
     return self.height
 end
 
+function Screen:getTarget()
+    return self.targetWidth, self.targetHeight
+end
+
 function Screen:center()
     return self.cx, self.cy
+end
+
+function Screen:setSmoothingSpeed(speed)
+    self.smoothingSpeed = math.max(speed or 0, 0)
+end
+
+function Screen:setSnapThreshold(threshold)
+    if threshold == nil then
+        self.snapThreshold = 0
+        return
+    end
+
+    self.snapThreshold = math.max(threshold, 0)
 end
 
 return Screen


### PR DESCRIPTION
## Summary
- smooth the Screen module by lerping toward window size changes and expose tuning helpers
- call Screen:update every frame so dimensions ease while tracking the instantaneous target size
- enrich GameState transitions with a reusable context, easing metadata, and safer draw overlay usage

## Testing
- Not run (luac not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d621410134832fa84313d339c4cc57