### PR TITLE
Add controller scrolling support to achievements menu

### DIFF
--- a/achievementsmenu.lua
+++ b/achievementsmenu.lua
@@ -25,6 +25,7 @@ local scrollOffset = 0
 local minScrollOffset = 0
 local viewportHeight = 0
 local contentHeight = 0
+local DPAD_SCROLL_AMOUNT = CARD_SPACING
 
 local function buildThumbSnakeTrail(trackX, thumbY, trackWidth, thumbHeight)
     local segmentSize = SnakeUtils.SEGMENT_SIZE
@@ -127,6 +128,17 @@ local function updateScrollBounds(sw, sh)
     elseif scrollOffset > 0 then
         scrollOffset = 0
     end
+end
+
+local function scrollBy(amount)
+    if amount == 0 then
+        return
+    end
+
+    scrollOffset = scrollOffset + amount
+
+    local sw, sh = Screen:get()
+    updateScrollBounds(sw, sh)
 end
 
 function AchievementsMenu:enter()
@@ -339,16 +351,24 @@ function AchievementsMenu:wheelmoved(dx, dy)
         return
     end
 
-    scrollOffset = scrollOffset + dy * SCROLL_SPEED
-    local sw, sh = Screen:get()
-    updateScrollBounds(sw, sh)
+    scrollBy(dy * SCROLL_SPEED)
 end
 
 function AchievementsMenu:gamepadpressed(_, button)
-    if button == "dpup" or button == "dpleft" then
+    if button == "dpup" then
+        scrollBy(DPAD_SCROLL_AMOUNT)
         buttonList:moveFocus(-1)
-    elseif button == "dpdown" or button == "dpright" then
+    elseif button == "dpleft" then
+        buttonList:moveFocus(-1)
+    elseif button == "dpdown" then
+        scrollBy(-DPAD_SCROLL_AMOUNT)
         buttonList:moveFocus(1)
+    elseif button == "dpright" then
+        buttonList:moveFocus(1)
+    elseif button == "leftshoulder" then
+        scrollBy(DPAD_SCROLL_AMOUNT * math.max(1, math.floor(viewportHeight / CARD_SPACING)))
+    elseif button == "rightshoulder" then
+        scrollBy(-DPAD_SCROLL_AMOUNT * math.max(1, math.floor(viewportHeight / CARD_SPACING)))
     elseif button == "a" or button == "start" or button == "b" then
         local action = buttonList:activateFocused()
         if action then


### PR DESCRIPTION
## Summary
- add a reusable scroll helper for the achievements menu and reuse it for the mouse wheel
- enable d-pad and shoulder buttons to scroll the achievements list when using a controller

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68d80a4c5fe8832fbe20a2c50fcdc008