### PR TITLE
Remove fruit jackpot system

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -232,10 +232,6 @@ local english = {
                 title = "Crash-Test Maestro",
                 description = "In one run, shrug off a wall, rock, and saw with crash shields.",
             },
-            jackpotSpark = {
-                title = "Lucky Spark",
-                description = "Trigger a fruit jackpot payout.",
-            },
             dragonHunter = {
                 title = "Dragon Hunter",
                 description = "Collect the legendary Dragonfruit",

--- a/achievement_definitions.lua
+++ b/achievement_definitions.lua
@@ -308,17 +308,6 @@ local definitions = {
         end,
     },
     {
-        id = "jackpotSpark",
-        titleKey = "achievements_definitions.jackpotSpark.title",
-        descriptionKey = "achievements_definitions.jackpotSpark.description",
-        icon = "Apple",
-        goal = 1,
-        stat = "jackpotsTriggered",
-        category = "skill",
-        categoryOrder = 2,
-        order = 90,
-    },
-    {
         id = "dragonHunter",
         titleKey = "achievements_definitions.dragonHunter.title",
         descriptionKey = "achievements_definitions.dragonHunter.description",

--- a/achievements.lua
+++ b/achievements.lua
@@ -124,7 +124,6 @@ function Achievements:_ensureInitialized()
                 shieldWallBounces = PlayerStats:get("shieldWallBounces") or 0,
                 shieldRockBreaks = PlayerStats:get("shieldRockBreaks") or 0,
                 shieldSawParries = PlayerStats:get("shieldSawParries") or 0,
-                jackpotsTriggered = PlayerStats:get("jackpotsTriggered") or 0,
             }
         end)
 
@@ -137,7 +136,6 @@ function Achievements:_ensureInitialized()
                 runShieldWallBounces = SessionStats:get("runShieldWallBounces") or 0,
                 runShieldRockBreaks = SessionStats:get("runShieldRockBreaks") or 0,
                 runShieldSawParries = SessionStats:get("runShieldSawParries") or 0,
-                runJackpotsTriggered = SessionStats:get("runJackpotsTriggered") or 0,
             }
         end)
 

--- a/debug.lua
+++ b/debug.lua
@@ -199,7 +199,6 @@ function Debug:collectData()
             string.format("Game mode: %s", GameModes:getCurrentName() or "(none)"),
             string.format("Score: %d", Score:get() or 0),
             string.format("High score: %d", Score:getHigh() or 0),
-            string.format("Jackpot chance: %.2f", Score.jackpotChance or 0),
             string.format("Player stats: %d entries", countTableEntries(PlayerStats.data)),
             string.format("UI buttons: %d", countTableEntries(UI.buttons)),
         }

--- a/debugoverlay.lua
+++ b/debugoverlay.lua
@@ -209,7 +209,6 @@ function DebugOverlay:collectData()
             string.format("Game mode: %s", GameModes:getCurrentName() or "(none)"),
             string.format("Score: %d", Score:get() or 0),
             string.format("High score: %d", Score:getHigh() or 0),
-            string.format("Jackpot chance: %.2f", Score.jackpotChance or 0),
             string.format("Player stats: %d entries", countTableEntries(PlayerStats.data)),
             string.format("UI buttons: %d", countTableEntries(UI.buttons)),
         }

--- a/fruitevents.lua
+++ b/fruitevents.lua
@@ -284,28 +284,6 @@ function FruitEvents.handleConsumption(x, y)
         combo = comboState.count or 0,
     })
 
-    local jackpotChance = Score.getJackpotChance and Score:getJackpotChance() or 0
-    if jackpotChance > 0 then
-        if love.math.random() < jackpotChance then
-            local reward = Score.getJackpotReward and Score:getJackpotReward() or 0
-            if reward > 0 and Score.addBonus then
-                Score:addBonus(reward)
-                FloatingText:add("Jackpot +" .. tostring(reward), x, y - 28, {1, 0.85, 0.2, 1}, 1.2, 55)
-                Particles:spawnBurst(x, y, {
-                    count = love.math.random(10, 14),
-                    speed = 80,
-                    life = 0.5,
-                    size = 4,
-                    color = {1, 0.9, 0.4, 1},
-                    spread = math.pi * 2,
-                })
-                SessionStats:add("runJackpotsTriggered", 1)
-                PlayerStats:add("jackpotsTriggered", 1)
-                Achievements:check("jackpotSpark")
-            end
-        end
-    end
-
     local state = {
         snakeScore = Score:get(),
         snakeApplesEaten = Score:get(),

--- a/score.lua
+++ b/score.lua
@@ -14,8 +14,6 @@ Score.current = 0
 Score.highscores = {}
 Score.saveFile = "scores.lua"
 Score.fruitBonus = 0
-Score.jackpotChance = 0
-Score.jackpotReward = 0
 Score.comboBonusMult = 1
 Score.comboBonusBase = 1
 Score.highScoreGlowDuration = 4
@@ -34,8 +32,6 @@ end
 function Score:load()
         self.current = 0
         self.highscores = {}
-        self.jackpotChance = 0
-        self.jackpotReward = 0
         self.comboBonusBase = 1
         self.comboBonusMult = 1
         self.highScoreGlowTimer = 0
@@ -84,8 +80,6 @@ function Score:reset(mode)
         -- Just reset the current score
         self.current = 0
         self.fruitBonus = 0
-        self.jackpotChance = 0
-        self.jackpotReward = 0
         self.comboBonusBase = 1
         self.comboBonusMult = 1
         self.highScoreGlowTimer = 0
@@ -148,15 +142,6 @@ function Score:addBonus(points)
         end
 end
 
-function Score:addJackpotChance(chance, reward)
-        if chance and chance > 0 then
-                self.jackpotChance = math.min(1, (self.jackpotChance or 0) + chance)
-        end
-        if reward and reward > 0 then
-                self.jackpotReward = (self.jackpotReward or 0) + reward
-        end
-end
-
 local function updateComboBonusValue(self)
         local base = self.comboBonusBase or 1
         if base < 0 then base = 0 end
@@ -188,14 +173,6 @@ function Score:getHighScoreGlowStrength()
 
         local normalized = self.highScoreGlowTimer / self.highScoreGlowDuration
         return math.max(0, math.min(1, normalized))
-end
-
-function Score:getJackpotChance()
-        return self.jackpotChance or 0
-end
-
-function Score:getJackpotReward()
-        return self.jackpotReward or 0
 end
 
 function Score:handleGameOver(cause)

--- a/upgrades.lua
+++ b/upgrades.lua
@@ -771,20 +771,6 @@ local pool = {
         end,
     }),
     register({
-        id = "gem_maw",
-        name = "Gem Maw",
-        desc = "Fruits have a 12% chance to erupt into +5 bonus score.",
-        rarity = "common",
-        onAcquire = function(state)
-            if Score.addJackpotChance then
-                Score:addJackpotChance(0.12, 5)
-            else
-                Score.jackpotChance = math.min(1, (Score.jackpotChance or 0) + 0.12)
-                Score.jackpotReward = (Score.jackpotReward or 0) + 5
-            end
-        end,
-    }),
-    register({
         id = "stonebreaker_hymn",
         name = "Stonebreaker Hymn",
         desc = "Every other fruit shatters the nearest rock. Stacks to every fruit.",


### PR DESCRIPTION
## Summary
- remove jackpot chance/reward fields and payout logic from scoring and fruit events
- clean up achievements, localization, debug overlays, and upgrades tied to the jackpot feature

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d95ae02ef4832fb25132082a4ceacd