### PR TITLE
Refine game over presentation

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -86,6 +86,7 @@ local english = {
             no_fruit_summary = "No fruit collected this run.",
             fruit_chip = "${label}: +${gained} (Total ${total})",
             achievements_header = "Achievements Earned",
+            achievements_more = "+${count} more achievements",
             no_achievements = "No achievements unlocked this run.",
             tip_prefix = "Tip: ${tip}",
             play_again = "Play Again",


### PR DESCRIPTION
## Summary
- enrich the game-over background and summary panel with layered dividers and a ribbon for new high scores
- show detailed cards for recent achievements with overflow messaging to highlight additional unlocks
- add an English localization string for the achievements overflow label

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68daef4cf894832fb07a09a1c7696afb