### PR TITLE
Remove numeric selection hint from shop UI

### DIFF
--- a/shop.lua
+++ b/shop.lua
@@ -674,7 +674,7 @@ function Shop:draw(screenW, screenH)
     local keyHint
     local choices = #self.cards
     if choices > 0 then
-        keyHint = string.format("Press 1-%d or use arrows + Enter to claim a relic", choices)
+        keyHint = "Use arrows + Enter to claim a relic"
     else
         keyHint = "No relics available"
     end


### PR DESCRIPTION
## Summary
- update the shop hint text to stop referencing number-key selection

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da1b18e308832f82de6e0d14ed69a3