### PR TITLE
Adjust achievement card borders to match theme

### DIFF
--- a/achievementsmenu.lua
+++ b/achievementsmenu.lua
@@ -495,13 +495,14 @@ function AchievementsMenu:draw()
                 cardBase = darkenColor(panelColor, 0.2)
             end
 
+            local accentBorder = Theme.borderColor or panelBorder
             local borderTint
             if unlocked then
-                borderTint = Theme.achieveColor or lightenColor(panelBorder, 0.35)
+                borderTint = lightenColor(accentBorder, 0.2)
             elseif hiddenLocked then
                 borderTint = darkenColor(panelBorder, 0.15)
             else
-                borderTint = Theme.panelBorder or panelBorder
+                borderTint = Theme.panelBorder or accentBorder
             end
 
             love.graphics.setColor(shadowColor[1], shadowColor[2], shadowColor[3], (shadowColor[4] or 0.3) * 0.9)


### PR DESCRIPTION
## Summary
- replace the achievement card outlines with the theme border accent instead of the pink unlock color

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc4efd3ee8832fac353193f5bfba01