### PR TITLE
Remove selection hotkey labels from shop cards

### DIFF
--- a/shop.lua
+++ b/shop.lua
@@ -464,13 +464,6 @@ local function drawCard(card, x, y, w, h, hovered, index, _, isSelected, appeara
     local titleHeight = titleLineCount * titleFont:getHeight() * titleFont:getLineHeight()
     local contentTop = titleY + titleHeight
 
-    if index then
-        love.graphics.setFont(UI.fonts.small)
-        setColor(1, 1, 1, 0.65)
-        love.graphics.printf("[" .. tostring(index) .. "]", x + 18, y + 8, w - 36, "left")
-        setColor(1, 1, 1, 1)
-    end
-
     local descStart
     if card.rarityLabel then
         local rarityFont = UI.fonts.body


### PR DESCRIPTION
## Summary
- stop rendering numeric selection labels on shop upgrade cards so the hotkey hints no longer appear

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da2e926258832fba51b5e6c73601e1