### PR TITLE
Ensure occupancy grid drives spawn safety

### DIFF
--- a/fruit.lua
+++ b/fruit.lua
@@ -156,8 +156,8 @@ local function aabb(x1,y1,w1,h1, x2,y2,w2,h2)
            y1 < y2 + h2 and y1 + h1 > y2
 end
 
-function Fruit:spawn(trail, rocks)
-    local cx, cy, col, row = SnakeUtils.getSafeSpawn(trail, self, rocks)
+function Fruit:spawn(trail, rocks, safeZone)
+    local cx, cy, col, row = SnakeUtils.getSafeSpawn(trail, self, rocks, safeZone)
     if not cx then
         col, row = Arena:getRandomTile()
         cx, cy = Arena:getCenterOfTile(col, row)

--- a/fruitevents.lua
+++ b/fruitevents.lua
@@ -271,15 +271,17 @@ function FruitEvents.handleConsumption(x, y)
         SnakeUtils.setOccupied(col, row, false)
     end
 
+    local safeZone = Snake:getSafeZone(3)
+
     if name == "Dragonfruit" then
         PlayerStats:add("totalDragonfruitEaten", 1)
         Achievements:unlock("dragonHunter")
     end
 
-    Fruit:spawn(Snake:getSegments(), Rocks)
+    Fruit:spawn(Snake:getSegments(), Rocks, safeZone)
 
     if love.math.random() < Rocks:getSpawnChance() then
-        local fx, fy, tileCol, tileRow = SnakeUtils.getSafeSpawn(Snake:getSegments(), Fruit, Rocks)
+        local fx, fy, tileCol, tileRow = SnakeUtils.getSafeSpawn(Snake:getSegments(), Fruit, Rocks, safeZone)
         if fx then
             Rocks:spawn(fx, fy, "small")
             SnakeUtils.setOccupied(tileCol, tileRow, true)

--- a/gameutils.lua
+++ b/gameutils.lua
@@ -26,7 +26,7 @@ function GameUtils:prepareGame(sw, sh)
 
         --SnakeUtils.initOccupancy()
 
-        Fruit:spawn(Snake:getSegments(), Rocks)
+        Fruit:spawn(Snake:getSegments(), Rocks, Snake:getSafeZone(3))
 end
 
 return GameUtils


### PR DESCRIPTION
## Summary
- add occupancy helpers to centralize grid reservations and track validation
- reserve the snake's starting safe zone when constructing a floor and block saw placement that conflicts with occupied cells
- reuse the safe zone for fruit and rock spawns so the middle of new floors stays clear

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d8537f2818832fb18afcb5a8de6389