### PR TITLE
Fix circular require between UI and score

### DIFF
--- a/ui.lua
+++ b/ui.lua
@@ -1,4 +1,3 @@
-local Score = require("score")
 local Audio = require("audio")
 local Theme = require("theme")
 local Localization = require("localization")


### PR DESCRIPTION
## Summary
- remove the unnecessary score module import from the UI to break the circular dependency during startup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db8a0c747c832f987021f0cfb920fe