### PR TITLE
Shorten menu fade transitions

### DIFF
--- a/achievementsmenu.lua
+++ b/achievementsmenu.lua
@@ -9,7 +9,9 @@ local drawSnake = require("snakedraw")
 local SnakeUtils = require("snakeutils")
 local Face = require("face")
 
-local AchievementsMenu = {}
+local AchievementsMenu = {
+    transitionDuration = 0.45,
+}
 
 local buttonList = ButtonList.new()
 local iconCache = {}

--- a/menu.lua
+++ b/menu.lua
@@ -7,7 +7,9 @@ local Face = require("face")
 local ButtonList = require("buttonlist")
 local Localization = require("localization")
 
-local Menu = {}
+local Menu = {
+    transitionDuration = 0.45,
+}
 
 local buttonList = ButtonList.new()
 local buttons = {}

--- a/modeselect.lua
+++ b/modeselect.lua
@@ -7,7 +7,9 @@ local Theme = require("theme")
 local ButtonList = require("buttonlist")
 local Localization = require("localization")
 
-local ModeSelect = {}
+local ModeSelect = {
+    transitionDuration = 0.45,
+}
 
 local buttonList = ButtonList.new()
 

--- a/settingsscreen.lua
+++ b/settingsscreen.lua
@@ -5,7 +5,9 @@ local Theme = require("theme")
 local Settings = require("settings")
 local Localization = require("localization")
 
-local SettingsScreen = {}
+local SettingsScreen = {
+    transitionDuration = 0.45,
+}
 
 local options = {
     { type = "action", labelKey = "settings.toggle_fullscreen", action = function()


### PR DESCRIPTION
## Summary
- allow game states to override transition durations so screens can opt into faster fades
- shorten fades for menu, mode select, achievements, and settings states to 0.45s for snappier navigation

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d8bd5e85c4832fa3e89358bbc57815