### PR TITLE
Ensure saw stall effects stack properly

### DIFF
--- a/saws.lua
+++ b/saws.lua
@@ -332,7 +332,11 @@ function Saws:draw()
 end
 
 function Saws:stall(duration)
-    stallTimer = math.max(stallTimer, duration or 0)
+    if not duration or duration <= 0 then
+        return
+    end
+
+    stallTimer = (stallTimer or 0) + duration
 end
 
 function Saws:sink(duration)

--- a/snake.lua
+++ b/snake.lua
@@ -110,8 +110,7 @@ function Snake:addShieldBurst(config)
         self.shieldBurst.rocks = (self.shieldBurst.rocks or 0) + rocks
     end
     if stall ~= 0 then
-        local current = self.shieldBurst.stall or 0
-        self.shieldBurst.stall = math.max(current, stall)
+        self.shieldBurst.stall = (self.shieldBurst.stall or 0) + stall
     end
 end
 

--- a/upgrades.lua
+++ b/upgrades.lua
@@ -644,8 +644,7 @@ local pool = {
             else
                 Snake.shieldBurst = Snake.shieldBurst or { rocks = 0, stall = 0 }
                 Snake.shieldBurst.rocks = (Snake.shieldBurst.rocks or 0) + 1
-                local current = Snake.shieldBurst.stall or 0
-                Snake.shieldBurst.stall = math.max(current, 1.5)
+                Snake.shieldBurst.stall = (Snake.shieldBurst.stall or 0) + 1.5
             end
         end,
     }),


### PR DESCRIPTION
## Summary
- make saw stall timer additive so repeated effects stack their durations
- accumulate shield burst stall time from upgrades rather than taking the maximum
- update fallback upgrade handling to match the new stacking behaviour

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d78f91661c832f919c73ba56ef66e1