### PR TITLE
Add audio cues for key gameplay transitions

### DIFF
--- a/arena.lua
+++ b/arena.lua
@@ -1,4 +1,5 @@
 local Theme = require("theme")
+local Audio = require("audio")
 
 local EXIT_SAFE_ATTEMPTS = 180
 local MIN_HEAD_DISTANCE_TILES = 2
@@ -290,6 +291,7 @@ function Arena:spawnExit()
         col = chosenCol,
         row = chosenRow,
     }
+    Audio:playSound("exit_spawn")
 end
 
 function Arena:getExitCenter()

--- a/audio.lua
+++ b/audio.lua
@@ -14,6 +14,13 @@ function Audio:load()
     self.sounds.achievement = love.audio.newSource("Assets/Sounds/Retro Event Acute 11.wav", "static")
     self.sounds.shield_gain = love.audio.newSource("Assets/Sounds/switch_001.ogg", "static")
     self.sounds.shield_break = love.audio.newSource("Assets/Sounds/abs-cancel-1.wav", "static")
+    self.sounds.death = love.audio.newSource("Assets/Sounds/error_007.ogg", "static")
+    self.sounds.exit_spawn = love.audio.newSource("Assets/Sounds/toggle_001.ogg", "static")
+    self.sounds.exit_enter = love.audio.newSource("Assets/Sounds/abs-confirm-1.wav", "static")
+    self.sounds.floor_advance = love.audio.newSource("Assets/Sounds/Retro PickUp 18.wav", "static")
+    self.sounds.floor_intro = love.audio.newSource("Assets/Sounds/Retro Event Acute 08.wav", "static")
+    self.sounds.shop_open = love.audio.newSource("Assets/Sounds/apple.wav", "static")
+    self.sounds.shop_purchase = love.audio.newSource("Assets/Sounds/abs-confirm-1.wav", "static")
 
     -- Music Tracks
     self.musicTracks.menu = love.audio.newSource("Assets/Music/Menu2.ogg", "stream")
@@ -26,6 +33,16 @@ function Audio:load()
 
     self:applyVolumes()
 end
+
+Audio.soundDesignNotes = {
+    death = "Short, heavy failure sting with a crunchy impact to sell the snake's demise.",
+    exit_spawn = "Gentle magical chime that signals the exit portal appearing nearby.",
+    exit_enter = "Deep whoosh or portal suction to reinforce diving into the exit.",
+    floor_advance = "Upbeat arpeggio or rising tone to celebrate clearing a floor.",
+    floor_intro = "Soft swell or drum hit that sets the tone for the new floor intro card.",
+    shop_open = "Friendly bell or door chime that implies entering the shop.",
+    shop_purchase = "Satisfied confirmation click confirming an upgrade purchase.",
+}
 
 function Audio:applyVolumes()
     for _, track in pairs(self.musicTracks) do

--- a/game.lua
+++ b/game.lua
@@ -200,17 +200,19 @@ function Game:leave()
 end
 
 function Game:beginDeath()
-	if self.state ~= "dying" then
-		self.state = "dying"
-		local trail = Snake:getSegments()
-		Death:spawnFromSnake(trail, SnakeUtils.SEGMENT_SIZE)
-	end
+        if self.state ~= "dying" then
+                self.state = "dying"
+                local trail = Snake:getSegments()
+                Death:spawnFromSnake(trail, SnakeUtils.SEGMENT_SIZE)
+                Audio:playSound("death")
+        end
 end
 
 function Game:startDescending(holeX, holeY, holeRadius)
-    self.state = "descending"
-    self.hole = {x = holeX, y = holeY, radius = holeRadius or 24}
-    Snake:startDescending(self.hole.x, self.hole.y, self.hole.radius)
+        self.state = "descending"
+        self.hole = {x = holeX, y = holeY, radius = holeRadius or 24}
+        Snake:startDescending(self.hole.x, self.hole.y, self.hole.radius)
+        Audio:playSound("exit_enter")
 end
 
 -- start a floor transition
@@ -226,6 +228,7 @@ function Game:startFloorTransition(advance, skipFade)
                 PlayerStats:updateMax("deepestFloorReached", nextFloor)
                 SessionStats:add("floorsCleared", 1)
                 SessionStats:updateMax("deepestFloorReached", nextFloor)
+                Audio:playSound("floor_advance")
         end
 
         startTransitionPhase(self, "fadeout", skipFade and 0 or 1.2, {
@@ -240,6 +243,7 @@ function Game:openShop()
         Shop:start(self.floor)
         self.shopCloseRequested = nil
         startTransitionPhase(self, "shop", 0)
+        Audio:playSound("shop_open")
 end
 
 function Game:startFloorIntro(duration, extra)
@@ -256,6 +260,7 @@ function Game:startFloorIntro(duration, extra)
         end
 
         startTransitionPhase(self, "floorintro", duration or 3.5, extra)
+        Audio:playSound("floor_intro")
 end
 
 function Game:startFadeIn(duration)

--- a/shop.lua
+++ b/shop.lua
@@ -1,5 +1,6 @@
 local UI = require("ui")
 local Upgrades = require("upgrades")
+local Audio = require("audio")
 
 local Shop = {}
 
@@ -738,6 +739,7 @@ function Shop:pick(i)
     if state then
         state.selectionFlash = 0
     end
+    Audio:playSound("shop_purchase")
     return true
 end
 


### PR DESCRIPTION
## Summary
- add cached audio sources for exit, death, floor transition, and shop events and document suggested sound design notes
- trigger the new cues when the snake dies, the exit spawns, floors advance, and the shop opens or confirms a purchase

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8425c3b64832f8ac2c346a772839a