### PR TITLE
Adjust Stonebreaker Hymn balance

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -296,7 +296,7 @@ local english = {
             },
             stonebreaker_hymn = {
                 name = "Stonebreaker Hymn",
-                description = "Every other fruit shatters the nearest rock. Additional copies advance it until every fruit shatters the nearest rock.",
+                description = "Every fourth fruit shatters the nearest rock. Additional copies advance it until every fruit shatters the nearest rock.",
             },
             echo_aegis = {
                 name = "Echo Aegis",

--- a/upgrades.lua
+++ b/upgrades.lua
@@ -821,7 +821,7 @@ local pool = {
         allowDuplicates = true,
         maxStacks = 2,
         onAcquire = function(state)
-            state.effects.rockShatter = (state.effects.rockShatter or 0) + 0.5
+            state.effects.rockShatter = (state.effects.rockShatter or 0) + 0.25
             state.counters.stonebreakerStacks = (state.counters.stonebreakerStacks or 0) + 1
             if Snake.setStonebreakerStacks then
                 Snake:setStonebreakerStacks(state.counters.stonebreakerStacks)
@@ -1892,7 +1892,7 @@ function Upgrades:applyPersistentEffects(rebaseline)
             stacks = state.counters.stonebreakerStacks or 0
         end
         if stacks <= 0 and effects.rockShatter then
-            local perStack = 0.5
+            local perStack = 0.25
             stacks = math.floor(((effects.rockShatter or 0) / perStack) + 0.5)
         end
         Snake:setStonebreakerStacks(stacks)


### PR DESCRIPTION
## Summary
- reduce the Stonebreaker Hymn rock shatter effect so it now triggers every fourth fruit, allowing more room for stacking bonuses
- update the English description to match the new cadence

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daca65fb9c832fb0be88b2a24632be