### PR TITLE
Remove highlight sheen from snake rendering

### DIFF
--- a/snakedraw.lua
+++ b/snakedraw.lua
@@ -12,15 +12,6 @@ local FRUIT_BULGE_SCALE = 1.25
 -- colors (body color reused for patches so they blend)
 local BODY_R, BODY_G, BODY_B = unpack(Theme.snakeDefault)
 
-local function makeHighlightColor(r, g, b)
-  return math.min(1, r * 1.2 + 0.08),
-         math.min(1, g * 1.2 + 0.08),
-         math.min(1, b * 1.2 + 0.08)
-end
-
-local HIGHLIGHT_R, HIGHLIGHT_G, HIGHLIGHT_B = makeHighlightColor(BODY_R, BODY_G, BODY_B)
-local HIGHLIGHT_ALPHA = 0.75
-
 -- Canvas for single-pass shadow
 local snakeCanvas = nil
 
@@ -119,17 +110,6 @@ local function renderSnakeToCanvas(trail, coords, head, tail, half, thickness)
         drawCornerPlugs(trail, half)
         drawFruitBulges(trail, head, bulgeRadius)
 
-        -- highlight sheen
-        love.graphics.push()
-        local highlightOffset = math.max(2, thickness * 0.22)
-        love.graphics.translate(-highlightOffset, -highlightOffset)
-        love.graphics.setColor(HIGHLIGHT_R, HIGHLIGHT_G, HIGHLIGHT_B, HIGHLIGHT_ALPHA)
-        love.graphics.setLineWidth(math.max(1.25, thickness * 0.22))
-        drawPolyline(coords)
-        drawEndcaps(head, tail, half * 0.45)
-        drawCornerPlugs(trail, half * 0.45)
-        drawFruitBulges(trail, head, bulgeRadius * 0.45)
-        love.graphics.pop()
 end
 
 local function drawSoftGlow(x, y, radius, r, g, b, a)


### PR DESCRIPTION
## Summary
- stop drawing the highlight sheen in the snake render pass to remove the highlighted effect
- remove unused highlight color helpers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daea4aaff0832f8c878e2fbcde53b6