### PR TITLE
Reduce floating text scale

### DIFF
--- a/floatingtext.lua
+++ b/floatingtext.lua
@@ -3,7 +3,7 @@ local UI = require("ui")
 local FloatingText = {}
 
 local entries = {}
-local defaultFont = UI.fonts.display or love.graphics.newFont("Assets/Fonts/Comfortaa-Bold.ttf", 32)
+local defaultFont = UI.fonts.display or love.graphics.newFont("Assets/Fonts/Comfortaa-Bold.ttf", 24)
 
 local baseColor = UI.colors.accentText or UI.colors.text or { 1, 1, 1, 1 }
 
@@ -11,9 +11,9 @@ local DEFAULTS = {
     color = { baseColor[1], baseColor[2], baseColor[3], 1 },
     duration = 1.0,
     riseSpeed = 30,
-    scale = 1.2,
+    scale = 1.0,
     pop = {
-        scale = 1.28,
+        scale = 1.12,
         duration = 0.18,
     },
     wobble = {


### PR DESCRIPTION
## Summary
- reduce the default floating text font size from 32 to 24 to shrink on-screen text
- lower the default scale and pop scale so floating text animations appear less oversized

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc0ac2d268832fbd3df2665b4d0de1