### PR TITLE
Enhance fun challenges system

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -71,6 +71,36 @@ local english = {
                     description = "Slither ${goal} tiles in total.",
                     progress = "Lifetime slither: ${current}/${goal}",
                 },
+                shield_bounce = {
+                    title = "Shield Wall Master",
+                    description = "Bounce off walls with your shield ${goal} times.",
+                    progress = "Wall bounces: ${current}/${goal}",
+                    complete = "Shield walls conquered with ${current} bounces!",
+                },
+                rock_breaker = {
+                    title = "Rock Breaker",
+                    description = "Smash ${goal} rocks with your shield.",
+                    progress = "Rocks shattered: ${current}/${goal}",
+                    complete = "Pulverized ${current} rocks!",
+                },
+                saw_parry = {
+                    title = "Saw Parry Ace",
+                    description = "Deflect ${goal} saws with your shield.",
+                    progress = "Saws parried: ${current}/${goal}",
+                    complete = "Saws sent flying: ${current}!",
+                },
+                time_keeper = {
+                    title = "Time Keeper",
+                    description = "Stay alive for ${goal} minutes across your runs.",
+                    progress = "Lifetime survival: ${current}/${goal}",
+                    complete = "Endurance expert! Survived ${current}.",
+                },
+                streak_pusher = {
+                    title = "Streak Pusher",
+                    description = "Beat your combo streak of ${current} and hit ${goal}.",
+                    progress = "Current best streak: ${current}/${goal}",
+                    complete = "New streak champion at ${current}!",
+                },
             },
         },
         settings = {

--- a/funchallenges.lua
+++ b/funchallenges.lua
@@ -2,6 +2,10 @@ local PlayerStats = require("playerstats")
 
 local FunChallenges = {}
 
+local defaultDateProvider = function()
+    return os.date("*t")
+end
+
 local function defaultProgressReplacements(current, goal)
     return {
         current = current or 0,
@@ -10,6 +14,10 @@ local function defaultProgressReplacements(current, goal)
 end
 
 local function mergeReplacements(base, extra)
+    if not base then
+        base = {}
+    end
+
     if not extra then
         return base
     end
@@ -21,6 +29,152 @@ local function mergeReplacements(base, extra)
     return base
 end
 
+local function buildChallengeLookup(list)
+    local lookup = {}
+
+    for index, challenge in ipairs(list) do
+        challenge.index = index
+        if challenge.id and not lookup[challenge.id] then
+            lookup[challenge.id] = challenge
+        end
+    end
+
+    return lookup
+end
+
+local function callChallengeFunction(challenge, key, ...)
+    if not challenge then
+        return nil
+    end
+
+    local fn = challenge[key]
+    if type(fn) ~= "function" then
+        return nil
+    end
+
+    local ok, result = pcall(fn, challenge, ...)
+    if not ok then
+        print(string.format("[FunChallenges] Failed to call %s for '%s': %s", key, challenge.id or "<unknown>", result))
+        return nil
+    end
+
+    return result
+end
+
+local function resolveGoal(challenge, context)
+    local override = context and context.goalOverride
+    if override ~= nil then
+        return override
+    end
+
+    local value = callChallengeFunction(challenge, "getGoal", context)
+    if value ~= nil then
+        return value
+    end
+
+    return challenge.goal or 0
+end
+
+local function resolveCurrent(challenge, context)
+    local override = context and context.currentOverride
+    if override ~= nil then
+        return override
+    end
+
+    local value = callChallengeFunction(challenge, "getValue", context)
+    if value ~= nil then
+        return value
+    end
+
+    if challenge.stat then
+        return PlayerStats:get(challenge.stat) or 0
+    end
+
+    return 0
+end
+
+local function resolveProgressReplacements(challenge, current, goal, context)
+    local replacements = defaultProgressReplacements(current, goal)
+    local extra = callChallengeFunction(challenge, "progressReplacements", current, goal, context)
+    if extra then
+        replacements = mergeReplacements(replacements, extra)
+    end
+    return replacements
+end
+
+local function resolveDescriptionReplacements(challenge, current, goal, context)
+    local replacements = { goal = goal or 0, current = current or 0 }
+    local extra = callChallengeFunction(challenge, "descriptionReplacements", current, goal, context)
+    if extra then
+        replacements = mergeReplacements(replacements, extra)
+    end
+    return replacements
+end
+
+local function clampRatio(current, goal)
+    if goal and goal > 0 then
+        return math.max(0, math.min(1, current / goal))
+    end
+    return 0
+end
+
+local function resolveDate(self, override)
+    if type(override) == "table" then
+        return override
+    end
+
+    local provider = self._dateProvider or defaultDateProvider
+    return provider()
+end
+
+local function getChallengeIndex(self, count, date)
+    if count <= 0 then
+        return nil
+    end
+
+    date = resolveDate(self, date)
+    if not date then
+        return 1
+    end
+
+    local value = (date.year or 0) * 512 + (date.yday or 0)
+    local offset = self._dailyOffset or 0
+    local adjusted = value + offset
+    local index = ((adjusted % count) + count) % count + 1
+
+    return index
+end
+
+local function evaluateChallenge(challenge, context)
+    if not challenge then
+        return nil
+    end
+
+    context = context or {}
+
+    local goal = resolveGoal(challenge, context)
+    local current = resolveCurrent(challenge, context)
+    local ratio = clampRatio(current, goal)
+
+    local descriptionReplacements = resolveDescriptionReplacements(challenge, current, goal, context)
+    local progressReplacements = resolveProgressReplacements(challenge, current, goal, context)
+
+    return {
+        id = challenge.id,
+        index = challenge.index,
+        titleKey = challenge.titleKey,
+        descriptionKey = challenge.descriptionKey,
+        descriptionReplacements = descriptionReplacements,
+        progressKey = challenge.progressKey,
+        progressReplacements = progressReplacements,
+        completeKey = challenge.completeKey,
+        goal = goal,
+        current = current,
+        ratio = ratio,
+        completed = goal > 0 and current >= goal,
+    }
+end
+
 FunChallenges.challenges = {
     {
         id = "combo_crunch",
@@ -30,7 +184,7 @@ FunChallenges.challenges = {
         goal = 6,
         progressKey = "menu.fun_daily.combo.progress",
         completeKey = "menu.fun_daily.combo.complete",
-        progressReplacements = function(current, goal)
+        progressReplacements = function(self, current, goal)
             return {
                 best = current or 0,
                 goal = goal or 0,
@@ -104,90 +258,161 @@ FunChallenges.challenges = {
         goal = 12000,
         progressKey = "menu.fun_daily.marathon.progress",
     },
+    {
+        id = "shield_wall_master",
+        titleKey = "menu.fun_daily.shield_bounce.title",
+        descriptionKey = "menu.fun_daily.shield_bounce.description",
+        stat = "shieldWallBounces",
+        goal = 18,
+        progressKey = "menu.fun_daily.shield_bounce.progress",
+        completeKey = "menu.fun_daily.shield_bounce.complete",
+    },
+    {
+        id = "rock_breaker",
+        titleKey = "menu.fun_daily.rock_breaker.title",
+        descriptionKey = "menu.fun_daily.rock_breaker.description",
+        stat = "shieldRockBreaks",
+        goal = 15,
+        progressKey = "menu.fun_daily.rock_breaker.progress",
+        completeKey = "menu.fun_daily.rock_breaker.complete",
+    },
+    {
+        id = "saw_parry_ace",
+        titleKey = "menu.fun_daily.saw_parry.title",
+        descriptionKey = "menu.fun_daily.saw_parry.description",
+        stat = "shieldSawParries",
+        goal = 8,
+        progressKey = "menu.fun_daily.saw_parry.progress",
+        completeKey = "menu.fun_daily.saw_parry.complete",
+    },
+    {
+        id = "time_keeper",
+        titleKey = "menu.fun_daily.time_keeper.title",
+        descriptionKey = "menu.fun_daily.time_keeper.description",
+        stat = "totalTimeAlive",
+        goal = 5400,
+        progressKey = "menu.fun_daily.time_keeper.progress",
+        progressReplacements = function(self, current, goal)
+            local function formatSeconds(seconds)
+                seconds = math.max(0, math.floor(seconds or 0))
+                local minutes = math.floor(seconds / 60)
+                local secs = seconds % 60
+                return string.format("%d:%02d", minutes, secs)
+            end
+
+            return {
+                current = formatSeconds(current),
+                goal = formatSeconds(goal),
+            }
+        end,
+        descriptionReplacements = function(self, current, goal)
+            return {
+                goal = math.floor((goal or 0) / 60),
+                current = math.floor((current or 0) / 60),
+            }
+        end,
+    },
+    {
+        id = "streak_pusher",
+        titleKey = "menu.fun_daily.streak_pusher.title",
+        descriptionKey = "menu.fun_daily.streak_pusher.description",
+        stat = "bestComboStreak",
+        getGoal = function(self)
+            local best = PlayerStats:get(self.stat) or 0
+            return math.max(4, best + 2)
+        end,
+        progressKey = "menu.fun_daily.streak_pusher.progress",
+        completeKey = "menu.fun_daily.streak_pusher.complete",
+        descriptionReplacements = function(self, current, goal)
+            return {
+                current = current or 0,
+                goal = goal or 0,
+            }
+        end,
+    },
 }
 
-local function getChallengeIndex(count)
-    if count <= 0 then
+FunChallenges.lookup = buildChallengeLookup(FunChallenges.challenges)
+
+function FunChallenges:setDateProvider(provider)
+    if type(provider) == "function" then
+        self._dateProvider = provider
+    else
+        self._dateProvider = nil
+    end
+end
+
+function FunChallenges:setDailyOffset(offset)
+    if type(offset) == "number" then
+        self._dailyOffset = math.floor(offset)
+    else
+        self._dailyOffset = nil
+    end
+end
+
+function FunChallenges:getChallengeIndex(date)
+    return getChallengeIndex(self, #self.challenges, date)
+end
+
+function FunChallenges:getChallengeById(id, context)
+    if not id then
         return nil
     end
 
-    local date = os.date("*t")
-    if not date then
-        return 1
-    end
-
-    local value = (date.year or 0) * 512 + (date.yday or 0)
-    return (value % count) + 1
-end
-
-local function resolveProgressReplacements(challenge, current, goal)
-    local replacements = defaultProgressReplacements(current, goal)
-    if challenge.progressReplacements then
-        replacements = mergeReplacements(replacements, challenge.progressReplacements(current, goal))
-    end
-    return replacements
-end
-
-local function resolveDescriptionReplacements(challenge, current, goal)
-    local replacements = { goal = goal or 0 }
-    if challenge.descriptionReplacements then
-        replacements = mergeReplacements(replacements, challenge.descriptionReplacements(current, goal))
-    end
-    return replacements
-end
-
-local function resolveGoal(challenge)
-    if challenge.getGoal then
-        local value = challenge:getGoal()
-        if value ~= nil then
-            return value
-        end
-    end
-
-    return challenge.goal or 0
-end
-
-function FunChallenges:getDailyChallenge()
-    local count = #self.challenges
-    local index = getChallengeIndex(count)
-    if not index then
-        return nil
-    end
-
-    local challenge = self.challenges[index]
+    local challenge = self.lookup[id]
     if not challenge then
         return nil
     end
 
-    local current = 0
-    if challenge.getValue then
-        current = challenge:getValue() or 0
-    elseif challenge.stat then
-        current = PlayerStats:get(challenge.stat) or 0
+    return evaluateChallenge(challenge, context)
+end
+
+function FunChallenges:getChallengeForIndex(index, context)
+    local challenge = self.challenges[index]
+    return evaluateChallenge(challenge, context)
+end
+
+function FunChallenges:getDailyChallenge(date, context)
+    local count = #self.challenges
+    local index = getChallengeIndex(self, count, date)
+    if not index then
+        return nil
     end
 
-    local goal = resolveGoal(challenge)
-    local ratio = 0
-    if goal > 0 then
-        ratio = math.min(1, current / goal)
+    return self:getChallengeForIndex(index, context)
+end
+
+function FunChallenges:getUpcomingChallenges(amount, options)
+    amount = math.max(0, math.floor(amount or 0))
+    if amount == 0 or #self.challenges == 0 then
+        return {}
     end
 
-    local descriptionReplacements = resolveDescriptionReplacements(challenge, current, goal)
-    local progressReplacements = resolveProgressReplacements(challenge, current, goal)
+    local results = {}
+    local date = options and options.date
+    local sharedContext = options and options.context
+    local contextBuilder = options and options.contextBuilder
+    local index = getChallengeIndex(self, #self.challenges, date)
+    if not index then
+        return results
+    end
 
-    return {
-        id = challenge.id,
-        titleKey = challenge.titleKey,
-        descriptionKey = challenge.descriptionKey,
-        descriptionReplacements = descriptionReplacements,
-        progressKey = challenge.progressKey,
-        progressReplacements = progressReplacements,
-        completeKey = challenge.completeKey,
-        goal = goal,
-        current = current,
-        ratio = ratio,
-        completed = goal > 0 and current >= goal,
-    }
+    for i = 0, amount - 1 do
+        local currentIndex = ((index + i - 1) % #self.challenges) + 1
+        local context
+        if contextBuilder then
+            context = contextBuilder(currentIndex, self.challenges[currentIndex])
+        else
+            context = sharedContext
+        end
+
+        local evaluated = self:getChallengeForIndex(currentIndex, context)
+        if evaluated then
+            results[#results + 1] = evaluated
+        end
+    end
+
+    return results
 end
 
 return FunChallenges


### PR DESCRIPTION
## Summary
- refactor the fun challenge evaluator to support custom date providers, safe callbacks, and challenge lookup helpers
- add new lifetime objectives like shield wall mastery, rock breaking, saw parries, endurance timekeeping, and streak pushing with tailored progress text
- localize the newly added daily challenges for the menu panel

## Testing
- not run (luac not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68db71b2c86c832f806363716b7a0d89