### PR TITLE
Adjust highlights for rocks and snake

### DIFF
--- a/rocks.lua
+++ b/rocks.lua
@@ -49,7 +49,7 @@ local function buildRockHighlight(points)
 
     local highlight = {}
     local scaleX, scaleY = 0.78, 0.66
-    local offsetX, offsetY = -ROCK_SIZE * 0.12, -ROCK_SIZE * 0.18
+    local offsetX, offsetY = -ROCK_SIZE * 0.12 + 2, -ROCK_SIZE * 0.18 + 2
 
     for i = 1, #points, 2 do
         local x = points[i] * scaleX + offsetX

--- a/snakedraw.lua
+++ b/snakedraw.lua
@@ -121,7 +121,8 @@ local function renderSnakeToCanvas(trail, coords, head, tail, half, thickness)
 
         -- highlight sheen
         love.graphics.push()
-        love.graphics.translate(0, -math.max(2, thickness * 0.22))
+        local highlightOffset = math.max(2, thickness * 0.22)
+        love.graphics.translate(-highlightOffset, -highlightOffset)
         love.graphics.setColor(HIGHLIGHT_R, HIGHLIGHT_G, HIGHLIGHT_B, HIGHLIGHT_ALPHA)
         love.graphics.setLineWidth(math.max(2, thickness * 0.35))
         drawPolyline(coords)


### PR DESCRIPTION
## Summary
- offset the generated rock highlight shape slightly to the right and downward
- translate the snake highlight sheen up and to the left so it stays on the top-left edge regardless of turning

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dae65cf880832fa29ac52a59f7bca8