### PR TITLE
Remove Gyro Stabilizers upgrade

### DIFF
--- a/upgrades.lua
+++ b/upgrades.lua
@@ -801,16 +801,6 @@ local pool = {
         },
     }),
     register({
-        id = "gyro_stabilizers",
-        name = "Gyro Stabilizers",
-        desc = "Saws spin 35% slower.",
-        rarity = "uncommon",
-        tags = {"defense"},
-        onAcquire = function(state)
-            state.effects.sawSpinMult = (state.effects.sawSpinMult or 1) * 0.65
-        end,
-    }),
-    register({
         id = "tempest_nectar",
         name = "Tempest Nectar",
         desc = "Fruit grant +1 bonus score and stall saws for 0.6s.",


### PR DESCRIPTION
## Summary
- remove the Gyro Stabilizers upgrade that only reduced saw spin speed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d78baae398832f955ffe22a68003d3