### PR TITLE
Enable shop gamepad navigation

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -879,6 +879,13 @@ end
 
 local map = { dpleft="left", dpright="right", dpup="up", dpdown="down" }
 local function handleGamepadInput(self, button)
+        if self.transitionPhase == "shop" then
+                if Shop:gamepadpressed(nil, button) then
+                        self.shopCloseRequested = true
+                end
+                return
+        end
+
         if self.state == "paused" then
                 if button == "start" then
                         self.state = "playing"


### PR DESCRIPTION
## Summary
- add focus tracking to shop cards so they can be highlighted and selected with a controller
- wire shop interactions into the global gamepad handler so d-pad and confirm inputs work during shop transitions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8038e0d3c832fab891c420ead095c