### PR TITLE
Retune shield upgrade rewards

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -361,7 +361,7 @@ local english = {
             },
             grim_reliquary = {
                 name = "Grim Reliquary",
-                description = "Begin each floor with +1 crash shield. Saws move 10% faster.",
+                description = "Saw tracks stall for +0.6s after each fruit. Saws move 10% faster.",
             },
             relentless_pursuit = {
                 name = "Relentless Pursuit",
@@ -392,7 +392,7 @@ local english = {
             },
             tectonic_resolve = {
                 name = "Tectonic Resolve",
-                description = "Rock spawn chance decreases by 15%. Begin each floor with +1 crash shield.",
+                description = "Rock spawn chance decreases by 15%. Each fruit has a 25% chance to shatter the nearest rock.",
             },
             titanblood_pact = {
                 name = "Titanblood Pact",

--- a/upgrades.lua
+++ b/upgrades.lua
@@ -1103,13 +1103,8 @@ local pool = {
         tags = {"defense"},
         onAcquire = function(state)
             state.effects.sawSpeedMult = (state.effects.sawSpeedMult or 1) * 1.1
-            Snake:addCrashShields(1)
+            state.effects.sawStall = (state.effects.sawStall or 0) + 0.6
         end,
-        handlers = {
-            floorStart = function()
-                Snake:addCrashShields(1)
-            end,
-        },
     }),
     register({
         id = "relentless_pursuit",
@@ -1298,13 +1293,8 @@ local pool = {
         tags = {"defense"},
         onAcquire = function(state)
             state.effects.rockSpawnMult = (state.effects.rockSpawnMult or 1) * 0.85
-            Snake:addCrashShields(1)
+            state.effects.rockShatter = (state.effects.rockShatter or 0) + 0.25
         end,
-        handlers = {
-            floorStart = function()
-                Snake:addCrashShields(1)
-            end,
-        },
     }),
     register({
         id = "titanblood_pact",


### PR DESCRIPTION
## Summary
- remove the automatic crash shield generation from Grim Reliquary while adding a stall bonus to keep its defensive identity
- remove the recurring crash shield generation from Tectonic Resolve and replace it with a rock-shatter chance to lean into rock control instead

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68daed363384832fab3f4a8b63155d15