### PR TITLE
Extract easing helpers into shared module

### DIFF
--- a/easing.lua
+++ b/easing.lua
@@ -1,0 +1,59 @@
+local Easing = {}
+
+function Easing.clamp01(value)
+    if value < 0 then
+        return 0
+    elseif value > 1 then
+        return 1
+    end
+
+    return value
+end
+
+function Easing.lerp(a, b, t)
+    return a + (b - a) * t
+end
+
+function Easing.easeInOutCubic(t)
+    if t < 0.5 then
+        return 4 * t * t * t
+    end
+
+    t = (2 * t) - 2
+    return 0.5 * t * t * t + 1
+end
+
+function Easing.easeOutExpo(t)
+    if t >= 1 then
+        return 1
+    end
+
+    return 1 - math.pow(2, -10 * t)
+end
+
+function Easing.easeOutBack(t)
+    local c1 = 1.70158
+    local c3 = c1 + 1
+
+    return 1 + c3 * math.pow(t - 1, 3) + c1 * math.pow(t - 1, 2)
+end
+
+function Easing.easedProgress(timer, duration)
+    if not duration or duration <= 0 then
+        return 1
+    end
+
+    return Easing.easeInOutCubic(Easing.clamp01(timer / duration))
+end
+
+function Easing.getTransitionAlpha(t, direction)
+    t = Easing.clamp01(t)
+
+    if direction == 1 then
+        return Easing.easeInOutCubic(t)
+    end
+
+    return Easing.easeInOutCubic(1 - t)
+end
+
+return Easing

--- a/game.lua
+++ b/game.lua
@@ -5,6 +5,7 @@ local PlayerStats = require("playerstats")
 local SessionStats = require("sessionstats")
 local Snake = require("snake")
 local SnakeUtils = require("snakeutils")
+local Easing = require("easing")
 local Face = require("face")
 local Fruit = require("fruit")
 local Rocks = require("rocks")
@@ -34,42 +35,12 @@ local Localization = require("localization")
 local Game = {}
 local TRACK_LENGTH = 120
 
-local function clamp01(value)
-        if value < 0 then return 0 end
-        if value > 1 then return 1 end
-        return value
-end
-
-local function lerp(a, b, t)
-        return a + (b - a) * t
-end
-
-local function easeInOutCubic(t)
-        if t < 0.5 then
-                return 4 * t * t * t
-        end
-        t = (2 * t) - 2
-        return 0.5 * t * t * t + 1
-end
-
-local function easeOutExpo(t)
-        if t >= 1 then return 1 end
-        return 1 - math.pow(2, -10 * t)
-end
-
-local function easeOutBack(t)
-        local c1 = 1.70158
-        local c3 = c1 + 1
-        return 1 + c3 * math.pow(t - 1, 3) + c1 * math.pow(t - 1, 2)
-end
-
-local function easedProgress(timer, duration)
-        if not duration or duration <= 0 then
-                return 1
-        end
-
-        return easeInOutCubic(clamp01(timer / duration))
-end
+local clamp01 = Easing.clamp01
+local lerp = Easing.lerp
+local easeInOutCubic = Easing.easeInOutCubic
+local easeOutExpo = Easing.easeOutExpo
+local easeOutBack = Easing.easeOutBack
+local easedProgress = Easing.easedProgress
 
 local function buildModifierSections(self)
     local sections = {}

--- a/gamestate.lua
+++ b/gamestate.lua
@@ -1,4 +1,5 @@
 local Theme = require("theme")
+local Easing = require("easing")
 
 local GameState = {}
 
@@ -28,34 +29,9 @@ local transitionBlockedEvents = {
     gamepadaxis = true,
 }
 
--- Easing function: cubic ease-in-out (t in [0,1])
-local function easeInOutCubic(t)
-    if t < 0.5 then
-        return 4 * t * t * t
-    else
-        return 1 - math.pow(-2 * t + 2, 3) / 2
-    end
-end
-
--- Returns alpha from 0 to 1 based on eased time
-local function getTransitionAlpha(t, direction)
-    t = math.min(math.max(t, 0), 1)
-    if direction == 1 then
-        return easeInOutCubic(t)
-    else
-        return easeInOutCubic(1 - t)
-    end
-end
-
-local function clamp01(value)
-    if value < 0 then
-        return 0
-    elseif value > 1 then
-        return 1
-    end
-
-    return value
-end
+local clamp01 = Easing.clamp01
+local easeInOutCubic = Easing.easeInOutCubic
+local getTransitionAlpha = Easing.getTransitionAlpha
 
 local function parseDuration(value)
     if type(value) == "number" and value >= 0 then


### PR DESCRIPTION
## Summary
- add a reusable `easing` helper module for interpolation utilities
- update `game.lua` and `gamestate.lua` to consume the shared easing helpers instead of local copies

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db8c957040832f99e0c05948649b53