### PR TITLE
Enable controller activation for abilities

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -518,12 +518,12 @@ local english = {
             },
             thunder_dash = {
                 name = "Thunder Dash",
-                description = "Press Space to dash forward, smashing through rocks while briefly speeding up.",
+                description = "Press Space (or A/Right Shoulder on a controller) to dash forward, smashing through rocks while briefly speeding up.",
                 activation_text = "Thunder Dash!",
             },
             temporal_anchor = {
                 name = "Temporal Anchor",
-                description = "Press Shift to slow time for a short duration, reducing all movement to 35% speed.",
+                description = "Press Shift (or X/Left Shoulder on a controller) to slow time for a short duration, reducing all movement to 35% speed.",
                 activation_text = "Time Slow!",
             },
             zephyr_coils = {

--- a/game.lua
+++ b/game.lua
@@ -1013,6 +1013,10 @@ local function handleGamepadInput(self, button)
                         Controls:keypressed(self, map[button])
                 elseif button == "start" and self.state == "playing" then
                         self.state = "paused"
+                elseif button == "a" or button == "rightshoulder" or button == "righttrigger" then
+                        Controls:keypressed(self, "space")
+                elseif button == "x" or button == "leftshoulder" or button == "lefttrigger" then
+                        Controls:keypressed(self, "lshift")
                 end
         end
 end


### PR DESCRIPTION
## Summary
- allow controller face and shoulder buttons to trigger dash and time-slow abilities during gameplay
- update English localization strings to mention the new controller bindings for these abilities

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc07822128832f870fb2c21c3e1b52