### PR TITLE
Add temporal anchor upgrade with time slow ability

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -386,6 +386,11 @@ local english = {
                 description = "Press Space to dash forward, smashing through rocks while briefly speeding up.",
                 activation_text = "Thunder Dash!",
             },
+            temporal_anchor = {
+                name = "Temporal Anchor",
+                description = "Press Shift to slow time for a short duration, reducing all movement to 35% speed.",
+                activation_text = "Time Slow!",
+            },
             zephyr_coils = {
                 name = "Zephyr Coils",
                 description = "Rare: Snake speed +20% but you gain +1 extra growth.",

--- a/controls.lua
+++ b/controls.lua
@@ -15,6 +15,8 @@ function Controls:keypressed(game, key)
         elseif key == "left" then Snake:setDirection("left")
         elseif key == "right" then Snake:setDirection("right")
         elseif key == "space" then Snake:activateDash()
+        elseif key == "lshift" or key == "rshift" then
+            Snake:activateTimeDilation()
         end
     end
 end

--- a/game.lua
+++ b/game.lua
@@ -849,30 +849,40 @@ function Game:update(dt)
         end
 
         PauseMenu:update(dt, false)
-        FruitEvents.update(dt)
+
+        local timeScale = 1
+        if Snake.getTimeScale then
+                local scale = Snake:getTimeScale()
+                if scale and scale > 0 then
+                        timeScale = scale
+                end
+        end
+        local scaledDt = dt * timeScale
+
+        FruitEvents.update(scaledDt)
 
         if self.state == "transition" then
-                self:updateTransition(dt)
+                self:updateTransition(scaledDt)
                 return
         end
 
         if self.state == "descending" then
-                self:updateDescending(dt)
+                self:updateDescending(scaledDt)
                 return
         end
 
         if self.mode and self.mode.update then
-                self.mode.update(self, dt)
+                self.mode.update(self, scaledDt)
         end
 
         if self.state == "playing" then
-                self:updateGameplay(dt)
+                self:updateGameplay(scaledDt)
         end
 
-        self:updateEntities(dt)
+        self:updateEntities(scaledDt)
         UI:setUpgradeIndicators(Upgrades:getHUDIndicators())
 
-        local result = self:handleDeath(dt)
+        local result = self:handleDeath(scaledDt)
         if result then
                 return result
         end

--- a/ui.lua
+++ b/ui.lua
@@ -779,6 +779,24 @@ local function drawIndicatorIcon(icon, accentColor, x, y, radius)
         love.graphics.setColor(outline[1], outline[2], outline[3], outline[4] or 1)
         love.graphics.setLineWidth(2)
         love.graphics.circle("line", 0, 0, radius * 0.95, 28)
+    elseif icon == "hourglass" then
+        local bowl = {
+            -radius * 0.7, -radius * 0.78,
+            radius * 0.7, -radius * 0.78,
+            radius * 0.32, -radius * 0.12,
+            radius * 0.32, radius * 0.12,
+            radius * 0.7, radius * 0.78,
+            -radius * 0.7, radius * 0.78,
+            -radius * 0.32, radius * 0.12,
+            -radius * 0.32, -radius * 0.12,
+        }
+        love.graphics.polygon("fill", bowl)
+        love.graphics.setColor(base[1], base[2], base[3], (base[4] or 1) * 0.6)
+        love.graphics.ellipse("fill", 0, -radius * 0.36, radius * 0.4, radius * 0.2, 28)
+        love.graphics.ellipse("fill", 0, radius * 0.36, radius * 0.4, radius * 0.2, 28)
+        love.graphics.setColor(detail[1], detail[2], detail[3], detail[4] or 1)
+        love.graphics.setLineWidth(2)
+        love.graphics.polygon("line", bowl)
     elseif icon == "phoenix" then
         local wing = {
             -radius * 0.88, radius * 0.16,


### PR DESCRIPTION
## Summary
- add a Temporal Anchor upgrade that unlocks a Shift-activated time dilation ability and celebratory effects
- scale gameplay updates with the snake's time dilation state and surface the cooldown in the HUD with a new hourglass icon
- localize the upgrade and bind the new ability to Shift controls

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da21a760d4832fbed76cd1e13c6d11