### PR TITLE
Refactor face rendering to shape-drawn idle and blink states

### DIFF
--- a/face.lua
+++ b/face.lua
@@ -1,12 +1,37 @@
 local Face = {}
 
+local FACE_WIDTH = 14
+local FACE_HEIGHT = 11
+
+local LEFT_EYE_CENTER_X = 1.5
+local RIGHT_EYE_CENTER_X = 11.5
+local EYE_CENTER_Y = 1.5
+local EYE_RADIUS = 2
+local EYELID_WIDTH = 4
+local EYELID_HEIGHT = 1
+
 local textures = {
-	idle  = love.graphics.newImage("Assets/FaceBlank.png"),
-	happy = love.graphics.newImage("Assets/FaceHappy.png"),
-	sad   = love.graphics.newImage("Assets/FaceSad.png"),
-	angry = love.graphics.newImage("Assets/FaceAngry.png"),
-	blink = love.graphics.newImage("Assets/FaceBlink.png"),
+    happy = love.graphics.newImage("Assets/FaceHappy.png"),
+    sad   = love.graphics.newImage("Assets/FaceSad.png"),
+    angry = love.graphics.newImage("Assets/FaceAngry.png"),
 }
+
+local shapeDrawers = {}
+
+shapeDrawers.idle = function()
+    love.graphics.setColor(0, 0, 0, 1)
+    love.graphics.circle("fill", LEFT_EYE_CENTER_X, EYE_CENTER_Y, EYE_RADIUS)
+    love.graphics.circle("fill", RIGHT_EYE_CENTER_X, EYE_CENTER_Y, EYE_RADIUS)
+end
+
+shapeDrawers.blink = function()
+    love.graphics.setColor(0, 0, 0, 1)
+    local leftX = LEFT_EYE_CENTER_X - EYELID_WIDTH / 2
+    local rightX = RIGHT_EYE_CENTER_X - EYELID_WIDTH / 2
+    local top = EYE_CENTER_Y - EYELID_HEIGHT / 2
+    love.graphics.rectangle("fill", leftX, top, EYELID_WIDTH, EYELID_HEIGHT)
+    love.graphics.rectangle("fill", rightX, top, EYELID_WIDTH, EYELID_HEIGHT)
+end
 
 Face.state = "idle"
 Face.timer = 0
@@ -47,8 +72,44 @@ function Face:update(dt)
     end
 end
 
-function Face:getTexture()
-    return textures[self.state] or textures.idle
+function Face:draw(x, y, scale)
+    scale = scale or 1
+
+    local drawer = shapeDrawers[self.state]
+
+    if drawer then
+        love.graphics.push()
+        love.graphics.translate(x, y)
+        love.graphics.scale(scale)
+        love.graphics.translate(-FACE_WIDTH / 2, -FACE_HEIGHT / 2)
+
+        drawer()
+
+        love.graphics.pop()
+    else
+        local texture = textures[self.state]
+        if not texture then
+            drawer = shapeDrawers.idle
+        end
+
+        if texture then
+            local ox = texture:getWidth() / 2
+            local oy = texture:getHeight() / 2
+            love.graphics.setColor(1, 1, 1, 1)
+            love.graphics.draw(texture, x, y, 0, scale, scale, ox, oy)
+        elseif drawer then
+            love.graphics.push()
+            love.graphics.translate(x, y)
+            love.graphics.scale(scale)
+            love.graphics.translate(-FACE_WIDTH / 2, -FACE_HEIGHT / 2)
+
+            drawer()
+
+            love.graphics.pop()
+        end
+    end
+
+    love.graphics.setColor(1, 1, 1, 1)
 end
 
 return Face

--- a/menu.lua
+++ b/menu.lua
@@ -99,10 +99,7 @@ function Menu:draw()
 
     if trail and #trail > 0 then
         local head = trail[#trail]
-        local faceTex = Face:getTexture()
-        local fw, fh = faceTex:getWidth(), faceTex:getHeight()
-        love.graphics.setColor(1, 1, 1, 1)
-        love.graphics.draw(faceTex, head.x, head.y, 0, wordScale, wordScale, fw / 2, fh / 2)
+        Face:draw(head.x, head.y, wordScale)
     end
 
     for _, btn in ipairs(buttons) do

--- a/snakedraw.lua
+++ b/snakedraw.lua
@@ -281,13 +281,8 @@ local function drawSnake(trail, segmentCount, SEGMENT_SIZE, popTimer, getHead, s
       drawAdrenalineAura(trail, hx, hy, SEGMENT_SIZE, upgradeVisuals.adrenaline)
     end
 
-    local faceTexture = Face:getTexture()
     local faceScale = 1
-    local ox = faceTexture:getWidth() / 2
-    local oy = faceTexture:getHeight() / 2
-
-    love.graphics.setColor(1, 1, 1, 1)
-    love.graphics.draw(faceTexture, hx, hy, 0, faceScale, faceScale, ox, oy)
+    Face:draw(hx, hy, faceScale)
 
     drawShieldBubble(hx, hy, SEGMENT_SIZE, shieldCount, shieldFlashTimer)
 


### PR DESCRIPTION
## Summary
- replace the idle and blink face states with shape-drawn eyes to match existing placement
- add a Face:draw helper that renders either the new shapes or fallback textures
- update snake and menu rendering to use the new drawing helper

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7126741e0832f9b3aec17c2d1fb53