### PR TITLE
Add Phoenix Echo floor rewind upgrade and spectral harvest option

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -300,6 +300,9 @@ function Game:updateGameplay(dt)
         local moveResult, cause = Movement:update(dt)
 
         if moveResult == "dead" then
+                if Upgrades.tryFloorReplay and Upgrades:tryFloorReplay(self, cause) then
+                        return
+                end
                 self.deathCause = cause
                 self:beginDeath()
                 return


### PR DESCRIPTION
## Summary
- add the Spectral Harvest upgrade that automatically collects an extra fruit once per floor
- add the Phoenix Echo epic upgrade and supporting code to rewind a fatal floor instead of ending the run
- hook the gameplay loop into the new floor rewind logic so upgrades can cancel a lethal crash

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d73c3cb5f0832fb556c3e38e00cf92