### PR TITLE
Adjust default shop card slots

### DIFF
--- a/metaprogression.lua
+++ b/metaprogression.lua
@@ -31,7 +31,7 @@ local unlockDefinitions = {
     [2] = {
         id = "shop_expansion_1",
         name = "Shop Expansion I",
-        description = "Adds a fourth upgrade card to every visit.",
+        description = "Adds a third upgrade card to every visit.",
         effects = {
             shopExtraChoices = 1,
         },

--- a/shop.lua
+++ b/shop.lua
@@ -19,17 +19,26 @@ function Shop:refreshCards(options)
     local initialDelay = options.initialDelay or 0
 
     self.restocking = nil
-    local extraChoices = 0
+    local baseChoices = 2
+    local upgradeBonus = 0
     if Upgrades.getEffect then
-        extraChoices = math.max(0, math.floor(Upgrades:getEffect("shopSlots") or 0))
+        upgradeBonus = math.max(0, math.floor(Upgrades:getEffect("shopSlots") or 0))
     end
+
+    local metaBonus = 0
     if MetaProgression and MetaProgression.getShopBonusSlots then
-        extraChoices = extraChoices + math.max(0, MetaProgression:getShopBonusSlots() or 0)
+        metaBonus = math.max(0, MetaProgression:getShopBonusSlots() or 0)
     end
-    extraChoices = math.min(extraChoices, 2)
+
+    local extraChoices = upgradeBonus + metaBonus
+
+    self.baseChoices = baseChoices
+    self.upgradeBonusChoices = upgradeBonus
+    self.metaBonusChoices = metaBonus
     self.extraChoices = extraChoices
 
-    local cardCount = 3 + extraChoices
+    local cardCount = baseChoices + extraChoices
+    self.totalChoices = cardCount
     self.cards = Upgrades:getRandom(cardCount, { floor = self.floor }) or {}
     self.cardStates = {}
     self.selected = nil


### PR DESCRIPTION
## Summary
- start the shop with two base upgrade card choices and track bonus slots from upgrades and meta progression separately
- ensure the total shop card count remains dynamic as additional slots are earned
- update the Shop Expansion I description to reflect the revised third card unlock

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dadc073f90832f9645189895585b53