### PR TITLE
Keep snake body visible during exit cinematic

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -208,9 +208,14 @@ function Game:beginDeath()
 end
 
 function Game:startDescending(holeX, holeY, holeRadius)
-    self.state = "descending"
-    self.hole = {x = holeX, y = holeY, radius = holeRadius or 24}
-    Snake:startDescending(self.hole.x, self.hole.y, self.hole.radius)
+        self.state = "descending"
+        self.hole = {
+                x = holeX,
+                y = holeY,
+                radius = holeRadius or 24,
+                baseRadius = holeRadius or 24,
+        }
+        Snake:startDescending(self.hole.x, self.hole.y, self.hole.radius)
 end
 
 -- start a floor transition
@@ -309,6 +314,11 @@ end
 
 function Game:updateDescending(dt)
         Snake:update(dt)
+
+        local radius = Snake:getDescendingVisualRadius()
+        if radius and self.hole then
+                self.hole.radius = radius
+        end
 
         local segments = Snake:getSegments()
         local tail = segments[#segments]


### PR DESCRIPTION
## Summary
- add easing helpers and trail length calculations to support controlled exit cinematics
- drive the snake toward the exit via a scripted descent that gradually consumes the body and shrinks the exit radius
- update the game loop to honor the scripted radius while the cinematic plays
- keep the snake body visible outside the exit until it actually enters the hole

## Testing
- `luac -p snake.lua game.lua` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d80fcd82ec832f80f8adbd0e3be060