### PR TITLE
Polish menu and settings UI with drop shadows

### DIFF
--- a/buttonlist.lua
+++ b/buttonlist.lua
@@ -32,6 +32,8 @@ function ButtonList:reset(definitions)
         button.x = button.x or 0
         button.y = button.y or 0
         button.hoveredByMouse = false
+        button.textAlign = button.textAlign or "center"
+        button.textPadding = button.textPadding or 0
 
         self.buttons[#self.buttons + 1] = button
     end
@@ -95,6 +97,7 @@ end
 function ButtonList:syncUI()
     for _, button in ipairs(self.buttons) do
         UI.registerButton(button.id, button.x, button.y, button.w, button.h, button.text)
+        UI.setButtonTextAlign(button.id, button.textAlign, button.textPadding)
     end
 end
 

--- a/floatingtext.lua
+++ b/floatingtext.lua
@@ -1,3 +1,5 @@
+local UI = require("ui")
+
 local FloatingText = {}
 
 local entries = {}
@@ -244,6 +246,8 @@ function FloatingText:update(dt)
 end
 
 function FloatingText:draw()
+    UI.pushTextShadow(false)
+
     for _, entry in ipairs(entries) do
         love.graphics.setFont(entry.font)
 
@@ -276,6 +280,8 @@ function FloatingText:draw()
 
         love.graphics.pop()
     end
+
+    UI.popTextShadow()
 
     love.graphics.setColor(1, 1, 1, 1)
 end

--- a/menu.lua
+++ b/menu.lua
@@ -12,6 +12,7 @@ local Menu = {}
 local buttonList = ButtonList.new()
 local buttons = {}
 local t = 0
+local buttonArea = nil
 
 function Menu:enter()
     t = 0
@@ -21,8 +22,14 @@ function Menu:enter()
     Screen:update()
 
     local sw, sh = Screen:get()
+    local safe = UI.layout.safeMargin
     local centerX = sw / 2
-    local startY = sh / 2 - ((UI.spacing.buttonHeight + UI.spacing.buttonSpacing) * 2.5) + UI.spacing.buttonHeight
+
+    local buttonWidth = math.min(UI.spacing.buttonWidth, sw - safe.x * 2)
+    local totalHeight = (#labels) * (UI.spacing.buttonHeight + UI.spacing.buttonSpacing) - UI.spacing.buttonSpacing
+    local alignedTop = safe.y + UI.fonts.title:getHeight() + 60
+    local centeredTop = sh / 2 - totalHeight / 2
+    local startY = math.max(alignedTop, centeredTop)
 
     local labels = {
         { key = "menu.start_game",   action = "modeselect" },
@@ -34,14 +41,14 @@ function Menu:enter()
     local defs = {}
 
     for i, entry in ipairs(labels) do
-        local x = centerX - UI.spacing.buttonWidth / 2
+        local x = centerX - buttonWidth / 2
         local y = startY + (i - 1) * (UI.spacing.buttonHeight + UI.spacing.buttonSpacing)
 
         defs[#defs + 1] = {
             id = "menuButton" .. i,
             x = x,
             y = y,
-            w = UI.spacing.buttonWidth,
+            w = buttonWidth,
             h = UI.spacing.buttonHeight,
             labelKey = entry.key,
             text = Localization:get(entry.key),
@@ -54,6 +61,28 @@ function Menu:enter()
     end
 
     buttons = buttonList:reset(defs)
+
+    if #buttons > 0 then
+        local minX, minY = math.huge, math.huge
+        local maxX, maxY = -math.huge, -math.huge
+
+        for _, btn in ipairs(buttons) do
+            minX = math.min(minX, btn.x)
+            minY = math.min(minY, btn.y)
+            maxX = math.max(maxX, btn.x + btn.w)
+            maxY = math.max(maxY, btn.y + btn.h)
+        end
+
+        local padding = UI.spacing.panelPadding * 1.5
+        buttonArea = {
+            x = minX - padding,
+            y = minY - padding,
+            w = (maxX - minX) + padding * 2,
+            h = (maxY - minY) + padding * 2,
+        }
+    else
+        buttonArea = nil
+    end
 end
 
 function Menu:update(dt)
@@ -102,6 +131,12 @@ function Menu:draw()
         Face:draw(head.x, head.y, wordScale)
     end
 
+    if buttonArea then
+        UI.drawPanel(buttonArea.x, buttonArea.y, buttonArea.w, buttonArea.h, {
+            radius = UI.spacing.buttonRadius + 4,
+        })
+    end
+
     for _, btn in ipairs(buttons) do
         if btn.labelKey then
             btn.text = Localization:get(btn.labelKey)
@@ -121,9 +156,8 @@ function Menu:draw()
         end
     end
 
-    love.graphics.setFont(UI.fonts.small)
-    love.graphics.setColor(Theme.textColor)
-    love.graphics.print(Localization:get("menu.version"), 10, sh - 24)
+    local safe = UI.layout.safeMargin
+    UI.print(Localization:get("menu.version"), safe.x, sh - safe.y, { font = "small" })
 end
 
 function Menu:mousepressed(x, y, button)

--- a/modeselect.lua
+++ b/modeselect.lua
@@ -10,19 +10,21 @@ local Localization = require("localization")
 local ModeSelect = {}
 
 local buttonList = ButtonList.new()
+local contentArea = nil
 
 function ModeSelect:enter()
     Screen:update()
     UI.clearButtons()
 
     local sw, sh = Screen:get()
+    local safe = UI.layout.safeMargin
     local centerX = sw / 2
 
-    local buttonWidth = math.min(600, sw - 100)
+    local buttonWidth = math.min(UI.layout.columnWidth, sw - safe.x * 2)
     local buttonHeight = 90
     local spacing = 20
     local x = centerX - buttonWidth / 2
-    local y = 160
+    local y = safe.y + UI.fonts.title:getHeight() + 48
 
     local defs = {}
 
@@ -48,6 +50,8 @@ function ModeSelect:enter()
             score = score,
             modeKey = key,
             unlocked = isUnlocked,
+            textAlign = "left",
+            textPadding = 28,
         }
 
         y = y + buttonHeight + spacing
@@ -64,9 +68,33 @@ function ModeSelect:enter()
         action = "menu",
         modeKey = "back",
         unlocked = true,
+        textAlign = "center",
+        textPadding = 0,
     }
 
-    buttonList:reset(defs)
+    local buttons = buttonList:reset(defs)
+
+    if #buttons > 0 then
+        local minX, minY = math.huge, math.huge
+        local maxX, maxY = -math.huge, -math.huge
+
+        for _, btn in ipairs(buttons) do
+            minX = math.min(minX, btn.x)
+            minY = math.min(minY, btn.y)
+            maxX = math.max(maxX, btn.x + btn.w)
+            maxY = math.max(maxY, btn.y + btn.h)
+        end
+
+        local padding = UI.spacing.panelPadding * 1.5
+        contentArea = {
+            x = minX - padding,
+            y = minY - padding,
+            w = (maxX - minX) + padding * 2,
+            h = (maxY - minY) + padding * 2,
+        }
+    else
+        contentArea = nil
+    end
 end
 
 function ModeSelect:update(dt)
@@ -76,13 +104,18 @@ end
 
 function ModeSelect:draw()
     local sw, sh = Screen:get()
+    local safe = UI.layout.safeMargin
 
     love.graphics.setColor(Theme.bgColor)
     love.graphics.rectangle("fill", 0, 0, sw, sh)
 
-    love.graphics.setFont(UI.fonts.title)
-    love.graphics.setColor(Theme.textColor)
-    love.graphics.printf(Localization:get("modeselect.title"), 0, 40, sw, "center")
+    UI.printf(Localization:get("modeselect.title"), safe.x, safe.y, sw - safe.x * 2, "center", { font = "title" })
+
+    if contentArea then
+        UI.drawPanel(contentArea.x, contentArea.y, contentArea.w, contentArea.h, {
+            radius = UI.spacing.buttonRadius + 6,
+        })
+    end
 
     for _, btn in buttonList:iter() do
         if btn.textKey then
@@ -108,18 +141,13 @@ function ModeSelect:draw()
 
     for _, btn in buttonList:iter() do
         if btn.description and btn.description ~= "" then
-            love.graphics.setFont(UI.fonts.body)
             local descColor = btn.unlocked and Theme.textColor or Theme.lockedCardColor
-            love.graphics.setColor(descColor)
-            love.graphics.printf(btn.description, btn.x + 20, btn.y + btn.h - 32, btn.w - 40, "left")
+            UI.printf(btn.description, btn.x + 28, btn.y + btn.h - 40, btn.w - 56, "left", { font = "body", color = descColor })
         end
 
         if btn.unlocked and btn.score and btn.modeKey ~= "back" then
             local scoreText = Localization:get("modeselect.high_score", { score = tostring(btn.score) })
-            love.graphics.setFont(UI.fonts.body)
-            love.graphics.setColor(Theme.progressColor)
-            local tw = UI.fonts.body:getWidth(scoreText)
-            love.graphics.print(scoreText, btn.x + btn.w - tw - 20, btn.y + 12)
+            UI.printf(scoreText, btn.x + btn.w - 200, btn.y + 16, 180, "right", { font = "body", color = Theme.progressColor })
         end
     end
 end

--- a/settingsscreen.lua
+++ b/settingsscreen.lua
@@ -24,22 +24,27 @@ local buttons = {}
 local hoveredIndex = nil
 local sliderDragging = nil
 local focusedIndex = 1
+local panelBounds = nil
 
 function SettingsScreen:enter()
     Screen:update()
     local sw, sh = Screen:get()
+    local safe = UI.layout.safeMargin
     local centerX = sw / 2
     local totalHeight = (#options) * (UI.spacing.buttonHeight + UI.spacing.buttonSpacing) - UI.spacing.buttonSpacing
-    local startY = sh / 2 - totalHeight / 2
+    local buttonWidth = math.min(420, sw - safe.x * 2)
+    local alignedTop = safe.y + UI.fonts.title:getHeight() + 48
+    local centeredTop = sh / 2 - totalHeight / 2
+    local startY = math.max(alignedTop, centeredTop)
 
     -- reset UI.buttons so we don’t keep stale hitboxes
     UI.clearButtons()
     buttons = {}
 
     for i, opt in ipairs(options) do
-        local x = centerX - UI.spacing.buttonWidth / 2
+        local x = centerX - buttonWidth / 2
         local y = startY + (i - 1) * (UI.spacing.buttonHeight + UI.spacing.buttonSpacing)
-        local w = UI.spacing.buttonWidth
+        local w = buttonWidth
         local h = UI.spacing.buttonHeight
         local id = "settingsOption" .. i
 
@@ -68,6 +73,28 @@ function SettingsScreen:enter()
     end
 
     self:updateFocusVisuals()
+
+    if #buttons > 0 then
+        local minX, minY = math.huge, math.huge
+        local maxX, maxY = -math.huge, -math.huge
+
+        for _, btn in ipairs(buttons) do
+            minX = math.min(minX, btn.x)
+            minY = math.min(minY, btn.y)
+            maxX = math.max(maxX, btn.x + btn.w)
+            maxY = math.max(maxY, btn.y + btn.h)
+        end
+
+        local padding = UI.spacing.panelPadding * 1.5
+        panelBounds = {
+            x = minX - padding,
+            y = minY - padding,
+            w = (maxX - minX) + padding * 2,
+            h = (maxY - minY) + padding * 2,
+        }
+    else
+        panelBounds = nil
+    end
 end
 
 function SettingsScreen:leave()
@@ -86,7 +113,10 @@ function SettingsScreen:update(dt)
         end
 
         if sliderDragging and opt.slider == sliderDragging then
-            local rel = (mx - btn.x) / btn.w
+            local padding = UI.spacing.panelPadding
+            local trackX = btn.x + padding
+            local trackW = math.max(1, btn.w - padding * 2)
+            local rel = (mx - trackX) / trackW
             Settings[sliderDragging] = math.min(1, math.max(0, rel))
             Settings:save()
             Audio:applyVolumes()
@@ -101,14 +131,17 @@ function SettingsScreen:update(dt)
 end
 
 function SettingsScreen:draw()
-    local sw, _ = Screen:get()
+    local sw, sh = Screen:get()
+    local safe = UI.layout.safeMargin
     love.graphics.clear(Theme.bgColor)
 
-    love.graphics.setFont(UI.fonts.title)
-    love.graphics.setColor(1, 1, 1)
-    love.graphics.printf(Localization:get("settings.title"), 0, 80, sw, "center")
+    UI.printf(Localization:get("settings.title"), safe.x, safe.y, sw - safe.x * 2, "center", { font = "title" })
 
-    love.graphics.setFont(UI.fonts.body)
+    if panelBounds then
+        UI.drawPanel(panelBounds.x, panelBounds.y, panelBounds.w, panelBounds.h, {
+            radius = UI.spacing.buttonRadius + 6,
+        })
+    end
 
     for index, btn in ipairs(buttons) do
         local opt = btn.option
@@ -120,37 +153,53 @@ function SettingsScreen:draw()
             local state = isMuted and Localization:get("common.off") or Localization:get("common.on")
             label = string.format("%s: %s", label, state)
             UI.registerButton(btn.id, btn.x, btn.y, btn.w, btn.h, label)
+            UI.setButtonTextAlign(btn.id, "left", 28)
             UI.setButtonFocus(btn.id, isFocused)
             UI.drawButton(btn.id)
 
         elseif opt.type == "slider" and opt.slider then
-            -- slider UI
-            love.graphics.setColor(1, 1, 1)
-            love.graphics.printf(label, btn.x, btn.y - 20, btn.w, "center")
+            UI.drawPanel(btn.x, btn.y, btn.w, btn.h, {
+                color = Theme.panelColor,
+                borderColor = Theme.panelBorder,
+                shadowOffset = UI.spacing.panelShadow,
+                radius = UI.spacing.buttonRadius,
+            })
 
-            local trackY = btn.y + btn.h / 2 - 4
-            local trackH = 8
-
-            love.graphics.setColor(0.3, 0.3, 0.3)
-            love.graphics.rectangle("fill", btn.x, trackY, btn.w, trackH, 4, 4)
-
+            local padding = UI.spacing.panelPadding
+            local labelY = btn.y + padding - 4
             local value = Settings[opt.slider]
-            love.graphics.setColor(0.6, 0.8, 1.0)
-            love.graphics.rectangle("fill", btn.x, trackY, btn.w * value, trackH, 4, 4)
-
-            local handleX = btn.x + btn.w * value
-            love.graphics.setColor(1, 1, 1)
-            love.graphics.circle("fill", handleX, trackY + trackH / 2, 10)
-
             local percentText = string.format("%.0f%%", value * 100)
-            love.graphics.printf(percentText, btn.x + btn.w + 10, btn.y + btn.h / 2 - 8, 50, "left")
+
+            UI.printf(label, btn.x + padding, labelY, btn.w - padding * 2 - 80, "left", { font = "body" })
+            UI.printf(percentText, btn.x + btn.w - padding - 80, labelY, 80, "right", { font = "body", color = Theme.progressColor })
+
+            local trackX = btn.x + padding
+            local trackW = math.max(0, btn.w - padding * 2)
+            local trackY = btn.y + btn.h - padding - 10
+            local trackH = 6
+
+            local shadowColor = Theme.shadowColor or {0, 0, 0, 0.4}
+            love.graphics.setColor(shadowColor[1], shadowColor[2], shadowColor[3], 0.4)
+            love.graphics.rectangle("fill", trackX, trackY, trackW, trackH, 3, 3)
+
+            love.graphics.setColor(Theme.progressColor)
+            love.graphics.rectangle("fill", trackX, trackY, trackW * value, trackH, 3, 3)
+
+            local handleX = trackX + trackW * value
+            local handleY = trackY + trackH / 2
+            love.graphics.setColor(Theme.textColor)
+            love.graphics.circle("fill", handleX, handleY, 10)
+            love.graphics.setColor(Theme.borderColor)
+            love.graphics.setLineWidth(2)
+            love.graphics.circle("line", handleX, handleY, 10)
+            love.graphics.setLineWidth(1)
 
             if isFocused then
-                love.graphics.setColor(0.6, 0.8, 1.0, 0.6)
+                local highlight = Theme.highlightColor or {1, 1, 1, 0.2}
+                love.graphics.setColor(highlight[1], highlight[2], highlight[3], (highlight[4] or 0.2) + 0.1)
                 love.graphics.setLineWidth(3)
-                love.graphics.rectangle("line", btn.x - 8, trackY - 24, btn.w + 16, trackH + 48, 8, 8)
+                love.graphics.rectangle("line", btn.x - 6, btn.y - 6, btn.w + 12, btn.h + 12, UI.spacing.buttonRadius + 4, UI.spacing.buttonRadius + 4)
                 love.graphics.setLineWidth(1)
-                love.graphics.setColor(1, 1, 1)
             end
 
         elseif opt.type == "cycle" and opt.setting == "language" then
@@ -158,12 +207,18 @@ function SettingsScreen:draw()
             local state = Localization:getLanguageName(current)
             label = string.format("%s: %s", label, state)
             UI.registerButton(btn.id, btn.x, btn.y, btn.w, btn.h, label)
+            UI.setButtonTextAlign(btn.id, "left", 28)
             UI.setButtonFocus(btn.id, isFocused)
             UI.drawButton(btn.id)
 
         else
             -- plain button
             UI.registerButton(btn.id, btn.x, btn.y, btn.w, btn.h, label)
+            if opt.action == "menu" then
+                UI.setButtonTextAlign(btn.id, "center", 0)
+            else
+                UI.setButtonTextAlign(btn.id, "left", 28)
+            end
             UI.setButtonFocus(btn.id, isFocused)
             UI.drawButton(btn.id)
         end
@@ -294,13 +349,17 @@ function SettingsScreen:mousepressed(x, y, button)
         end
 
         if opt.slider then
-            local trackY = btn.y + btn.h / 2 - 4
-            local trackH = 8
-            local hoveredSlider = x >= btn.x and x <= btn.x + btn.w and
-                                  y >= trackY and y <= trackY + trackH
+            local padding = UI.spacing.panelPadding
+            local trackX = btn.x + padding
+            local trackW = math.max(1, btn.w - padding * 2)
+            local trackY = btn.y + btn.h - padding - 10
+            local trackH = 6
+            local hitRadius = 12
+            local hoveredSlider = x >= trackX - hitRadius and x <= trackX + trackW + hitRadius and
+                                  y >= trackY - hitRadius and y <= trackY + trackH + hitRadius
             if hoveredSlider then
                 sliderDragging = opt.slider
-                local rel = (x - btn.x) / btn.w
+                local rel = (x - trackX) / trackW
                 Settings[sliderDragging] = math.min(1, math.max(0, rel))
                 Settings:save()
                 Audio:applyVolumes()

--- a/ui.lua
+++ b/ui.lua
@@ -70,18 +70,176 @@ UI.fonts = {
 
 -- Spacing and layout constants
 UI.spacing = {
-    buttonWidth   = 260,
-    buttonHeight  = 56,
-    buttonRadius  = 12,
-    buttonSpacing = 24,
-    panelRadius   = 10,
-    panelPadding  = 16,
-    shadowOffset  = 4,
+    buttonWidth      = 260,
+    buttonHeight     = 56,
+    buttonRadius     = 12,
+    buttonSpacing    = 24,
+    panelRadius      = 10,
+    panelPadding     = 16,
+    panelShadow      = 12,
+    shadowOffset     = 4,
 }
+
+UI.layout = {
+    safeMargin = { x = 80, y = 72 },
+    columnWidth = 560,
+}
+
+UI.textShadow = {
+    enabled = true,
+    offsetX = 2,
+    offsetY = 2,
+    useTextAlpha = true,
+}
+
+UI._shadowStack = {}
+
+local function cloneColor(color, alphaOverride)
+    local base = color or { 0, 0, 0, 1 }
+    return {
+        base[1] or 0,
+        base[2] or 0,
+        base[3] or 0,
+        alphaOverride or base[4] or 1,
+    }
+end
+
+UI.textShadow.color = cloneColor(Theme.shadowColor, Theme.shadowColor and Theme.shadowColor[4] or 0.4)
+
+local lg = love.graphics
+local unpack = table.unpack or unpack
+local originalPrint = lg.print
+local originalPrintf = lg.printf
+
+local function drawWithShadow(drawFunc)
+    if not UI.textShadow.enabled then
+        drawFunc(0, 0)
+        return
+    end
+
+    local textR, textG, textB, textA = lg.getColor()
+    local shadowColor = UI.textShadow.color or Theme.shadowColor or {0, 0, 0, 0.4}
+    local offsetX = UI.textShadow.offsetX or 0
+    local offsetY = UI.textShadow.offsetY or 0
+    local shadowAlpha = shadowColor[4] or 1
+
+    if UI.textShadow.useTextAlpha then
+        shadowAlpha = shadowAlpha * (textA or 1)
+    end
+
+    if (shadowAlpha > 0) and (offsetX ~= 0 or offsetY ~= 0) then
+        lg.setColor(shadowColor[1], shadowColor[2], shadowColor[3], shadowAlpha)
+        drawFunc(offsetX, offsetY)
+        lg.setColor(textR, textG, textB, textA)
+    end
+
+    drawFunc(0, 0)
+end
+
+lg.print = function(text, x, y, r, sx, sy, ox, oy, kx, ky)
+    x = x or 0
+    y = y or 0
+    r = r or 0
+    sx = sx or 1
+    sy = sy or sx
+    ox = ox or 0
+    oy = oy or 0
+    kx = kx or 0
+    ky = ky or 0
+
+    drawWithShadow(function(offsetX, offsetY)
+        return originalPrint(text, x + offsetX, y + offsetY, r, sx, sy, ox, oy, kx, ky)
+    end)
+end
+
+lg.printf = function(text, x, y, limit, align, r, sx, sy, ox, oy, kx, ky)
+    x = x or 0
+    y = y or 0
+    limit = limit or lg.getWidth()
+    align = align or "left"
+    r = r or 0
+    sx = sx or 1
+    sy = sy or sx
+    ox = ox or 0
+    oy = oy or 0
+    kx = kx or 0
+    ky = ky or 0
+
+    drawWithShadow(function(offsetX, offsetY)
+        return originalPrintf(text, x + offsetX, y + offsetY, limit, align, r, sx, sy, ox, oy, kx, ky)
+    end)
+end
+
+function UI.pushTextShadow(enabled)
+    UI._shadowStack[#UI._shadowStack + 1] = UI.textShadow.enabled
+    UI.textShadow.enabled = enabled
+end
+
+function UI.popTextShadow()
+    local previous = UI._shadowStack[#UI._shadowStack]
+    if previous == nil then return end
+    UI._shadowStack[#UI._shadowStack] = nil
+    UI.textShadow.enabled = previous
+end
+
+function UI.withoutTextShadow(fn)
+    UI.pushTextShadow(false)
+    local results = {pcall(fn)}
+    UI.popTextShadow()
+
+    if not results[1] then
+        error(results[2])
+    end
+
+    return unpack(results, 2)
+end
 
 -- Utility: set font
 function UI.setFont(font)
     love.graphics.setFont(UI.fonts[font or "body"])
+end
+
+local function setColor(color)
+    if not color then return end
+    love.graphics.setColor(color[1], color[2], color[3], color[4] or 1)
+end
+
+function UI.print(text, x, y, opts)
+    opts = opts or {}
+
+    local prevFont = love.graphics.getFont()
+    local prevColor = {love.graphics.getColor()}
+
+    if opts.font then
+        UI.setFont(opts.font)
+    elseif opts.fontObject then
+        love.graphics.setFont(opts.fontObject)
+    end
+
+    setColor(opts.color or Theme.textColor)
+    love.graphics.print(text, x, y)
+
+    love.graphics.setFont(prevFont)
+    setColor(prevColor)
+end
+
+function UI.printf(text, x, y, limit, align, opts)
+    opts = opts or {}
+
+    local prevFont = love.graphics.getFont()
+    local prevColor = {love.graphics.getColor()}
+
+    if opts.font then
+        UI.setFont(opts.font)
+    elseif opts.fontObject then
+        love.graphics.setFont(opts.fontObject)
+    end
+
+    setColor(opts.color or Theme.textColor)
+    love.graphics.printf(text, x, y, limit or love.graphics.getWidth(), align or "left", opts.r, opts.sx, opts.sy, opts.ox, opts.oy, opts.kx, opts.ky)
+
+    love.graphics.setFont(prevFont)
+    setColor(prevColor)
 end
 
 -- Utility: draw rounded rectangle
@@ -97,6 +255,44 @@ function UI.drawRoundedRect(x, y, w, h, r)
     love.graphics.circle("fill", x + w - r, y + h - r, r, segments)
 end
 
+function UI.drawPanel(x, y, w, h, opts)
+    opts = opts or {}
+
+    local radius = opts.radius or UI.spacing.panelRadius
+    local shadowOffset = opts.shadowOffset or UI.spacing.panelShadow
+    local shadowColor = opts.shadowColor or Theme.shadowColor
+
+    if shadowColor and (shadowColor[4] or 0) > 0 then
+        love.graphics.setColor(shadowColor[1], shadowColor[2], shadowColor[3], shadowColor[4])
+        love.graphics.rectangle("fill", x + shadowOffset, y + shadowOffset, w, h, radius, radius)
+    end
+
+    setColor(opts.color or Theme.panelColor)
+    love.graphics.rectangle("fill", x, y, w, h, radius, radius)
+
+    local borderColor = opts.borderColor
+    if borderColor == nil then
+        borderColor = Theme.panelBorder
+    end
+
+    if borderColor and (borderColor[4] or 0) > 0 then
+        love.graphics.setLineWidth(opts.borderWidth or 3)
+        love.graphics.setColor(borderColor[1], borderColor[2], borderColor[3], borderColor[4] or 1)
+        love.graphics.rectangle("line", x, y, w, h, radius, radius)
+        love.graphics.setLineWidth(1)
+    end
+end
+
+function UI.setButtonTextAlign(id, align, padding)
+    if not id then return end
+
+    local btn = UI.buttons[id]
+    if not btn then return end
+
+    btn.textAlign = align or "center"
+    btn.textPadding = padding or 0
+end
+
 -- Easing
 local function easeOutQuad(t)
     return t * (2 - t)
@@ -108,6 +304,8 @@ function UI.registerButton(id, x, y, w, h, text)
     local btn = UI.buttons[id]
     btn.bounds = {x = x, y = y, w = w, h = h}
     btn.text = text
+    btn.textAlign = btn.textAlign or "center"
+    btn.textPadding = btn.textPadding or 0
 end
 
 -- Draw button (render only)
@@ -152,9 +350,11 @@ function UI.drawButton(id)
     end
 
     -- TEXT
-    UI.setFont("button")
-    love.graphics.setColor(Theme.textColor)
-    love.graphics.printf(btn.text, b.x, b.y + yOffset + (b.h / 2) - UI.fonts.button:getHeight() / 2, b.w, "center")
+    local textAlign = btn.textAlign or "center"
+    local padding = btn.textPadding or 0
+    local textX = b.x + padding
+    local textWidth = math.max(0, b.w - padding * 2)
+    UI.printf(btn.text, textX, b.y + yOffset + (b.h - UI.fonts.button:getHeight()) / 2, textWidth, textAlign, { font = "button", color = Theme.textColor })
 end
 
 -- Hover check


### PR DESCRIPTION
## Summary
- add layout constants and a reusable panel/text helpers so all text renders with a consistent drop shadow
- refresh the menu and mode select screens with centered panels, safe margins, and button text alignment tweaks
- restyle settings controls with a framed panel, refined sliders, and shadow-safe floating text

## Testing
- luac -p ui.lua *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d749a9e02c832f907d941fc0884efc