### PR TITLE
Simplify shop card rarity presentation

### DIFF
--- a/shop.lua
+++ b/shop.lua
@@ -107,101 +107,102 @@ local rarityBorderAlpha = 0.85
 local rarityStyles = {
     common = {
         base = {0.20, 0.23, 0.28, 1},
-        highlight = {0.32, 0.35, 0.42, 0.82},
-        lowlight = {0.13, 0.15, 0.20, 0.88},
-        highlightHeight = 0.45,
-        accent = {0.72, 0.82, 0.92, 0.26},
-        shadowAlpha = 0.22,
-        glow = 0.08,
-        innerGlow = 0.18,
+        shadowAlpha = 0.18,
+        aura = {
+            color = {0.52, 0.62, 0.78, 0.22},
+            radius = 0.72,
+            y = 0.42,
+        },
+        outerGlow = {
+            color = {0.62, 0.74, 0.92, 1},
+            min = 0.04,
+            max = 0.14,
+            speed = 1.4,
+            expand = 5,
+            width = 6,
+        },
+        innerGlow = {
+            color = {0.82, 0.90, 1.0, 1},
+            min = 0.06,
+            max = 0.18,
+            speed = 1.2,
+            inset = 8,
+            width = 2,
+        },
     },
     uncommon = {
-        base = {0.18, 0.27, 0.21, 1},
-        highlight = {0.26, 0.36, 0.29, 0.86},
-        lowlight = {0.10, 0.16, 0.13, 0.9},
-        highlightHeight = 0.5,
-        accent = {0.56, 0.78, 0.58, 0.32},
-        shadowAlpha = 0.26,
-        glow = 0.14,
-        innerGlow = 0.22,
-        stripes = {
-            color = {0.72, 0.92, 0.76, 0.12},
-            width = 24,
-            spacing = 38,
-            angle = -math.pi / 7,
+        base = {0.18, 0.28, 0.22, 1},
+        shadowAlpha = 0.24,
+        aura = {
+            color = {0.46, 0.78, 0.56, 0.28},
+            radius = 0.76,
+            y = 0.40,
         },
-        sparkles = {
-            color = {0.84, 1.0, 0.86, 0.55},
-            radius = 10,
+        outerGlow = {
+            color = {0.52, 0.92, 0.64, 1},
+            min = 0.08,
+            max = 0.24,
             speed = 1.6,
-            positions = {
-                {0.24, 0.26, 0.9},
-                {0.68, 0.34, 1.1},
-                {0.42, 0.58, 0.7},
-            },
+            expand = 6,
+            width = 6,
+        },
+        innerGlow = {
+            color = {0.68, 0.96, 0.78, 1},
+            min = 0.10,
+            max = 0.28,
+            speed = 1.8,
+            inset = 8,
+            width = 3,
         },
     },
     rare = {
-        base = {0.23, 0.16, 0.32, 1},
-        highlight = {0.34, 0.24, 0.48, 0.88},
-        lowlight = {0.17, 0.11, 0.26, 0.92},
-        highlightHeight = 0.52,
-        accent = {0.76, 0.56, 0.88, 0.38},
-        shadowAlpha = 0.32,
-        glow = 0.2,
-        innerGlow = 0.26,
-        stripes = {
-            color = {0.90, 0.76, 1.0, 0.18},
-            width = 28,
-            spacing = 36,
-            angle = -math.pi / 8,
+        base = {0.24, 0.16, 0.32, 1},
+        shadowAlpha = 0.30,
+        aura = {
+            color = {0.82, 0.64, 0.98, 0.30},
+            radius = 0.82,
+            y = 0.36,
         },
-        sparkles = {
-            color = {0.95, 0.82, 1.0, 0.68},
-            radius = 11,
-            speed = 1.85,
-            positions = {
-                {0.22, 0.28, 1.0},
-                {0.74, 0.30, 1.2},
-                {0.56, 0.56, 0.9},
-                {0.36, 0.68, 0.8},
-            },
+        outerGlow = {
+            color = {0.86, 0.72, 1.0, 1},
+            min = 0.14,
+            max = 0.32,
+            speed = 1.9,
+            expand = 7,
+            width = 7,
         },
-        flare = {
-            color = {0.86, 0.64, 1.0, 0.26},
-            radius = 0.38,
+        innerGlow = {
+            color = {0.94, 0.82, 1.0, 1},
+            min = 0.16,
+            max = 0.36,
+            speed = 2.1,
+            inset = 8,
+            width = 3,
         },
     },
     epic = {
-        base = {0.28, 0.12, 0.06, 1},
-        highlight = {0.44, 0.20, 0.12, 0.94},
-        lowlight = {0.20, 0.07, 0.04, 0.95},
-        highlightHeight = 0.58,
-        accent = {1.0, 0.52, 0.28, 0.46},
-        shadowAlpha = 0.36,
-        glow = 0.28,
-        innerGlow = 0.3,
-        stripes = {
-            color = {1.0, 0.72, 0.48, 0.22},
-            width = 32,
-            spacing = 40,
-            angle = -math.pi / 9,
+        base = {0.32, 0.14, 0.08, 1},
+        shadowAlpha = 0.34,
+        aura = {
+            color = {1.0, 0.62, 0.36, 0.34},
+            radius = 0.86,
+            y = 0.38,
         },
-        sparkles = {
-            color = {1.0, 0.82, 0.62, 0.76},
-            radius = 12,
+        outerGlow = {
+            color = {1.0, 0.72, 0.48, 1},
+            min = 0.18,
+            max = 0.40,
             speed = 2.2,
-            positions = {
-                {0.22, 0.24, 1.05},
-                {0.5, 0.32, 1.3},
-                {0.78, 0.28, 1.1},
-                {0.64, 0.58, 0.9},
-                {0.36, 0.62, 1.0},
-            },
+            expand = 8,
+            width = 8,
         },
-        flare = {
-            color = {1.0, 0.64, 0.36, 0.32},
-            radius = 0.42,
+        innerGlow = {
+            color = {1.0, 0.82, 0.62, 1},
+            min = 0.22,
+            max = 0.42,
+            speed = 2.4,
+            inset = 8,
+            width = 3,
         },
     },
 }
@@ -209,6 +210,44 @@ local rarityStyles = {
 local function applyColor(setColorFn, color, overrideAlpha)
     if not color then return end
     setColorFn(color[1], color[2], color[3], overrideAlpha or color[4] or 1)
+end
+
+local function withTransformedScissor(x, y, w, h, fn)
+    if not fn then return end
+
+    local sx1, sy1 = love.graphics.transformPoint(x, y)
+    local sx2, sy2 = love.graphics.transformPoint(x + w, y + h)
+
+    local scissorX = math.min(sx1, sx2)
+    local scissorY = math.min(sy1, sy2)
+    local scissorW = math.abs(sx2 - sx1)
+    local scissorH = math.abs(sy2 - sy1)
+
+    if scissorW <= 0 or scissorH <= 0 then
+        fn()
+        return
+    end
+
+    local previous = { love.graphics.getScissor() }
+    love.graphics.setScissor(scissorX, scissorY, scissorW, scissorH)
+    fn()
+    if previous[1] then
+        love.graphics.setScissor(previous[1], previous[2], previous[3], previous[4])
+    else
+        love.graphics.setScissor()
+    end
+end
+
+local function getAnimatedAlpha(def, time)
+    if not def then return nil end
+    local minAlpha = def.min or def.alpha or 0
+    local maxAlpha = def.max or def.alpha or minAlpha
+    if not def.speed or maxAlpha == minAlpha then
+        return maxAlpha
+    end
+    local phase = def.phase or 0
+    local wave = math.sin(time * def.speed + phase) * 0.5 + 0.5
+    return minAlpha + (maxAlpha - minAlpha) * wave
 end
 
 local function drawCard(card, x, y, w, h, hovered, index, _, isSelected, appearanceAlpha)
@@ -237,77 +276,47 @@ local function drawCard(card, x, y, w, h, hovered, index, _, isSelected, appeara
     applyColor(setColor, style.base)
     love.graphics.rectangle("fill", x, y, w, h, 12, 12)
 
-    if style.lowlight then
-        applyColor(setColor, style.lowlight)
-        local lowlightHeight = (style.lowlightHeight or 0.36) * h
-        love.graphics.rectangle("fill", x, y + h - lowlightHeight, w, lowlightHeight, 12, 12)
+    local currentTime = (love.timer and love.timer.getTime and love.timer.getTime()) or 0
+
+    if style.aura then
+        withTransformedScissor(x, y, w, h, function()
+            applyColor(setColor, style.aura.color)
+            local radius = math.max(w, h) * (style.aura.radius or 0.72)
+            local centerY = y + h * (style.aura.y or 0.4)
+            love.graphics.circle("fill", x + w * 0.5, centerY, radius)
+        end)
     end
 
-    if style.highlight then
-        applyColor(setColor, style.highlight)
-        local highlightHeight = (style.highlightHeight or 0.48)
-        love.graphics.rectangle("fill", x + 6, y + 6, w - 12, (h - 12) * highlightHeight, 10, 10)
-    end
-
-    if style.flare then
-        love.graphics.setScissor(x, y, w, h)
-        applyColor(setColor, style.flare.color)
-        local radius = math.min(w, h) * (style.flare.radius or 0.36)
-        love.graphics.circle("fill", x + w * 0.5, y + h * 0.32, radius)
-        love.graphics.setScissor()
-    end
-
-    if style.stripes then
-        love.graphics.push()
-        love.graphics.setScissor(x, y, w, h)
-        love.graphics.translate(x + w / 2, y + h / 2)
-        love.graphics.rotate(style.stripes.angle or -math.pi / 6)
-        local diag = math.sqrt(w * w + h * h)
-        local spacing = style.stripes.spacing or 34
-        local width = style.stripes.width or 22
-        applyColor(setColor, style.stripes.color)
-        local stripeCount = math.ceil((diag * 2) / spacing) + 2
-        for i = -stripeCount, stripeCount do
-            local pos = i * spacing
-            love.graphics.rectangle("fill", -diag, pos - width / 2, diag * 2, width)
+    if style.outerGlow then
+        local glowAlpha = getAnimatedAlpha(style.outerGlow, currentTime)
+        if glowAlpha and glowAlpha > 0 then
+            applyColor(setColor, style.outerGlow.color or borderColor, glowAlpha)
+            love.graphics.setLineWidth(style.outerGlow.width or 6)
+            local expand = style.outerGlow.expand or 6
+            love.graphics.rectangle("line", x - expand, y - expand, w + expand * 2, h + expand * 2, 18, 18)
         end
-        love.graphics.pop()
-        love.graphics.setScissor()
-    end
-
-    if style.sparkles and style.sparkles.positions then
-        local time = (love.timer and love.timer.getTime and love.timer.getTime()) or 0
-        love.graphics.setScissor(x, y, w, h)
-        for i, pos in ipairs(style.sparkles.positions) do
-            local px, py, scale = pos[1], pos[2], pos[3] or 1
-            local pulse = 0.6 + 0.4 * math.sin(time * (style.sparkles.speed or 1.8) + i * 0.9)
-            local radius = (style.sparkles.radius or 9) * scale * pulse
-            local sparkleColor = style.sparkles.color or borderColor
-            local sparkleAlpha = (sparkleColor[4] or 1) * pulse
-            applyColor(setColor, sparkleColor, sparkleAlpha)
-            love.graphics.circle("fill", x + px * w, y + py * h, radius)
-        end
-        love.graphics.setScissor()
-    end
-
-    if style.glow and style.glow > 0 then
-        applyColor(setColor, borderColor, style.glow)
-        love.graphics.setLineWidth(6)
-        love.graphics.rectangle("line", x - 3, y - 3, w + 6, h + 6, 16, 16)
     end
 
     applyColor(setColor, borderColor, rarityBorderAlpha)
     love.graphics.setLineWidth(style.borderWidth or 4)
     love.graphics.rectangle("line", x, y, w, h, 12, 12)
 
-    if style.innerGlow and style.innerGlow > 0 then
-        local baseAlpha = style.innerGlow
-        if hovered or isSelected then
-            baseAlpha = math.max(baseAlpha, hovered and 0.6 or 0.4)
-        end
-        applyColor(setColor, borderColor, baseAlpha)
-        love.graphics.setLineWidth(2)
-        love.graphics.rectangle("line", x + 6, y + 6, w - 12, h - 12, 10, 10)
+    local hoverGlowAlpha
+    if style.innerGlow then
+        hoverGlowAlpha = getAnimatedAlpha(style.innerGlow, currentTime)
+    end
+
+    if hovered or isSelected then
+        local focusAlpha = hovered and 0.6 or 0.4
+        hoverGlowAlpha = math.max(hoverGlowAlpha or 0, focusAlpha)
+    end
+
+    if hoverGlowAlpha and hoverGlowAlpha > 0 then
+        local innerColor = (style.innerGlow and style.innerGlow.color) or borderColor
+        local inset = (style.innerGlow and style.innerGlow.inset) or 6
+        love.graphics.setLineWidth((style.innerGlow and style.innerGlow.width) or 2)
+        applyColor(setColor, innerColor, hoverGlowAlpha)
+        love.graphics.rectangle("line", x + inset, y + inset, w - inset * 2, h - inset * 2, 10, 10)
     elseif hovered or isSelected then
         local glowAlpha = hovered and 0.55 or 0.35
         applyColor(setColor, borderColor, glowAlpha)


### PR DESCRIPTION
## Summary
- replace the shop card highlight/stripe/sparkle layers with aura and glow driven styling
- add animated aura and glow parameters per rarity to keep the visuals readable while conveying value

## Testing
- not run (LÖVE runtime unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d751b81e60832f9e4900d842f236bf