### PR TITLE
Reduce Circuit Breaker saw stall duration

### DIFF
--- a/upgrades.lua
+++ b/upgrades.lua
@@ -764,10 +764,10 @@ local pool = {
     register({
         id = "circuit_breaker",
         name = "Circuit Breaker",
-        desc = "Saw tracks freeze for 2s after each fruit.",
+        desc = "Saw tracks freeze for 1s after each fruit.",
         rarity = "uncommon",
         onAcquire = function(state)
-            state.effects.sawStall = (state.effects.sawStall or 0) + 2
+            state.effects.sawStall = (state.effects.sawStall or 0) + 1
         end,
     }),
     register({


### PR DESCRIPTION
## Summary
- lower the Circuit Breaker upgrade's stall bonus from 2 seconds to 1 second
- update the upgrade description to reflect the new duration

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8d37efa68832f9e64fdc54355af14