### PR TITLE
Add upgrade-focused fun challenges and tracking

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -54,6 +54,23 @@ local english = {
                     progress = "Emergency saves: ${current}/${goal}",
                     complete = "Shield mastery! ${current} clutch saves.",
                 },
+                shop = {
+                    title = "Upgrade Spree",
+                    description = "Purchase ${goal} upgrades across all runs.",
+                    progress = "Upgrades bought: ${current}/${goal}",
+                    complete = "Your shopping cart is overflowing with ${current} upgrades!",
+                },
+                legendary = {
+                    title = "Legendary Collector",
+                    description = "Add ${goal} legendary upgrades to your collection.",
+                    progress = "Legendary finds: ${current}/${goal}",
+                    complete = "A legendary haul of ${current}!",
+                },
+                marathon = {
+                    title = "Serpentine Marathon",
+                    description = "Slither ${goal} tiles in total.",
+                    progress = "Lifetime slither: ${current}/${goal}",
+                },
             },
         },
         settings = {
@@ -118,6 +135,9 @@ local english = {
                 tilesTravelled = "Tiles Slithered",
                 totalTimeAlive = "Time Alive",
                 longestRunDuration = "Longest Run",
+                totalUpgradesPurchased = "Upgrades Purchased",
+                legendaryUpgradesPurchased = "Legendary Upgrades",
+                mostUpgradesInRun = "Most Upgrades in a Run",
                 bestFloorClearTime = "Fastest Floor Clear",
                 longestFloorClearTime = "Slowest Floor Clear",
                 averageFloorClearTime = "Average Floor Clear",

--- a/funchallenges.lua
+++ b/funchallenges.lua
@@ -78,6 +78,32 @@ FunChallenges.challenges = {
         progressKey = "menu.fun_daily.shields.progress",
         completeKey = "menu.fun_daily.shields.complete",
     },
+    {
+        id = "shopaholic",
+        titleKey = "menu.fun_daily.shop.title",
+        descriptionKey = "menu.fun_daily.shop.description",
+        stat = "totalUpgradesPurchased",
+        goal = 30,
+        progressKey = "menu.fun_daily.shop.progress",
+        completeKey = "menu.fun_daily.shop.complete",
+    },
+    {
+        id = "legendary_collector",
+        titleKey = "menu.fun_daily.legendary.title",
+        descriptionKey = "menu.fun_daily.legendary.description",
+        stat = "legendaryUpgradesPurchased",
+        goal = 3,
+        progressKey = "menu.fun_daily.legendary.progress",
+        completeKey = "menu.fun_daily.legendary.complete",
+    },
+    {
+        id = "serpentine_marathon",
+        titleKey = "menu.fun_daily.marathon.title",
+        descriptionKey = "menu.fun_daily.marathon.description",
+        stat = "tilesTravelled",
+        goal = 12000,
+        progressKey = "menu.fun_daily.marathon.progress",
+    },
 }
 
 local function getChallengeIndex(count)

--- a/upgrades.lua
+++ b/upgrades.lua
@@ -7,6 +7,7 @@ local FloatingText = require("floatingtext")
 local Particles = require("particles")
 local Localization = require("localization")
 local MetaProgression = require("metaprogression")
+local PlayerStats = require("playerstats")
 
 local Upgrades = {}
 local poolById = {}
@@ -2111,6 +2112,13 @@ function Upgrades:acquire(card, context)
 
     state.takenSet[upgrade.id] = (state.takenSet[upgrade.id] or 0) + 1
     table.insert(state.takenOrder, upgrade.id)
+
+    PlayerStats:add("totalUpgradesPurchased", 1)
+    PlayerStats:updateMax("mostUpgradesInRun", #state.takenOrder)
+
+    if upgrade.rarity == "legendary" then
+        PlayerStats:add("legendaryUpgradesPurchased", 1)
+    end
 
     if upgrade.tags then
         for _, tag in ipairs(upgrade.tags) do


### PR DESCRIPTION
## Summary
- add new fun challenges that highlight upgrade shopping and lifetime travel goals
- track total, legendary, and per-run upgrade purchases when cards are acquired
- localize the new challenge prompts and lifetime stat labels

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db709d16c4832fad1b56a6eda983ba