### PR TITLE
Increase shop claim message font size

### DIFF
--- a/shop.lua
+++ b/shop.lua
@@ -667,7 +667,7 @@ function Shop:draw(screenW, screenH)
     end
 
     if self.selected then
-        love.graphics.setFont(UI.fonts.body)
+        love.graphics.setFont(UI.fonts.button)
         love.graphics.setColor(1, 0.88, 0.6, 0.9)
         love.graphics.printf(
             string.format("%s claimed", self.selected.name or "Relic"),


### PR DESCRIPTION
## Summary
- increase the font size of the "claimed" message shown after picking a shop item by switching to the button font

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dab5711224832f8a6cc932a6769a26