### PR TITLE
Stop spawning fruit after exit opens

### DIFF
--- a/arena.lua
+++ b/arena.lua
@@ -300,6 +300,10 @@ function Arena:getExitCenter()
     return self.exit.x, self.exit.y, r
 end
 
+function Arena:hasExit()
+    return self.exit ~= nil
+end
+
 function Arena:update(dt)
     if self.exit and self.exit.anim < 1 then
         self.exit.anim = math.min(1, self.exit.anim + dt / self.exit.animTime)

--- a/fruit.lua
+++ b/fruit.lua
@@ -226,6 +226,7 @@ end
 
 function Fruit:checkCollisionWith(x, y, trail, rocks)
     if fading then return false end
+    if active.phase == "inactive" then return false end
 
     local half = HITBOX_SIZE / 2
     if aabb(x - half, y - half, HITBOX_SIZE, HITBOX_SIZE,
@@ -241,12 +242,16 @@ function Fruit:checkCollisionWith(x, y, trail, rocks)
             type = active.type
         }
         fadeTimer = 0
+        active.phase = "inactive"
+        active.alpha = 0
         return true
     end
     return false
 end
 
 local function drawFruit(f)
+    if f.phase == "inactive" then return end
+
     local x, y = f.x, f.y + (f.offsetY or 0)
     local alpha = f.alpha or 1
     local sx, sy = f.scaleX or 1, f.scaleY or 1

--- a/fruitevents.lua
+++ b/fruitevents.lua
@@ -7,6 +7,7 @@ local PlayerStats = require("playerstats")
 local SessionStats = require("sessionstats")
 local Rocks = require("rocks")
 local Saws = require("saws")
+local Arena = require("arena")
 local SnakeUtils = require("snakeutils")
 local UI = require("ui")
 local FloatingText = require("floatingtext")
@@ -251,7 +252,14 @@ function FruitEvents.handleConsumption(x, y)
         Achievements:unlock("dragonHunter")
     end
 
-    Fruit:spawn(Snake:getSegments(), Rocks, safeZone)
+    UI:triggerScorePulse()
+    UI:addFruit(fruitType)
+    local goalReached = UI:isGoalReached()
+
+    local exitAlreadyOpen = Arena and Arena.hasExit and Arena:hasExit()
+    if not exitAlreadyOpen and not goalReached then
+        Fruit:spawn(Snake:getSegments(), Rocks, safeZone)
+    end
 
     if love.math.random() < Rocks:getSpawnChance() then
         local fx, fy, tileCol, tileRow = SnakeUtils.getSafeSpawn(Snake:getSegments(), Fruit, Rocks, safeZone)
@@ -261,8 +269,6 @@ function FruitEvents.handleConsumption(x, y)
         end
     end
 
-    UI:triggerScorePulse()
-    UI:addFruit(fruitType)
     Saws:onFruitCollected()
     if Rocks.onFruitCollected then
         Rocks:onFruitCollected(x, y)


### PR DESCRIPTION
## Summary
- add an Arena:hasExit helper so systems can check whether an exit is active
- mark collected fruit as inactive to avoid redraws or repeated collision checks when none should respawn
- stop respawning fruit once the floor goal has been reached and the exit is (or will be) open

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d9fb7ee324832f8b0ec4b5b63640a9