### PR TITLE
Refine game over flow with dedicated progression view

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -86,6 +86,7 @@ local english = {
             no_achievements = "No achievements unlocked this run.",
             tip_prefix = "Tip: ${tip}",
             play_again = "Play Again",
+            view_run_summary = "Continue",
             quit_to_menu = "Quit to Menu",
             meta_progress_title = "Meta Progression",
             meta_progress_gain = "Banked ${points} meta XP from ${fruit} fruit.",


### PR DESCRIPTION
## Summary
- split the game over experience into a dedicated progression phase followed by the run summary
- add layout helpers to position buttons and reuse panels for the progression view
- expose a localized Continue label for the progression-to-summary transition button

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dabe8fa0b8832fb123dfcbc673d5a6