### PR TITLE
Guard Pocket Springs shield effect behind ownership check

### DIFF
--- a/upgrades.lua
+++ b/upgrades.lua
@@ -616,6 +616,10 @@ local pool = {
         end,
         handlers = {
             fruitCollected = function(data, state)
+                if not state or not state.takenSet or (state.takenSet.pocket_springs or 0) <= 0 then
+                    return
+                end
+
                 state.counters.pocketSprings = (state.counters.pocketSprings or 0) + 1
                 if state.counters.pocketSprings >= 8 then
                     state.counters.pocketSprings = state.counters.pocketSprings - 8


### PR DESCRIPTION
## Summary
- ensure the Pocket Springs fruit handler only runs when the upgrade is actually owned to stop unintended shield generation

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dab2377330832f80744b4bbf1e292a