### PR TITLE
Add relic vault system and roguelike depth

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -27,6 +27,8 @@ local Death = require("death")
 local Floors = require("floors")
 local Shop = require("shop")
 local Upgrades = require("upgrades")
+local Relics = require("relics")
+local RelicVault = require("relicvault")
 local FruitWallet = require("fruitwallet")
 
 local Game = {}
@@ -127,6 +129,7 @@ function Game:load()
 
         Score:load()
         Upgrades:beginRun()
+        Relics:beginRun()
         GameUtils:prepareGame(self.screenWidth, self.screenHeight)
         Face:set("idle")
 
@@ -210,6 +213,17 @@ function Game:openShop()
         startTransitionPhase(self, "shop", 0)
 end
 
+function Game:openRelicVault(options)
+        if not options or #options == 0 then
+                self:startFloorIntro()
+                return
+        end
+
+        RelicVault:start(self.floor, options)
+        self.vaultCloseRequested = nil
+        startTransitionPhase(self, "relicvault", 0)
+end
+
 function Game:startFloorIntro(duration, extra)
         extra = extra or {}
 
@@ -246,8 +260,24 @@ function Game:updateTransition(dt)
 
         elseif self.transitionPhase == "shop" then
                 Shop:update(dt)
-                if self.shopCloseRequested and Shop:isSelectionComplete() then
+                if Shop:isSelectionComplete() and self.shopCloseRequested then
                         self.shopCloseRequested = nil
+                        if Relics:shouldOfferVault(self.floor) then
+                                local vaultOptions = Relics:prepareVault(self.floor)
+                                if vaultOptions and #vaultOptions > 0 then
+                                        self:openRelicVault(vaultOptions)
+                                else
+                                        self:startFloorIntro()
+                                end
+                        else
+                                self:startFloorIntro()
+                        end
+                end
+
+        elseif self.transitionPhase == "relicvault" then
+                RelicVault:update(dt)
+                if RelicVault:isSelectionComplete() and self.vaultCloseRequested then
+                        self.vaultCloseRequested = nil
                         self:startFloorIntro()
                 end
 
@@ -426,6 +456,14 @@ function Game:drawTransition()
                 love.graphics.translate(-self.screenWidth / 2, -self.screenHeight / 2)
                 Shop:draw(self.screenWidth, self.screenHeight)
                 love.graphics.pop()
+                love.graphics.setColor(1, 1, 1, 1)
+                return
+        end
+
+        if self.transitionPhase == "relicvault" then
+                love.graphics.setColor(0, 0, 0, 0.9)
+                love.graphics.rectangle("fill", 0, 0, self.screenWidth, self.screenHeight)
+                RelicVault:draw(self.screenWidth, self.screenHeight)
                 love.graphics.setColor(1, 1, 1, 1)
                 return
         end
@@ -680,6 +718,7 @@ function Game:update(dt)
         end
 end
 
+
 function Game:setupFloor(floorNum)
     self.currentFloorData = Floors[floorNum] or Floors[1]
 
@@ -716,6 +755,7 @@ function Game:setupFloor(floorNum)
     local adjustedContext, appliedTraits = FloorTraits:apply(self.currentFloorData.traits, traitContext)
     traitContext = adjustedContext or traitContext
 
+    traitContext = Relics:modifyFloorContext(traitContext, floorNum)
     traitContext = Upgrades:modifyFloorContext(traitContext)
 
     UI:setFruitGoal(traitContext.fruitGoal)
@@ -725,6 +765,7 @@ function Game:setupFloor(floorNum)
 
     Upgrades:applyPersistentEffects(true)
     Upgrades:notify("floorStart", { floor = floorNum, context = traitContext })
+    Relics:onFloorStart(floorNum, traitContext)
 
     local numRocks = traitContext.rocks
     local numSaws = traitContext.saws
@@ -793,6 +834,10 @@ function Game:keypressed(key)
                 if Shop:keypressed(key) then
                         self.shopCloseRequested = true
                 end
