### PR TITLE
Add full gamepad support to the shop

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -879,6 +879,13 @@ end
 
 local map = { dpleft="left", dpright="right", dpup="up", dpdown="down" }
 local function handleGamepadInput(self, button)
+        if self.transitionPhase == "shop" then
+                if Shop:gamepadpressed(nil, button) then
+                        self.shopCloseRequested = true
+                end
+                return
+        end
+
         if self.state == "paused" then
                 if button == "start" then
                         self.state = "playing"


### PR DESCRIPTION
## Summary
- add persistent focus tracking to shop cards so they respond to gamepad navigation and selection
- route shop phase controller input through the new gamepad handler to allow selecting relics without a mouse

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d79fbb1084832fbdf1ee7e0b0de5b9