### PR TITLE
Optimize frequently-used helpers for performance

### DIFF
--- a/conveyors.lua
+++ b/conveyors.lua
@@ -4,6 +4,7 @@ local Conveyors = {}
 
 local belts = {}
 local slots = {}
+local slotLookup = {}
 local nextSlotId = 0
 
 local TRACK_LENGTH = 120
@@ -46,23 +47,29 @@ local function getPalette()
     }
 end
 
+local function makeSlotKey(x, y, dir)
+    return x .. ":" .. y .. ":" .. dir
+end
+
 local function getSlot(x, y, dir)
     dir = dir or "horizontal"
-    for _, slot in ipairs(slots) do
-        if slot.x == x and slot.y == y and slot.dir == dir then
-            return slot
-        end
+    local key = makeSlotKey(x, y, dir)
+    local slot = slotLookup[key]
+
+    if slot then
+        return slot
     end
 
     nextSlotId = nextSlotId + 1
-    local slot = {
+    slot = {
         id = nextSlotId,
         x = x,
         y = y,
         dir = dir,
     }
 
-    table.insert(slots, slot)
+    slotLookup[key] = slot
+    slots[#slots + 1] = slot
     return slot
 end
 
@@ -72,7 +79,7 @@ function Conveyors:spawn(x, y, dir, length)
 
     local slot = getSlot(x, y, dir)
 
-    table.insert(belts, {
+    belts[#belts + 1] = {
         x = x,
         y = y,
         dir = dir,
@@ -86,7 +93,7 @@ function Conveyors:spawn(x, y, dir, length)
         shadowAlpha = 0,
         patternOffset = 0,
         slotId = slot and slot.id or nil,
-    })
+    }
 end
 
 function Conveyors:getAll()
@@ -96,6 +103,7 @@ end
 function Conveyors:reset()
     belts = {}
     slots = {}
+    slotLookup = {}
     nextSlotId = 0
 end
 

--- a/floatingtext.lua
+++ b/floatingtext.lua
@@ -168,13 +168,14 @@ function FloatingText:add(text, x, y, color, duration, riseSpeed, font, options)
     local wobbleFrequency = options.wobbleFrequency or DEFAULTS.wobble.frequency
     local fadeStart = options.fadeStart or DEFAULTS.fadeStart
     local drift
+    local random = love.math.random
 
     if options.drift ~= nil then
         drift = options.drift
     elseif DEFAULTS.drift == 0 then
         drift = 0
     else
-        drift = (love.math.random() * 2 - 1) * DEFAULTS.drift
+        drift = (random() * 2 - 1) * DEFAULTS.drift
     end
 
     local rise = options.riseDistance
@@ -184,9 +185,9 @@ function FloatingText:add(text, x, y, color, duration, riseSpeed, font, options)
     end
 
     local rotationAmplitude = options.rotationAmplitude or DEFAULTS.rotation
-    local rotationDirection = (love.math.random() < 0.5) and -1 or 1
+    local rotationDirection = (random() < 0.5) and -1 or 1
 
-    table.insert(entries, {
+    entries[#entries + 1] = {
         text = text,
         x = x,
         y = y,
@@ -211,7 +212,7 @@ function FloatingText:add(text, x, y, color, duration, riseSpeed, font, options)
         rotation = 0,
         ox = fontWidth / 2,
         oy = fontHeight / 2,
-    })
+    }
 end
 
 function FloatingText:update(dt)

--- a/particles.lua
+++ b/particles.lua
@@ -37,19 +37,22 @@ function Particles:spawnBurst(x, y, options)
     local drag = options.drag or 0
     local gravity = options.gravity or 0
     local fadeTo = options.fadeTo
+    local random = love.math.random
+    local cos = math.cos
+    local sin = math.sin
 
     if count == 0 then
         return
     end
 
     for i = 1, count do
-        local angle = spread * (i / count) + (love.math.random() - 0.5) * angleJitter
-        local velocity = speed + love.math.random() * speedVariance
-        local vx = math.cos(angle) * velocity
-        local vy = math.sin(angle) * velocity
-        local scale = scaleMin + love.math.random() * scaleVariance
+        local angle = spread * (i / count) + (random() - 0.5) * angleJitter
+        local velocity = speed + random() * speedVariance
+        local vx = cos(angle) * velocity
+        local vy = sin(angle) * velocity
+        local scale = scaleMin + random() * scaleVariance
 
-        table.insert(list, {
+        list[#list + 1] = {
             x = x,
             y = y,
             vx = vx,
@@ -62,7 +65,7 @@ function Particles:spawnBurst(x, y, options)
             gravity = gravity,
             fadeTo = fadeTo,
             startAlpha = startAlpha,
-        })
+        }
     end
 end
 


### PR DESCRIPTION
## Summary
- memoize conveyor slots to avoid repeated linear scans when spawning belts
- reduce per-frame allocations by using direct table writes and cached random/math lookups in particle and floating text helpers

## Testing
- not run (project uses Love2D runtime)


------
https://chatgpt.com/codex/tasks/task_e_68dc282c6a98832f8cd2a39b667e19cb