### PR TITLE
Add consistent highlights to major game elements

### DIFF
--- a/fruit.lua
+++ b/fruit.lua
@@ -95,6 +95,15 @@ local FADE_DURATION   = 0.20
 local SHADOW_OFFSET = 3
 local OUTLINE_SIZE = 3
 
+local function getHighlightColor(color)
+    color = color or {1, 1, 1, 1}
+    local r = math.min(1, color[1] * 1.2 + 0.08)
+    local g = math.min(1, color[2] * 1.2 + 0.08)
+    local b = math.min(1, color[3] * 1.2 + 0.08)
+    local a = (color[4] or 1) * 0.75
+    return {r, g, b, a}
+end
+
 -- State
 local active = {
     x = 0, y = 0,
@@ -265,6 +274,19 @@ local function drawFruit(f)
     -- fruit body
     love.graphics.setColor(f.type.color[1], f.type.color[2], f.type.color[3], alpha)
     love.graphics.ellipse("fill", x, y, r * sx, r * sy)
+
+    -- highlight
+    local highlight = getHighlightColor(f.type.color)
+    local hx = x - r * sx * 0.3
+    local hy = y - r * sy * 0.35
+    local hrx = r * sx * 0.55
+    local hry = r * sy * 0.45
+    love.graphics.push()
+    love.graphics.translate(hx, hy)
+    love.graphics.rotate(-0.35)
+    love.graphics.setColor(highlight[1], highlight[2], highlight[3], (highlight[4] or 1) * alpha)
+    love.graphics.ellipse("fill", 0, 0, hrx, hry)
+    love.graphics.pop()
 
     -- outline (2–3px black border)
     love.graphics.setLineWidth(OUTLINE_SIZE)

--- a/rocks.lua
+++ b/rocks.lua
@@ -35,6 +35,32 @@ local function generateRockShape(size, seed)
     return points
 end
 
+local function getHighlightColor(color)
+    color = color or {1, 1, 1, 1}
+    local r = math.min(1, color[1] * 1.2 + 0.08)
+    local g = math.min(1, color[2] * 1.2 + 0.08)
+    local b = math.min(1, color[3] * 1.2 + 0.08)
+    local a = (color[4] or 1) * 0.75
+    return {r, g, b, a}
+end
+
+local function buildRockHighlight(points)
+    if not points then return nil end
+
+    local highlight = {}
+    local scaleX, scaleY = 0.78, 0.66
+    local offsetX, offsetY = -ROCK_SIZE * 0.12, -ROCK_SIZE * 0.18
+
+    for i = 1, #points, 2 do
+        local x = points[i] * scaleX + offsetX
+        local y = points[i + 1] * scaleY + offsetY
+        highlight[#highlight + 1] = x
+        highlight[#highlight + 1] = y
+    end
+
+    return highlight
+end
+
 function Rocks:spawn(x, y)
     local col, row = Arena:getTileFromWorld(x, y)
     table.insert(current, {
@@ -47,10 +73,13 @@ function Rocks:spawn(x, y)
         scaleX = 1,
         scaleY = 0,
         offsetY = -40,
-        shape = generateRockShape(ROCK_SIZE, love.math.random(1, 999999)),
+        shape = nil,
         col = col,
         row = row,
     })
+    local rock = current[#current]
+    rock.shape = generateRockShape(ROCK_SIZE, love.math.random(1, 999999))
+    rock.highlightShape = buildRockHighlight(rock.shape)
 end
 
 function Rocks:getAll()
@@ -252,6 +281,13 @@ function Rocks:draw()
         -- main rock fill
         love.graphics.setColor(Theme.rock)
         love.graphics.polygon("fill", rock.shape)
+
+        -- highlight
+        if rock.highlightShape then
+            local highlight = getHighlightColor(Theme.rock)
+            love.graphics.setColor(highlight[1], highlight[2], highlight[3], highlight[4])
+            love.graphics.polygon("fill", rock.highlightShape)
+        end
 
         -- outline
         love.graphics.setColor(0, 0, 0, 1)

--- a/saws.lua
+++ b/saws.lua
@@ -16,6 +16,15 @@ local SINK_OFFSET = 2
 local SINK_DISTANCE = 28
 local SINK_SPEED = 3
 
+local function getHighlightColor(color)
+    color = color or {1, 1, 1, 1}
+    local r = math.min(1, color[1] * 1.2 + 0.08)
+    local g = math.min(1, color[2] * 1.2 + 0.08)
+    local b = math.min(1, color[3] * 1.2 + 0.08)
+    local a = (color[4] or 1) * 0.7
+    return {r, g, b, a}
+end
+
 -- modifiers
 Saws.speedMult = 1.0
 Saws.spinMult = 1.0
@@ -324,6 +333,16 @@ function Saws:draw()
         -- Fill
         love.graphics.setColor(Theme.sawColor)
         love.graphics.polygon("fill", points)
+
+        -- highlight
+        local highlight = getHighlightColor(Theme.sawColor)
+        love.graphics.setColor(highlight[1], highlight[2], highlight[3], highlight[4])
+        love.graphics.push()
+        love.graphics.translate(-outer * 0.22, -outer * 0.18)
+        love.graphics.rotate(-0.3)
+        love.graphics.scale(0.7, 0.5)
+        love.graphics.circle("fill", 0, 0, outer)
+        love.graphics.pop()
 
         -- Outline
         love.graphics.setColor(0, 0, 0, 1)

--- a/snakedraw.lua
+++ b/snakedraw.lua
@@ -12,6 +12,15 @@ local FRUIT_BULGE_SCALE = 1.25
 -- colors (body color reused for patches so they blend)
 local BODY_R, BODY_G, BODY_B = Theme.snakeDefault
 
+local function makeHighlightColor(r, g, b)
+  return math.min(1, r * 1.2 + 0.08),
+         math.min(1, g * 1.2 + 0.08),
+         math.min(1, b * 1.2 + 0.08)
+end
+
+local HIGHLIGHT_R, HIGHLIGHT_G, HIGHLIGHT_B = makeHighlightColor(BODY_R, BODY_G, BODY_B)
+local HIGHLIGHT_ALPHA = 0.75
+
 -- Canvas for single-pass shadow
 local snakeCanvas = nil
 
@@ -109,6 +118,17 @@ local function renderSnakeToCanvas(trail, coords, head, tail, half, thickness)
         love.graphics.setColor(BODY_R, BODY_G, BODY_B)
         drawCornerPlugs(trail, half)
         drawFruitBulges(trail, head, bulgeRadius)
+
+        -- highlight sheen
+        love.graphics.push()
+        love.graphics.translate(0, -math.max(2, thickness * 0.22))
+        love.graphics.setColor(HIGHLIGHT_R, HIGHLIGHT_G, HIGHLIGHT_B, HIGHLIGHT_ALPHA)
+        love.graphics.setLineWidth(math.max(2, thickness * 0.35))
+        drawPolyline(coords)
+        drawEndcaps(head, tail, half * 0.55)
+        drawCornerPlugs(trail, half * 0.55)
+        drawFruitBulges(trail, head, bulgeRadius * 0.55)
+        love.graphics.pop()
 end
 
 local function drawSoftGlow(x, y, radius, r, g, b, a)


### PR DESCRIPTION
## Summary
- add reusable highlight color helpers for rocks, fruit, saws, and the snake
- draw subtle highlight geometry on rocks, fruit, saw blades, and the snake body to match conveyor rollers

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68dae0911b58832fb04ae94c615423d2