### PR TITLE
Add snake-driven lighting overlay for dark floors

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -13,6 +13,7 @@ local Score = require("score")
 local PauseMenu = require("pausemenu")
 local Movement = require("movement")
 local Particles = require("particles")
+local Lighting = require("lighting")
 local Achievements = require("achievements")
 local FloatingText = require("floatingtext")
 local Arena = require("arena")
@@ -369,6 +370,7 @@ local function drawPlayfieldLayers(self, stateOverride)
         Particles:draw()
         Popup:draw()
         Arena:drawBorder()
+        Lighting:draw(renderState)
 end
 
 local function drawInterfaceLayers(self)
@@ -664,6 +666,8 @@ function Game:setupFloor(floorNum)
             Theme[k] = v
         end
     end
+
+    Lighting:setFloorData(self.currentFloorData, floorNum)
 
     -- reset entities
     Arena:resetExit()

--- a/lighting.lua
+++ b/lighting.lua
@@ -1,0 +1,144 @@
+local Arena = require("arena")
+local Snake = require("snake")
+local Theme = require("theme")
+local SnakeUtils = require("snakeutils")
+
+local Lighting = {
+    darkness = 0.0,
+    lightRadius = SnakeUtils.SEGMENT_SIZE * 10,
+    maxLights = 12,
+    overlayMargin = 48,
+    cachedSegments = {},
+    glowColor = {1, 0.95, 0.8, 1},
+}
+
+local function clamp(value, min, max)
+    if value < min then return min end
+    if value > max then return max end
+    return value
+end
+
+local function luminance(color)
+    if not color then return 0.5 end
+    local r = color[1] or 0
+    local g = color[2] or 0
+    local b = color[3] or 0
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+end
+
+local function mix(a, b, t)
+    return a + (b - a) * t
+end
+
+local function brightenColor(color, strength)
+    if not color then
+        return {1, 0.95, 0.8, 1}
+    end
+
+    local r = color[1] or 0
+    local g = color[2] or 0
+    local b = color[3] or 0
+
+    local t = clamp(strength or 0.4, 0, 1)
+    r = mix(r, 1.0, t)
+    g = mix(g, 0.98, t)
+    b = mix(b, 0.85, t)
+
+    return {r, g, b, 1}
+end
+
+local function drawRadialLight(x, y, radius, color, intensity, layers)
+    layers = layers or 5
+    if radius <= 0 then return end
+
+    for i = layers, 1, -1 do
+        local t = (i - 1) / math.max(1, layers - 1)
+        local alpha = intensity * (1 - t)
+        alpha = alpha * alpha
+
+        love.graphics.setColor(color[1], color[2], color[3], alpha)
+        local ringRadius = radius * (0.35 + 0.65 * t)
+        love.graphics.circle("fill", x, y, ringRadius)
+    end
+end
+
+local function calculateDepthFactor(floorNum)
+    if not floorNum then return 0 end
+    return clamp((floorNum - 6) / 8, 0, 1)
+end
+
+function Lighting:setFloorData(floorData, floorNum)
+    local palette = floorData and floorData.palette or nil
+    local arenaBG = (palette and palette.arenaBG) or Theme.arenaBG
+    local snakeColor = (palette and palette.snake) or Theme.snakeDefault
+
+    local brightness = luminance(arenaBG)
+    local depthFactor = calculateDepthFactor(floorNum)
+
+    -- Baseline darkness rises as the arena palette gets darker and the player descends.
+    local darkness = 0.1 + (0.75 - brightness) * 0.55
+    darkness = darkness + depthFactor * 0.25
+    self.darkness = clamp(darkness, 0.05, 0.85)
+
+    self.lightRadius = SnakeUtils.SEGMENT_SIZE * (8 + depthFactor * 4 + (1 - brightness) * 6)
+    self.maxLights = 10 + math.floor(depthFactor * 6)
+    self.segmentFalloff = 0.55 + depthFactor * 0.25
+
+    self.glowColor = brightenColor(snakeColor, 0.45 + depthFactor * 0.2)
+end
+
+function Lighting:getLightSources(renderState)
+    if renderState == "gameover" then
+        return {}
+    end
+
+    local segments = Snake:getSegments()
+    if segments and #segments > 0 then
+        self.cachedSegments = segments
+        return segments
+    end
+
+    return self.cachedSegments or {}
+end
+
+function Lighting:draw(renderState)
+    if not love or not love.graphics then return end
+
+    local darkness = self.darkness or 0
+    if darkness <= 0.05 then return end
+
+    local sources = self:getLightSources(renderState)
+    if not sources or #sources == 0 then return end
+
+    local ax, ay, aw, ah = Arena:getBounds()
+    local margin = self.overlayMargin or 0
+
+    love.graphics.push("all")
+    love.graphics.setScissor(ax - margin, ay - margin, aw + margin * 2, ah + margin * 2)
+
+    love.graphics.setBlendMode("alpha")
+    love.graphics.setColor(0, 0, 0, darkness)
+    love.graphics.rectangle("fill", ax - margin, ay - margin, aw + margin * 2, ah + margin * 2)
+
+    love.graphics.setBlendMode("add")
+    local radius = self.lightRadius or (SnakeUtils.SEGMENT_SIZE * 10)
+    local maxLights = math.min(#sources, self.maxLights or #sources)
+    local color = self.glowColor or {1, 0.95, 0.8, 1}
+    local falloff = self.segmentFalloff or 0.6
+
+    for i = 1, maxLights do
+        local seg = sources[i]
+        if seg and seg.drawX and seg.drawY then
+            local strength = 1 - (i - 1) / math.max(1, maxLights - 1)
+            strength = strength * falloff
+            if i == 1 then
+                strength = strength * 1.35
+            end
+            drawRadialLight(seg.drawX, seg.drawY, radius * (0.9 + 0.15 * strength), color, darkness * strength, 6)
+        end
+    end
+
+    love.graphics.pop()
+end
+
+return Lighting


### PR DESCRIPTION
## Summary
- add a lighting module that darkens the arena and renders a glow from the snake
- configure lighting with each floor so deeper, darker stages get stronger illumination
- render the lighting overlay in the playfield so obstacles, tiles, and walls react to the snake's light

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d64ad84490832f884653d2db6d1436