### PR TITLE
Enrich particle effects across core hazards

### DIFF
--- a/fruit.lua
+++ b/fruit.lua
@@ -205,10 +205,17 @@ function Fruit:update(dt)
             Particles:spawnBurst(active.x, active.y, {
                 count = love.math.random(6, 9),
                 speed = 48,
+                speedVariance = 36,
                 life  = 0.35,
                 size  = 3,
                 color = {col[1], col[2], col[3], 1},
-                spread= math.pi * 2
+                spread= math.pi * 2,
+                angleJitter = math.pi,
+                drag = 2.2,
+                gravity = 160,
+                scaleMin = 0.55,
+                scaleVariance = 0.65,
+                fadeTo = 0,
             })
             active.phase = "squash"
             active.timer = 0

--- a/movement.lua
+++ b/movement.lua
@@ -97,10 +97,17 @@ function Movement:update(dt)
                         Particles:spawnBurst(headX, headY, {
                                 count = 12,
                                 speed = 70,
+                                speedVariance = 55,
                                 life = 0.45,
                                 size = 4,
                                 color = {0.55, 0.85, 1, 1},
                                 spread = math.pi * 2,
+                                angleJitter = math.pi * 0.75,
+                                drag = 3.2,
+                                gravity = 180,
+                                scaleMin = 0.5,
+                                scaleVariance = 0.75,
+                                fadeTo = 0,
                         })
 
                         if Snake.onShieldConsumed then
@@ -116,8 +123,19 @@ function Movement:update(dt)
                         if Snake:consumeCrashShield() then
                                 -- shield absorbed the hit, play feedback and continue
                                 Particles:spawnBurst(rock.x + rock.w/2, rock.y + rock.h/2, {
-                                        count = 8, speed = 40, life = 0.4, size = 3,
-                                        color = {0.9, 0.8, 0.5, 1}, spread = math.pi*2
+                                        count = 8,
+                                        speed = 40,
+                                        speedVariance = 36,
+                                        life = 0.4,
+                                        size = 3,
+                                        color = {0.9, 0.8, 0.5, 1},
+                                        spread = math.pi * 2,
+                                        angleJitter = math.pi * 0.8,
+                                        drag = 2.8,
+                                        gravity = 210,
+                                        scaleMin = 0.55,
+                                        scaleVariance = 0.5,
+                                        fadeTo = 0.05,
                                 })
                                 Rocks:destroy(rock, { spawnFX = false })
                                 -- clear the shattered rock so the next frame doesn't collide again
@@ -147,8 +165,19 @@ function Movement:update(dt)
                         Saws:destroy(sawHit)
 
                         Particles:spawnBurst(headX, headY, {
-                                count = 8, speed = 40, life = 0.35, size = 3,
-                                color = {0.9,0.7,0.3,1}, spread = math.pi*2
+                                count = 8,
+                                speed = 40,
+                                speedVariance = 34,
+                                life = 0.35,
+                                size = 3,
+                                color = {0.9, 0.7, 0.3, 1},
+                                spread = math.pi * 2,
+                                angleJitter = math.pi * 0.9,
+                                drag = 3.0,
+                                gravity = 240,
+                                scaleMin = 0.5,
+                                scaleVariance = 0.6,
+                                fadeTo = 0,
                         })
                         if Snake.onShieldConsumed then
                                 Snake:onShieldConsumed(headX, headY, "saw")
@@ -165,10 +194,17 @@ function Movement:update(dt)
                         Particles:spawnBurst(headX, headY + SEGMENT_SIZE / 2, {
                                 count = 10,
                                 speed = 55,
+                                speedVariance = 45,
                                 life = 0.35,
                                 size = 3,
                                 color = {0.8, 0.75, 0.7, 1},
                                 gravity = 220,
+                                angleJitter = math.pi * 0.65,
+                                drag = 2.6,
+                                spread = math.pi * 1.5,
+                                scaleMin = 0.5,
+                                scaleVariance = 0.6,
+                                fadeTo = 0,
                         })
                         Presses:bounce(pressHit)
                         if Snake.onShieldConsumed then

--- a/presses.lua
+++ b/presses.lua
@@ -107,12 +107,17 @@ local function spawnImpactBurst(press)
     Particles:spawnBurst(press.x, press.targetY + press.headHeight * 0.5, {
         count = 8,
         speed = 70,
+        speedVariance = 50,
         life = 0.35,
         size = 3,
         color = {r, g, b, 1},
         gravity = 260,
         spread = math.pi,
         angleJitter = 0.6,
+        drag = 3.0,
+        scaleMin = 0.5,
+        scaleVariance = 0.7,
+        fadeTo = 0,
     })
 end
 

--- a/rocks.lua
+++ b/rocks.lua
@@ -82,10 +82,17 @@ local function spawnShatterFX(x, y)
     Particles:spawnBurst(x, y, {
         count = love.math.random(8, 12),
         speed = 70,
+        speedVariance = 55,
         life = 0.45,
         size = 4,
         color = {0.85, 0.75, 0.6, 1},
         spread = math.pi * 2,
+        angleJitter = math.pi * 0.9,
+        drag = 3.0,
+        gravity = 240,
+        scaleMin = 0.5,
+        scaleVariance = 0.7,
+        fadeTo = 0.05,
     })
 end
 
@@ -198,10 +205,17 @@ function Rocks:update(dt)
                 Particles:spawnBurst(rock.x, rock.y, {
                     count = love.math.random(6, 10),
                     speed = 40,
+                    speedVariance = 34,
                     life = 0.4,
                     size = 3,
                     color = {0.6, 0.5, 0.4, 1},
                     spread = math.pi * 2,
+                    angleJitter = math.pi * 0.85,
+                    drag = 2.2,
+                    gravity = 160,
+                    scaleMin = 0.6,
+                    scaleVariance = 0.5,
+                    fadeTo = 0.1,
                 })
             end
 

--- a/saws.lua
+++ b/saws.lua
@@ -85,10 +85,17 @@ local function removeSaw(target)
             Particles:spawnBurst(px or saw.x, py or saw.y, {
                 count = 12,
                 speed = 80,
-                life = 0.35,
+                speedVariance = 65,
+                life = 0.4,
                 size = 3,
                 color = {0.85, 0.8, 0.75, 1},
                 spread = math.pi * 2,
+                angleJitter = math.pi,
+                drag = 3.6,
+                gravity = 260,
+                scaleMin = 0.55,
+                scaleVariance = 0.65,
+                fadeTo = 0.05,
             })
 
             table.remove(current, index)
@@ -183,10 +190,17 @@ function Saws:update(dt)
                 Particles:spawnBurst(saw.x, saw.y, {
                     count = love.math.random(6, 10),
                     speed = 60,
+                    speedVariance = 40,
                     life = 0.4,
                     size = 3,
                     color = {0.8, 0.8, 0.8, 1},
                     spread = math.pi * 2,
+                    angleJitter = math.pi * 0.8,
+                    drag = 2.4,
+                    gravity = 180,
+                    scaleMin = 0.6,
+                    scaleVariance = 0.55,
+                    fadeTo = 0.1,
                 })
             end
 


### PR DESCRIPTION
## Summary
- add drag, gravity, jitter, and scaling variance to shield-triggered particle bursts
- refresh saw, rock, and fruit impact bursts to leverage the newer particle system controls
- enrich press impact particles with variance and fading for a more dynamic burst

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7472ab880832fab221ac49594ffd9