### PR TITLE
Fix snake color unpacking

### DIFF
--- a/snakedraw.lua
+++ b/snakedraw.lua
@@ -10,7 +10,7 @@ local OUTLINE_SIZE   = 6
 local FRUIT_BULGE_SCALE = 1.25
 
 -- colors (body color reused for patches so they blend)
-local BODY_R, BODY_G, BODY_B = Theme.snakeDefault
+local BODY_R, BODY_G, BODY_B = unpack(Theme.snakeDefault)
 
 local function makeHighlightColor(r, g, b)
   return math.min(1, r * 1.2 + 0.08),


### PR DESCRIPTION
## Summary
- unpack the snake default color table before using its components for drawing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dae46c9760832f9522b16b94498387