### PR TITLE
Add Zephyr Coils upgrade and adjust Phoenix Echo effect

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -379,7 +379,11 @@ local english = {
             },
             phoenix_echo = {
                 name = "Phoenix Echo",
-                description = "Once per run, a fatal crash rewinds without resetting the floor, but you gain +1 extra growth.",
+                description = "Once per run, a fatal crash rewinds without resetting the floor.",
+            },
+            zephyr_coils = {
+                name = "Zephyr Coils",
+                description = "Rare: Snake speed +20% but you gain +1 extra growth.",
             },
             event_horizon = {
                 name = "Event Horizon",

--- a/upgrades.lua
+++ b/upgrades.lua
@@ -1316,6 +1316,16 @@ local pool = {
         tags = {"defense", "risk"},
         onAcquire = function(state)
             state.counters.phoenixEchoCharges = (state.counters.phoenixEchoCharges or 0) + 1
+        end,
+    }),
+    register({
+        id = "zephyr_coils",
+        nameKey = "upgrades.zephyr_coils.name",
+        descKey = "upgrades.zephyr_coils.description",
+        rarity = "rare",
+        tags = {"mobility", "risk"},
+        onAcquire = function(state)
+            Snake:addSpeedMultiplier(1.2)
             Snake.extraGrowth = (Snake.extraGrowth or 0) + 1
         end,
     }),


### PR DESCRIPTION
## Summary
- remove the extra growth penalty from Phoenix Echo so it only grants a rewind charge
- introduce the rare Zephyr Coils upgrade that boosts snake speed while adding extra growth
- update English localization text to cover the new upgrade and revised Phoenix Echo description

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da0feefcf4832f93b21710d4e8c75e