### PR TITLE
Make Stone Whisperer a common upgrade

### DIFF
--- a/upgrades.lua
+++ b/upgrades.lua
@@ -588,7 +588,7 @@ local pool = {
         id = "stone_whisperer",
         nameKey = "upgrades.stone_whisperer.name",
         descKey = "upgrades.stone_whisperer.description",
-        rarity = "rare",
+        rarity = "common",
         onAcquire = function(state)
             state.effects.rockSpawnMult = (state.effects.rockSpawnMult or 1) * 0.6
         end,


### PR DESCRIPTION
## Summary
- change the Stone Whisperer upgrade rarity to common so it appears more frequently

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dab625b160832f8f82ae611b9221d9