### PR TITLE
Add UI and gameplay audio feedback

### DIFF
--- a/audio.lua
+++ b/audio.lua
@@ -21,6 +21,11 @@ function Audio:load()
     self.sounds.floor_intro = love.audio.newSource("Assets/Sounds/Retro Event Acute 08.wav", "static")
     self.sounds.shop_open = love.audio.newSource("Assets/Sounds/apple.wav", "static")
     self.sounds.shop_purchase = love.audio.newSource("Assets/Sounds/abs-confirm-1.wav", "static")
+    self.sounds.shop_focus = love.audio.newSource("Assets/Sounds/harp strum 1.wav", "static")
+    self.sounds.goal_reached = love.audio.newSource("Assets/Sounds/power_up.wav", "static")
+    self.sounds.combo_increase = love.audio.newSource("Assets/Sounds/harp strum 3.wav", "static")
+    self.sounds.combo_break = love.audio.newSource("Assets/Sounds/impact2.ogg", "static")
+    self.sounds.jackpot = love.audio.newSource("Assets/Sounds/Coin Slid Along Wood.wav", "static")
 
     -- Music Tracks
     self.musicTracks.menu = love.audio.newSource("Assets/Music/Menu2.ogg", "stream")
@@ -42,6 +47,11 @@ Audio.soundDesignNotes = {
     floor_intro = "Soft swell or drum hit that sets the tone for the new floor intro card.",
     shop_open = "Friendly bell or door chime that implies entering the shop.",
     shop_purchase = "Satisfied confirmation click confirming an upgrade purchase.",
+    shop_focus = "Gentle flourish as the cursor glides over a relic choice.",
+    goal_reached = "Triumphant swell to celebrate filling the fruit goal.",
+    combo_increase = "Short melodic lift that grows as the combo builds.",
+    combo_break = "Snappy thunk signalling a lost streak.",
+    jackpot = "Burst of coins emphasizing a jackpot reward.",
 }
 
 function Audio:applyVolumes()

--- a/fruitevents.lua
+++ b/fruitevents.lua
@@ -318,6 +318,7 @@ function FruitEvents.handleConsumption(x, y)
             local reward = Score.getJackpotReward and Score:getJackpotReward() or 0
             if reward > 0 and Score.addBonus then
                 Score:addBonus(reward)
+                Audio:playSound("jackpot")
                 FloatingText:add("Jackpot +" .. tostring(reward), x, y - 28, {1, 0.85, 0.2, 1}, 1.2, 55)
                 Particles:spawnBurst(x, y, {
                     count = love.math.random(10, 14),

--- a/shop.lua
+++ b/shop.lua
@@ -45,6 +45,10 @@ end
 function Shop:setFocus(index)
     if not self.cards or not index then return end
     if index < 1 or index > #self.cards then return end
+    local previous = self.focusIndex
+    if previous ~= index then
+        Audio:playSound("shop_focus")
+    end
     self.focusIndex = index
     return self.cards[index]
 end

--- a/ui.lua
+++ b/ui.lua
@@ -124,6 +124,11 @@ function UI.drawButton(id)
         hovered = true
     end
 
+    if hovered and not btn.wasHovered then
+        Audio:playSound("hover")
+    end
+    btn.wasHovered = hovered
+
     -- Animate press depth
     local target = (btn.pressed and 1 or 0)
     btn.anim = btn.anim + (target - btn.anim) * 0.25
@@ -359,7 +364,7 @@ end
 function UI:celebrateGoal()
     self.goalReachedAnim = 0
     self.goalCelebrated = true
-    --Audio:playSound("goal_reached") -- placeholder sound
+    Audio:playSound("goal_reached")
 end
 
 function UI:update(dt)
@@ -443,6 +448,7 @@ function UI:setCombo(count, timer, duration)
     if combo.count >= 2 then
         if combo.count > previous then
             combo.pop = 1.0
+            Audio:playSound("combo_increase")
         end
 
         if combo.count >= 6 then
@@ -459,6 +465,7 @@ function UI:setCombo(count, timer, duration)
     else
         if previous >= 2 then
             combo.pop = 0
+            Audio:playSound("combo_break")
         end
         combo.tagline = nil
     end


### PR DESCRIPTION
## Summary
- load additional sound effects for combo streaks, jackpots, goals, and shop focus cues
- trigger hover, combo, goal, jackpot, and shop focus sounds throughout the UI and gameplay flow

## Testing
- not run (audio changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d8969fbc10832f8ac9c10817a4cfbb