### PR TITLE
Add fruit consumption markers

### DIFF
--- a/fruitevents.lua
+++ b/fruitevents.lua
@@ -239,6 +239,7 @@ function FruitEvents.handleConsumption(x, y)
     local col, row = Fruit:getTile()
 
     Snake:grow()
+    Snake:markFruitSegment()
     Face:set("happy", 2)
     FloatingText:add("+" .. tostring(points), x, y, Theme.textColor, 1.0, 40)
     Score:increase(points)

--- a/snake.lua
+++ b/snake.lua
@@ -747,6 +747,17 @@ function Snake:grow()
     popTimer = POP_DURATION
 end
 
+function Snake:markFruitSegment()
+    if not trail or #trail == 0 then
+        return
+    end
+
+    local headSegment = trail[1]
+    if headSegment then
+        headSegment.fruitMarker = true
+    end
+end
+
 function Snake:draw()
     if not isDead then
         local upgradeVisuals = collectUpgradeVisuals(self)

--- a/snakedraw.lua
+++ b/snakedraw.lua
@@ -7,6 +7,7 @@ local unpack = unpack
 local POP_DURATION   = 0.25
 local SHADOW_OFFSET  = 3
 local OUTLINE_SIZE   = 6
+local FRUIT_BULGE_SCALE = 1.15
 
 -- colors (body color reused for patches so they blend)
 local BODY_R, BODY_G, BODY_B = Theme.snakeDefault
@@ -73,22 +74,39 @@ local function drawCornerPlugs(trail, radius)
 end
 
 
+local function drawFruitBulges(trail, head, radius)
+  if not trail or radius <= 0 then return end
+
+  for i = 1, #trail do
+    local seg = trail[i]
+    if seg and seg.fruitMarker and seg ~= head then
+      local x, y = ptXY(seg)
+      if x and y then
+        love.graphics.circle("fill", x, y, radius)
+      end
+    end
+  end
+end
+
+
 local function renderSnakeToCanvas(trail, coords, head, tail, half, thickness)
-	-- OUTLINE
-	love.graphics.setColor(0, 0, 0, 1)
-	love.graphics.setLineWidth(thickness + OUTLINE_SIZE)
-	drawPolyline(coords)
-	drawEndcaps(head, tail, half + OUTLINE_SIZE * 0.5)
-	drawCornerPlugs(trail, half + OUTLINE_SIZE*0.5)
+        -- OUTLINE
+        love.graphics.setColor(0, 0, 0, 1)
+        love.graphics.setLineWidth(thickness + OUTLINE_SIZE)
+        drawPolyline(coords)
+        drawEndcaps(head, tail, half + OUTLINE_SIZE * 0.5)
+        drawCornerPlugs(trail, half + OUTLINE_SIZE*0.5)
+        drawFruitBulges(trail, head, half * FRUIT_BULGE_SCALE + OUTLINE_SIZE * 0.5)
 
-	-- BODY
-	love.graphics.setColor(BODY_R, BODY_G, BODY_B)
-	love.graphics.setLineWidth(thickness)
-	drawPolyline(coords)
-	drawEndcaps(head, tail, half)
+        -- BODY
+        love.graphics.setColor(BODY_R, BODY_G, BODY_B)
+        love.graphics.setLineWidth(thickness)
+        drawPolyline(coords)
+        drawEndcaps(head, tail, half)
 
-	love.graphics.setColor(BODY_R, BODY_G, BODY_B)
-	drawCornerPlugs(trail, half)
+        love.graphics.setColor(BODY_R, BODY_G, BODY_B)
+        drawCornerPlugs(trail, half)
+        drawFruitBulges(trail, head, half * FRUIT_BULGE_SCALE)
 end
 
 local function drawSoftGlow(x, y, radius, r, g, b, a)


### PR DESCRIPTION
## Summary
- mark the snake's trail when fruit is collected so the segment carries fruit metadata
- render a subtle bulge over marked segments, leaving a visual trace of the eaten fruit

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7810b3028832fa17ade036d2721c3