### PR TITLE
Scale menu snake word

### DIFF
--- a/menu.lua
+++ b/menu.lua
@@ -84,9 +84,13 @@ function Menu:draw()
     love.graphics.setColor(Theme.bgColor)
     love.graphics.rectangle("fill", 0, 0, sw, sh)
 
-    local cellSize = 20
+    local baseCellSize = 20
+    local baseSpacing = 10
+    local wordScale = 2
+
+    local cellSize = baseCellSize * wordScale
     local word = Localization:get("menu.title_word")
-    local spacing = 10
+    local spacing = baseSpacing * wordScale
     local wordWidth = (#word * (3 * cellSize + spacing)) - spacing - (cellSize * 3)
     local ox = (sw - wordWidth) / 2
     local oy = sh * 0.2
@@ -98,7 +102,7 @@ function Menu:draw()
         local faceTex = Face:getTexture()
         local fw, fh = faceTex:getWidth(), faceTex:getHeight()
         love.graphics.setColor(1, 1, 1, 1)
-        love.graphics.draw(faceTex, head.x - fw / 2, head.y - fh / 2)
+        love.graphics.draw(faceTex, head.x, head.y, 0, wordScale, wordScale, fw / 2, fh / 2)
     end
 
     for _, btn in ipairs(buttons) do


### PR DESCRIPTION
## Summary
- scale the menu title snake drawing by doubling the cell and spacing sizes
- scale the face sprite along with the snake so it remains proportional when rendered with MSAA

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d70e281698832fbae94a88665dbfa9