### PR TITLE
Fix XP gain to use run apple count

### DIFF
--- a/score.lua
+++ b/score.lua
@@ -1,4 +1,5 @@
 local PlayerStats = require("playerstats")
+local SessionStats = require("sessionstats")
 local Achievements = require("achievements")
 local GameModes = require("gamemodes")
 local Score = {}
@@ -186,14 +187,17 @@ function Score:handleGameOver(cause)
     local mode = GameModes:getCurrentName()
     self:setHighScore(mode, self.current)
 
+    local runApples = SessionStats:get("applesEaten") or 0
+    local lifetimeApples = PlayerStats:get("totalApplesEaten") or 0
+
     return {
         score       = self.current,
         highScore   = self:getHighScore(mode),
-        apples      = PlayerStats:get("totalApplesEaten") or 0,
+        apples      = runApples,
         mode        = mode,
-        totalApples = PlayerStats:get("totalApplesEaten") or 0,
+        totalApples = lifetimeApples,
         stats = {
-            apples = PlayerStats:get("totalApplesEaten") or 0
+            apples = runApples
         },
         cause = cause or "unknown",
         won = false,


### PR DESCRIPTION
## Summary
- ensure the game over payload reports apples eaten from the current run
- continue to expose lifetime apple totals separately for meta progression displays

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68da333c841c832f87721e341dc474bd