### PR TITLE
Fix vertical saw sink direction

### DIFF
--- a/saws.lua
+++ b/saws.lua
@@ -291,7 +291,16 @@ function Saws:draw()
         -- Saw blade
         love.graphics.push()
         local sinkOffset = (saw.sinkProgress or 0) * SINK_DISTANCE
-        love.graphics.translate(px or saw.x, (py or saw.y) + SINK_OFFSET + sinkOffset)
+        local offsetX, offsetY = 0, 0
+
+        if saw.dir == "horizontal" then
+            offsetY = SINK_OFFSET + sinkOffset
+        else
+            local sinkDir = (saw.side == "left") and -1 or 1
+            offsetX = sinkDir * (SINK_OFFSET + sinkOffset)
+        end
+
+        love.graphics.translate((px or saw.x) + offsetX, (py or saw.y) + offsetY)
 
         -- apply spinning rotation
         love.graphics.rotate(saw.rotation)


### PR DESCRIPTION
## Summary
- adjust vertical saw sink translation so blades retract along the slot direction
- preserve horizontal saw behavior while supporting left/right mounted tracks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d80bb83e2c832f89373481a764cddf