+        elseif self.transitionPhase == "relicvault" then
+                if RelicVault:keypressed(key) then
+                        self.vaultCloseRequested = true
+                end
         else
                 Controls:keypressed(self, key)
         end
@@ -805,6 +850,10 @@ function Game:mousepressed(x, y, button)
         elseif self.transitionPhase == "shop" then
                 if Shop:mousepressed(x, y, button) then
                         self.shopCloseRequested = true
+                end
+        elseif self.transitionPhase == "relicvault" then
+                if RelicVault:mousepressed(x, y, button) then
+                        self.vaultCloseRequested = true
                 end
         end
 end

--- a/relics.lua
+++ b/relics.lua
@@ -1,0 +1,452 @@
+local Upgrades = require("upgrades")
+local Score = require("score")
+local Snake = require("snake")
+local Rocks = require("rocks")
+local Saws = require("saws")
+local FruitEvents = require("fruitevents")
+local FloatingText = require("floatingtext")
+local Particles = require("particles")
+local UI = require("ui")
+local SessionStats = require("sessionstats")
+
+local Relics = {}
+
+local rarityInfo = {
+    common = {
+        label = "Common",
+        weight = 80,
+        color = {0.7, 0.9, 0.7, 1},
+    },
+    uncommon = {
+        label = "Uncommon",
+        weight = 45,
+        color = {0.55, 0.78, 0.88, 1},
+    },
+    rare = {
+        label = "Rare",
+        weight = 24,
+        color = {0.88, 0.66, 0.35, 1},
+    },
+    epic = {
+        label = "Epic",
+        weight = 10,
+        color = {0.95, 0.55, 0.8, 1},
+    },
+}
+
+local function getState(self)
+    if not self.state then
+        self.state = {
+            acquired = {},
+            order = {},
+            floorClaims = {},
+            schedule = {},
+            counters = {},
+            floorStartHandlers = {},
+        }
+    end
+    return self.state
+end
+
+local function buildVaultSchedule()
+    local schedule = {}
+    local floor = 2
+    while floor <= 14 do
+        table.insert(schedule, floor)
+        floor = floor + love.math.random(1, 2)
+    end
+    return schedule
+end
+
+local function rarityColor(info)
+    info = info or rarityInfo.common
+    return { info.color[1], info.color[2], info.color[3], info.color[4] }
+end
+
+local function addFloatingBanner(text, color)
+    local hx, hy = Snake:getHead()
+    if hx and hy then
+        FloatingText:add(text, hx, hy - 68, color or {1, 1, 1, 1}, 1.25, 48)
+    end
+end
+
+local relicPool = {
+    {
+        id = "evergreen_totem",
+        name = "Evergreen Totem",
+        desc = "Floors begin with a crash shield and the saws hesitate.",
+        summary = "Start every floor with a crash shield.",
+        rarity = "common",
+        minFloor = 2,
+        onFloorStart = function(_, floor, context)
+            Snake:addCrashShields(1)
+            if Saws and Saws.stall then
+                Saws:stall(0.45)
+            end
+            addFloatingBanner("Evergreen Ward", {0.55, 0.92, 0.62, 1})
+        end,
+    },
+    {
+        id = "ember_core",
+        name = "Ember Core",
+        desc = "Every fourth fruit ignites, stalling saws and shattering rock.",
+        summary = "Every 4 fruits trigger a fiery blast.",
+        rarity = "uncommon",
+        minFloor = 2,
+        onAcquire = function(self, state)
+            Upgrades:addEventHandler("fruitCollected", function(data)
+                local relicState = getState(self)
+                relicState.counters.emberCore = (relicState.counters.emberCore or 0) + 1
+                if relicState.counters.emberCore < 4 then
+                    return
+                end
+                relicState.counters.emberCore = relicState.counters.emberCore - 4
+                local x = data and data.x or 0
+                local y = data and data.y or 0
+                if Saws and Saws.stall then
+                    Saws:stall(1.25)
+                end
+                if Rocks and Rocks.shatterNearest then
+                    Rocks:shatterNearest(x, y, 2)
+                end
+                Particles:spawnBurst(x, y, {
+                    count = 26,
+                    speed = 150,
+                    life = 0.55,
+                    size = 5,
+                    spread = math.pi * 2,
+                    color = {1, 0.55, 0.25, 1},
+                    fadeTo = 0,
+                })
+                FloatingText:add("Ignition!", x, y - 62, {1, 0.6, 0.28, 1}, 1.2, 54)
+            end)
+        end,
+    },
+    {
+        id = "echo_flask",
+        name = "Echo Flask",
+        desc = "Combos of three or more pour extra score and time into the chain.",
+        summary = "Big combos grant bonus score and combo time.",
+        rarity = "uncommon",
+        minFloor = 3,
+        onAcquire = function(self)
+            Upgrades:addEventHandler("fruitCollected", function(data)
+                if not data then return end
+                local combo = data.combo or 0
+                if combo < 3 then return end
+                local x = data.x or 0
+                local y = data.y or 0
+                local bonus = 4 + math.floor((combo - 3) * 1.5)
+                Score:addBonus(bonus)
+                FruitEvents.boostComboTimer(0.6)
+                FloatingText:add("Echo +" .. tostring(bonus), x, y - 70, {0.75, 0.85, 1.0, 1}, 1.1, 46)
+            end)
+        end,
+    },
+    {
+        id = "glacial_prism",
+        name = "Glacial Prism",
+        desc = "Saw blades slow and linger after fruit, calming the arena.",
+        summary = "Saws slow down and stall longer after fruit.",
+        rarity = "rare",
+        minFloor = 4,
+        multipliers = {
+            sawSpeedMult = 0.85,
+            sawSpinMult = 0.9,
+            rockSpawnMult = 0.9,
+        },
+        bonuses = {
+            sawStall = 0.2,
+        },
+        onAcquire = function()
+            addFloatingBanner("Prism Chill", {0.75, 0.9, 1, 1})
+        end,
+    },
+    {
+        id = "storm_banner",
+        name = "Storm Banner",
+        desc = "Crash shields crackle, stunning saws and raining shards of score.",
+        summary = "Shields stun saws and grant bonus score.",
+        rarity = "rare",
+        minFloor = 5,
+        onAcquire = function(self)
+            Upgrades:addEventHandler("shieldConsumed", function(data)
+                local x = data and data.x or 0
+                local y = data and data.y or 0
+                if Saws and Saws.stall then
+                    Saws:stall(1.0)
+                end
+                local bonus = 8 + (#(getState(self).order) * 2)
+                Score:addBonus(bonus)
+                FloatingText:add("Storm Shield +" .. tostring(bonus), x, y - 58, {0.7, 0.9, 1.0, 1}, 1.0, 48)
+                Particles:spawnBurst(x, y, {
+                    count = 18,
+                    speed = 120,
+                    life = 0.5,
+                    size = 4,
+                    spread = math.pi * 2,
+                    color = {0.65, 0.85, 1, 1},
+                    fadeTo = 0,
+                })
+            end)
+        end,
+    },
+    {
+        id = "celestial_lens",
+        name = "Celestial Lens",
+        desc = "The combo timer stretches and fruit reveal glimpses of fate.",
+        summary = "Combo window +0.75; first fruit each floor gives bonus score.",
+        rarity = "epic",
+        minFloor = 6,
+        bonuses = {
+            comboWindowBonus = 0.75,
+        },
+        onFloorStart = function(self, floor)
+            local relicState = getState(self)
+            relicState.counters.floorFruit = relicState.counters.floorFruit or {}
+            relicState.counters.floorFruit[floor] = false
+        end,
+        onAcquire = function(self)
+            Upgrades:addEventHandler("fruitCollected", function(data)
+                local state = getState(self)
+                local floor = state.currentFloor or 1
+                state.counters.floorFruit = state.counters.floorFruit or {}
+                if state.counters.floorFruit[floor] then return end
+                state.counters.floorFruit[floor] = true
+                local x = data and data.x or 0
+                local y = data and data.y or 0
+                local reward = 12 + floor * 2
+                Score:addBonus(reward)
+                FloatingText:add("Starlit Tithe +" .. tostring(reward), x, y - 76, {0.9, 0.8, 1.0, 1}, 1.3, 52)
+            end)
+        end,
+    },
+}
+
+local poolById = {}
+for _, relic in ipairs(relicPool) do
+    poolById[relic.id] = relic
+end
+
+local function ensureSchedule(self)
+    local state = getState(self)
+    if #state.schedule == 0 then
+        state.schedule = buildVaultSchedule()
+    end
+    return state.schedule
+end
+
+local function adjustEffects(mult, bonuses)
+    local runState = Upgrades:getRunState()
+    if not runState then return end
+    local effects = runState.effects
+    if mult then
+        for key, value in pairs(mult) do
+            if effects[key] == nil or effects[key] == 0 then
+                effects[key] = value
+            else
+                effects[key] = effects[key] * value
+            end
+        end
+    end
+    if bonuses then
+        for key, value in pairs(bonuses) do
+            effects[key] = (effects[key] or 0) + value
+        end
+    end
+    Upgrades:applyPersistentEffects(true)
+end
+
+local function getAvailableRelics(self, floor)
+    local state = getState(self)
+    local list = {}
+    for _, relic in ipairs(relicPool) do
+        if not state.acquired[relic.id] then
+            if not relic.minFloor or relic.minFloor <= floor then
+                table.insert(list, relic)
+            end
+        end
+    end
+    return list
+end
+
+local function weightedSample(list)
+    local total = 0
+    for _, relic in ipairs(list) do
+        local rarity = rarityInfo[relic.rarity or "common"] or rarityInfo.common
+        total = total + (relic.weight or rarity.weight or 1)
+    end
+    if total <= 0 then return nil end
+    local draw = love.math.random() * total
+    local running = 0
+    for index, relic in ipairs(list) do
+        local rarity = rarityInfo[relic.rarity or "common"] or rarityInfo.common
+        running = running + (relic.weight or rarity.weight or 1)
+        if draw <= running then
+            table.remove(list, index)
+            return relic
+        end
+    end
+    return table.remove(list)
+end
+
+local function nextVaultFloor(self, currentFloor)
+    local schedule = ensureSchedule(self)
+    local state = getState(self)
+    for _, floor in ipairs(schedule) do
+        if not state.floorClaims[floor] and floor >= (currentFloor or 1) then
+            return floor
+        end
+    end
+    return nil
+end
+
+function Relics:beginRun()
+    self.state = nil
+    local state = getState(self)
+    state.schedule = buildVaultSchedule()
+    state.currentFloor = 1
+    state.highlightId = nil
+    state.pendingFloor = nil
+    SessionStats:set("relicsClaimed", 0)
+    self:updateUI(1)
+end
+
+function Relics:getState()
+    return getState(self)
+end
+
+function Relics:hasRelic(id)
+    local state = getState(self)
+    return state.acquired[id] == true
+end
+
+function Relics:getRelic(id)
+    return poolById[id]
+end
+
+function Relics:getRelicCount()
+    local state = getState(self)
+    return #state.order
+end
+
+function Relics:modifyFloorContext(context, floor)
+    return context
+end
+
+function Relics:shouldOfferVault(floor)
+    if not floor or floor <= 1 then return false end
+    local state = getState(self)
+    if state.floorClaims[floor] then return false end
+    if not nextVaultFloor(self, floor) or nextVaultFloor(self, floor) ~= floor then
+        return false
+    end
+    local available = getAvailableRelics(self, floor)
+    return #available > 0
+end
+
+function Relics:prepareVault(floor)
+    local state = getState(self)
+    state.pendingFloor = floor
+    local available = getAvailableRelics(self, floor)
+    if #available == 0 then
+        state.floorClaims[floor] = true
+        return nil
+    end
+    local selection = {}
+    local poolCopy = {}
+    for _, relic in ipairs(available) do
+        table.insert(poolCopy, relic)
+    end
+    for _ = 1, math.min(3, #poolCopy) do
+        local relic = weightedSample(poolCopy)
+        if relic then
+            table.insert(selection, {
+                relic = relic,
+                name = relic.name,
+                desc = relic.desc,
+                rarity = relic.rarity or "common",
+                rarityInfo = rarityInfo[relic.rarity or "common"] or rarityInfo.common,
+            })
+        end
+    end
+    if #selection == 0 then
+        state.floorClaims[floor] = true
+        return nil
+    end
+    return selection
+end
+
+function Relics:getSkipReward(floor)
+    floor = floor or getState(self).currentFloor or 1
+    local claimed = self:getRelicCount()
+    return 12 + floor * 3 + claimed * 4
+end
+
+function Relics:skipVault(floor)
+    local state = getState(self)
+    local reward = self:getSkipReward(floor)
+    state.floorClaims[floor] = true
+    state.pendingFloor = nil
+    Score:addBonus(reward)
+    addFloatingBanner("Vault Banked +" .. tostring(reward), {1, 0.8, 0.3, 1})
+    self:updateUI(state.currentFloor or floor)
+    return reward
+end
+
+function Relics:claim(relic, floor)
+    if not relic then return end
+    local state = getState(self)
+    if state.acquired[relic.id] then return end
+    state.acquired[relic.id] = true
+    table.insert(state.order, relic)
+    state.highlightId = relic.id
+    state.floorClaims[floor or state.pendingFloor or state.currentFloor or 1] = true
+    state.pendingFloor = nil
+    SessionStats:add("relicsClaimed", 1)
+    if relic.bonuses or relic.multipliers then
+        adjustEffects(relic.multipliers, relic.bonuses)
+    end
+    if relic.onAcquire then
+        relic.onAcquire(self, state)
+    end
+    if relic.onFloorStart then
+        table.insert(state.floorStartHandlers, relic.onFloorStart)
+    end
+    self:updateUI(state.currentFloor or floor)
+end
+
+function Relics:onFloorStart(floor, context)
+    local state = getState(self)
+    state.currentFloor = floor
+    if state.floorStartHandlers then
+        for _, handler in ipairs(state.floorStartHandlers) do
+            handler(self, floor, context)
+        end
+    end
+    self:updateUI(floor)
+end
+
+function Relics:updateUI(currentFloor)
+    local state = getState(self)
+    local display = { items = {}, nextVault = nextVaultFloor(self, currentFloor), nextSkip = nil }
+    for _, relic in ipairs(state.order) do
+        local info = rarityInfo[relic.rarity or "common"] or rarityInfo.common
+        table.insert(display.items, {
+            id = relic.id,
+            name = relic.name,
+            summary = relic.summary or relic.desc,
+            rarity = info.label,
+            color = rarityColor(info),
+            highlight = (state.highlightId == relic.id),
+        })
+    end
+    if display.nextVault then
+        display.nextSkip = self:getSkipReward(display.nextVault)
+    end
+    if UI and UI.setRelics then
+        UI:setRelics(display)
+    end
+end
+
+return Relics

--- a/relicvault.lua
+++ b/relicvault.lua
@@ -1,0 +1,192 @@
+local UI = require("ui")
+local Relics = require("relics")
+local RelicVault = {}
+
+function RelicVault:start(floor, options)
+    self.floor = floor or 1
+    self.cards = options or {}
+    self.cardStates = {}
+    self.cardBounds = {}
+    self.time = 0
+    self.selectionTimer = 0
+    self.selectionHold = 1.15
+    self.selectionDone = false
+    self.exitReady = false
+    self.selectedIndex = nil
+    self.skipChosen = false
+    self.skipReward = Relics:getSkipReward(floor)
+    for i = 1, #self.cards do
+        self.cardStates[i] = {
+            progress = 0,
+            delay = (i - 1) * 0.08,
+            hover = 0,
+        }
+    end
+end
+
+local function getCardLayout(count, screenW, screenH)
+    local cardWidth = 280
+    local cardHeight = 340
+    local spacing = 34
+    local totalWidth = cardWidth * count + spacing * math.max(0, count - 1)
+    local startX = (screenW - totalWidth) / 2
+    local startY = screenH * 0.35
+    return cardWidth, cardHeight, spacing, startX, startY
+end
+
+local function drawCard(card, state, x, y, w, h, isSelected)
+    local progress = math.min(1, state.progress or 0)
+    local alpha = progress
+    local rarityColor = card.rarityInfo and card.rarityInfo.color or {1, 1, 1, 1}
+    love.graphics.setColor(0, 0, 0, 0.35 * alpha)
+    love.graphics.rectangle("fill", x + 6, y + 10, w, h, 16, 16)
+    love.graphics.setColor(0.12, 0.15, 0.22, 0.92 * alpha)
+    love.graphics.rectangle("fill", x, y, w, h, 16, 16)
+
+    love.graphics.setColor(rarityColor[1], rarityColor[2], rarityColor[3], 0.85 * alpha)
+    love.graphics.setLineWidth(4)
+    love.graphics.rectangle("line", x, y, w, h, 16, 16)
+
+    if isSelected then
+        local pulse = 0.45 + 0.25 * math.sin(love.timer.getTime() * 5)
+        love.graphics.setColor(rarityColor[1], rarityColor[2], rarityColor[3], pulse)
+        love.graphics.setLineWidth(6)
+        love.graphics.rectangle("line", x - 10, y - 12, w + 20, h + 24, 18, 18)
+    end
+
+    love.graphics.setColor(1, 1, 1, alpha)
+    love.graphics.setFont(UI.fonts.button)
+    love.graphics.printf(card.name, x + 16, y + 24, w - 32, "center")
+
+    love.graphics.setFont(UI.fonts.small)
+    love.graphics.setColor(rarityColor[1], rarityColor[2], rarityColor[3], 0.9 * alpha)
+    love.graphics.printf(card.rarityInfo and card.rarityInfo.label or "", x + 18, y + 72, w - 36, "center")
+
+    love.graphics.setColor(1, 1, 1, alpha * 0.8)
+    love.graphics.setFont(UI.fonts.body)
+    love.graphics.printf(card.desc or "", x + 18, y + 116, w - 36, "center")
+end
+
+function RelicVault:update(dt)
+    self.time = (self.time or 0) + dt
+    for i, state in ipairs(self.cardStates) do
+        if self.time >= (state.delay or 0) then
+            state.progress = math.min(1, (state.progress or 0) + dt * 3.4)
+        end
+    end
+    if self.selectionDone then
+        self.selectionTimer = self.selectionTimer + dt
+        if self.selectionTimer >= self.selectionHold then
+            self.exitReady = true
+        end
+    end
+end
+
+function RelicVault:isSelectionComplete()
+    return self.exitReady
+end
+
+local function within(x, y, bounds)
+    return x >= bounds.x and x <= bounds.x + bounds.w and y >= bounds.y and y <= bounds.y + bounds.h
+end
+
+local function claimCard(self, index)
+    if self.selectionDone then return false end
+    local card = self.cards[index]
+    if not card then return false end
+    self.selectedIndex = index
+    self.selectionDone = true
+    self.selectionTimer = 0
+    self.skipChosen = false
+    Relics:claim(card.relic, self.floor)
+    return true
+end
+
+local function skipVault(self)
+    if self.selectionDone then return false end
+    self.selectionDone = true
+    self.selectionTimer = 0
+    self.skipChosen = true
+    local reward = Relics:skipVault(self.floor)
+    self.skipReward = reward
+    return true
+end
+
+function RelicVault:keypressed(key)
+    if key == "s" then
+        return skipVault(self)
+    end
+    local index = tonumber(key)
+    if index and index >= 1 and index <= #self.cards then
+        return claimCard(self, index)
+    end
+    if key == "return" or key == "space" then
+        if self.selectedIndex then
+            return claimCard(self, self.selectedIndex)
+        end
+    end
+    return false
+end
+
+function RelicVault:mousepressed(x, y, button)
+    if button ~= 1 then return false end
+    for i, bounds in ipairs(self.cardBounds) do
+        if within(x, y, bounds) then
+            return claimCard(self, i)
+        end
+    end
+    return false
+end
+
+function RelicVault:draw(screenW, screenH)
+    screenW = screenW or love.graphics.getWidth()
+    screenH = screenH or love.graphics.getHeight()
+
+    love.graphics.setColor(0, 0, 0, 0.78)
+    love.graphics.rectangle("fill", 0, 0, screenW, screenH)
+
+    love.graphics.setColor(1, 1, 1, 1)
+    love.graphics.setFont(UI.fonts.title)
+    love.graphics.printf("Vault of Echoes", 0, screenH * 0.12, screenW, "center")
+
+    love.graphics.setFont(UI.fonts.button)
+    love.graphics.setColor(1, 1, 1, 0.85)
+    local subtitle = string.format("Floor %d relics hum with possibility.", self.floor or 1)
+    love.graphics.printf(subtitle, 0, screenH * 0.2, screenW, "center")
+
+    local skipText = string.format("Press [S] to bank for +%d score", self.skipReward or Relics:getSkipReward(self.floor))
+    love.graphics.setFont(UI.fonts.body)
+    love.graphics.setColor(1, 1, 1, 0.72)
+    love.graphics.printf(skipText, 0, screenH * 0.26, screenW, "center")
+
+    local count = #self.cards
+    local cardWidth, cardHeight, spacing, startX, startY = getCardLayout(count, screenW, screenH)
+    self.cardBounds = {}
+    for i, card in ipairs(self.cards) do
+        local x = startX + (i - 1) * (cardWidth + spacing)
+        local y = startY
+        self.cardBounds[i] = { x = x, y = y, w = cardWidth, h = cardHeight }
+        local state = self.cardStates[i]
+        drawCard(card, state, x, y, cardWidth, cardHeight, self.selectedIndex == i and self.selectionDone)
+
+        love.graphics.setFont(UI.fonts.small)
+        love.graphics.setColor(1, 1, 1, 0.5)
+        love.graphics.printf("[" .. tostring(i) .. "]", x + 16, y + cardHeight + 12, cardWidth - 32, "center")
+    end
+
+    if self.selectionDone then
+        local message
+        if self.skipChosen then
+            message = string.format("Vault banked! +%d score", self.skipReward or 0)
+        else
+            local card = self.cards[self.selectedIndex]
+            message = card and (card.name .. " claimed!") or "Relic claimed!"
+        end
+        love.graphics.setFont(UI.fonts.button)
+        local alpha = math.min(1, self.selectionTimer / self.selectionHold)
+        love.graphics.setColor(1, 1, 1, alpha)
+        love.graphics.printf(message, 0, screenH * 0.82, screenW, "center")
+    end
+end
+
+return RelicVault

--- a/ui.lua
+++ b/ui.lua
@@ -18,6 +18,8 @@ UI.goalCelebrated = false
 
 UI.floorModifiers = {}
 
+UI.relicDisplay = { items = {}, nextVault = nil, nextSkip = nil }
+
 UI.combo = {
     count = 0,
     timer = 0,
@@ -335,6 +337,74 @@ function UI:drawFloorModifiers()
 
         if sectionIndex < #measuredSections then
             textY = textY + spacing
+        end
+    end
+end
+
+function UI:setRelics(data)
+    self.relicDisplay = self.relicDisplay or { items = {}, nextVault = nil, nextSkip = nil }
+    data = data or {}
+    self.relicDisplay.items = data.items or {}
+    self.relicDisplay.nextVault = data.nextVault
+    self.relicDisplay.nextSkip = data.nextSkip
+end
+
+function UI:drawRelics()
+    local display = self.relicDisplay or {}
+    local items = display.items or {}
+    local nextVault = display.nextVault
+    local nextSkip = display.nextSkip
+    if (#items == 0) and not nextVault then
+        return
+    end
+
+    local screenW, screenH = love.graphics.getWidth(), love.graphics.getHeight()
+    local panelWidth = 260
+    local headerHeight = 46
+    local itemHeight = #items * 44
+    local infoHeight = nextVault and 48 or 0
+    local panelHeight = headerHeight + itemHeight + infoHeight + 18
+    local x = screenW - panelWidth - 28
+    local y = 28
+
+    love.graphics.setColor(0, 0, 0, 0.35)
+    love.graphics.rectangle('fill', x + 6, y + 8, panelWidth, panelHeight, 14, 14)
+    love.graphics.setColor(0.1, 0.12, 0.18, 0.92)
+    love.graphics.rectangle('fill', x, y, panelWidth, panelHeight, 14, 14)
+    love.graphics.setColor(1, 1, 1, 0.2)
+    love.graphics.setLineWidth(2)
+    love.graphics.rectangle('line', x, y, panelWidth, panelHeight, 14, 14)
+
+    love.graphics.setFont(UI.fonts.button)
+    love.graphics.setColor(1, 1, 1, 0.92)
+    love.graphics.printf('Relics', x, y + 10, panelWidth, 'center')
+
+    local cursor = y + 44
+    for _, entry in ipairs(items) do
+        local nameColor = entry.color or {1, 1, 1, 1}
+        if entry.highlight then
+            love.graphics.setColor(nameColor[1], nameColor[2], nameColor[3], 0.18)
+        else
+            love.graphics.setColor(1, 1, 1, 0.08)
+        end
+        love.graphics.rectangle('fill', x + 10, cursor - 4, panelWidth - 20, 38, 10, 10)
+
+        love.graphics.setFont(UI.fonts.body)
+        love.graphics.setColor(nameColor[1], nameColor[2], nameColor[3], entry.highlight and 1 or 0.82)
+        love.graphics.printf(entry.name or '', x + 18, cursor, panelWidth - 36, 'left')
+        love.graphics.setFont(UI.fonts.small)
+        love.graphics.setColor(1, 1, 1, 0.68)
+        love.graphics.printf(entry.summary or '', x + 18, cursor + 18, panelWidth - 36, 'left')
+        cursor = cursor + 40
+    end
+
+    if nextVault then
+        love.graphics.setFont(UI.fonts.small)
+        love.graphics.setColor(1, 1, 1, 0.75)
+        love.graphics.printf(string.format('Next Vault: Floor %d', nextVault), x + 18, cursor + 6, panelWidth - 36, 'left')
+        if nextSkip then
+            love.graphics.setColor(1, 1, 1, 0.6)
+            love.graphics.printf(string.format('Bank Reward: +%d', nextSkip), x + 18, cursor + 24, panelWidth - 36, 'left')
         end
     end
 end
@@ -763,6 +833,7 @@ function UI:draw()
         )
     end
 
+    self:drawRelics()
     self:drawFloorModifiers()
 end
 


### PR DESCRIPTION
## Summary
- add a run-long relic system with randomized vault schedules, relic definitions, and UI synchronization
- introduce a relic vault intermission screen that lets players claim or bank relics between floors
- integrate the vault flow into the game loop and expand the HUD with a live relic tracker and next vault preview

## Testing
- `luac -p game.lua ui.lua relics.lua relicvault.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d6cbf25a94832fb327c34458fb60b6