### PR TITLE
Refactor floor setup logic into helper calls

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -97,6 +97,219 @@ local function drawAdrenalineGlow(self)
     love.graphics.pop()
 end
 
+local function applyPalette(palette)
+    if not palette then
+        return
+    end
+
+    for key, value in pairs(palette) do
+        Theme[key] = value
+    end
+end
+
+local function resetFloorEntities()
+    Arena:resetExit()
+    Movement:reset()
+    FloatingText:reset()
+    Particles:reset()
+    Rocks:reset()
+    Conveyors:reset()
+    Saws:reset()
+end
+
+local function prepareOccupancy()
+    SnakeUtils.initOccupancy()
+
+    for _, segment in ipairs(Snake:getSegments()) do
+        local col, row = Arena:getTileFromWorld(segment.drawX, segment.drawY)
+        SnakeUtils.setOccupied(col, row, true)
+    end
+
+    local safeZone = Snake:getSafeZone(3)
+    local headCol, headRow = Snake:getHeadCell()
+    local reservedCandidates = {}
+
+    if headCol and headRow then
+        for dx = -1, 1 do
+            for dy = -1, 1 do
+                reservedCandidates[#reservedCandidates + 1] = { headCol + dx, headRow + dy }
+            end
+        end
+    end
+
+    if safeZone then
+        for _, cell in ipairs(safeZone) do
+            reservedCandidates[#reservedCandidates + 1] = { cell[1], cell[2] }
+        end
+    end
+
+    local reservedCells = SnakeUtils.reserveCells(reservedCandidates)
+
+    return safeZone, reservedCells
+end
+
+local function applyBaselineHazardTraits(traitContext)
+    traitContext.conveyors = math.max(0, traitContext.conveyors or 0)
+
+    if traitContext.rockSpawnChance then
+        Rocks.spawnChance = traitContext.rockSpawnChance
+    end
+
+    if traitContext.sawSpeedMult then
+        Saws.speedMult = traitContext.sawSpeedMult
+    end
+
+    if traitContext.sawSpinMult then
+        Saws.spinMult = traitContext.sawSpinMult
+    end
+
+    if Saws.setStallOnFruit then
+        Saws:setStallOnFruit(traitContext.sawStall or 0)
+    else
+        Saws.stallOnFruit = traitContext.sawStall or 0
+    end
+end
+
+local function finalizeTraitContext(traitContext, numConveyors)
+    traitContext.rockSpawnChance = Rocks:getSpawnChance()
+    traitContext.sawSpeedMult = Saws.speedMult
+    traitContext.sawSpinMult = Saws.spinMult
+
+    if Saws.getStallOnFruit then
+        traitContext.sawStall = Saws:getStallOnFruit()
+    else
+        traitContext.sawStall = Saws.stallOnFruit or 0
+    end
+
+    traitContext.conveyors = numConveyors
+end
+
+local function trySpawnHorizontalSaw(halfTiles, bladeRadius)
+    local row = love.math.random(2, Arena.rows - 1)
+    local col = love.math.random(1 + halfTiles, Arena.cols - halfTiles)
+    local fx, fy = Arena:getCenterOfTile(col, row)
+
+    if SnakeUtils.trackIsFree(fx, fy, "horizontal", TRACK_LENGTH) then
+        Saws:spawn(fx, fy, bladeRadius, 8, "horizontal")
+        SnakeUtils.occupySawTrack(fx, fy, "horizontal", bladeRadius, TRACK_LENGTH)
+        return true
+    end
+
+    return false
+end
+
+local function trySpawnVerticalSaw(halfTiles, bladeRadius)
+    local side = (love.math.random() < 0.5) and "left" or "right"
+    local col = (side == "left") and 1 or Arena.cols
+    local row = love.math.random(1 + halfTiles, Arena.rows - halfTiles)
+    local fx, fy = Arena:getCenterOfTile(col, row)
+
+    if SnakeUtils.trackIsFree(fx, fy, "vertical", TRACK_LENGTH) then
+        Saws:spawn(fx, fy, bladeRadius, 8, "vertical", side)
+        SnakeUtils.occupySawTrack(fx, fy, "vertical", bladeRadius, TRACK_LENGTH, side)
+        return true
+    end
+
+    return false
+end
+
+local function spawnSaws(numSaws, halfTiles, bladeRadius)
+    for _ = 1, numSaws do
+        local dir = (love.math.random() < 0.5) and "horizontal" or "vertical"
+        local placed = false
+        local attempts = 0
+        local maxAttempts = 60
+
+        while not placed and attempts < maxAttempts do
+            attempts = attempts + 1
+
+            if dir == "horizontal" then
+                placed = trySpawnHorizontalSaw(halfTiles, bladeRadius)
+            else
+                placed = trySpawnVerticalSaw(halfTiles, bladeRadius)
+            end
+        end
+    end
+end
+
+local function chooseConveyorDirection(horizontalPossible, verticalPossible)
+    if horizontalPossible and verticalPossible then
+        return (love.math.random() < 0.5) and "horizontal" or "vertical"
+    elseif horizontalPossible then
+        return "horizontal"
+    elseif verticalPossible then
+        return "vertical"
+    end
+end
+
+local function trySpawnConveyor(dir, halfTiles, conveyorTrackLength)
+    if not dir then
+        return false
+    end
+
+    if dir == "horizontal" then
+        local minCol = 1 + halfTiles
+        local maxCol = Arena.cols - halfTiles
+        local col = love.math.random(minCol, maxCol)
+        local row = love.math.random(1, Arena.rows)
+        local fx, fy = Arena:getCenterOfTile(col, row)
+
+        if SnakeUtils.trackIsFree(fx, fy, dir, conveyorTrackLength) then
+            Conveyors:spawn(fx, fy, dir, conveyorTrackLength)
+            SnakeUtils.occupyTrack(fx, fy, dir, conveyorTrackLength)
+            return true
+        end
+    else
+        local col = love.math.random(1, Arena.cols)
+        local rowMin = 1 + halfTiles
+        local rowMax = Arena.rows - halfTiles
+        local row = love.math.random(rowMin, rowMax)
+        local fx, fy = Arena:getCenterOfTile(col, row)
+
+        if SnakeUtils.trackIsFree(fx, fy, dir, conveyorTrackLength) then
+            Conveyors:spawn(fx, fy, dir, conveyorTrackLength)
+            SnakeUtils.occupyTrack(fx, fy, dir, conveyorTrackLength)
+            return true
+        end
+    end
+
+    return false
+end
+
+local function spawnConveyors(numConveyors, halfTiles)
+    local conveyorTrackLength = TRACK_LENGTH
+    local horizontalPossible = (1 + halfTiles) <= (Arena.cols - halfTiles)
+    local verticalPossible = (1 + halfTiles) <= (Arena.rows - halfTiles)
+
+    for _ = 1, numConveyors do
+        local placed = false
+        local attempts = 0
+        local maxAttempts = 60
+
+        while not placed and attempts < maxAttempts do
+            attempts = attempts + 1
+            local dir = chooseConveyorDirection(horizontalPossible, verticalPossible)
+
+            if not dir then
+                break
+            end
+
+            placed = trySpawnConveyor(dir, halfTiles, conveyorTrackLength)
+        end
+    end
+end
+
+local function spawnRocks(numRocks, safeZone)
+    for _ = 1, numRocks do
+        local fx, fy = SnakeUtils.getSafeSpawn(Snake:getSegments(), Fruit, Rocks, safeZone)
+        if fx then
+            Rocks:spawn(fx, fy, "small")
+            local col, row = Arena:getTileFromWorld(fx, fy)
+            SnakeUtils.setOccupied(col, row, true)
+        end
+    end
+end
+
 function Game:load()
         self.state = "playing"
         self.floor = 1
@@ -732,70 +945,13 @@ function Game:setupFloor(floorNum)
 
     self.floorTimer = 0
 
-    if self.currentFloorData.palette then
-        for k, v in pairs(self.currentFloorData.palette) do
-            Theme[k] = v
-        end
-    end
+    applyPalette(self.currentFloorData.palette)
 
-    -- reset entities
-    Arena:resetExit()
-    Movement:reset()
-    FloatingText:reset()
-    Particles:reset()
-    Rocks:reset()
-    Conveyors:reset()
-    Saws:reset()
-    SnakeUtils.initOccupancy()
+    resetFloorEntities()
+    local safeZone, reservedCells = prepareOccupancy()
 
-    for _, seg in ipairs(Snake:getSegments()) do
-        local col, row = Arena:getTileFromWorld(seg.drawX, seg.drawY)
-        SnakeUtils.setOccupied(col, row, true)
-    end
-
-    local safeZone = Snake:getSafeZone(3)
-    local headCol, headRow = Snake:getHeadCell()
-    local reservedCandidates = {}
-
-    if headCol and headRow then
-        for dx = -1, 1 do
-            for dy = -1, 1 do
-                local col = headCol + dx
-                local row = headRow + dy
-                reservedCandidates[#reservedCandidates + 1] = {col, row}
-            end
-        end
-    end
-
-    if safeZone then
-        for _, cell in ipairs(safeZone) do
-            reservedCandidates[#reservedCandidates + 1] = {cell[1], cell[2]}
-        end
-    end
-
-    local reservedCells = SnakeUtils.reserveCells(reservedCandidates)
-
-    -- difficulty scaling baseline with floor traits
     local traitContext = FloorPlan.buildBaselineFloorContext(floorNum)
-    traitContext.conveyors = math.max(0, traitContext.conveyors or 0)
-
-    if traitContext.rockSpawnChance then
-        Rocks.spawnChance = traitContext.rockSpawnChance
-    end
-
-    if traitContext.sawSpeedMult then
-        Saws.speedMult = traitContext.sawSpeedMult
-    end
-
-    if traitContext.sawSpinMult then
-        Saws.spinMult = traitContext.sawSpinMult
-    end
-
-    if Saws.setStallOnFruit then
-        Saws:setStallOnFruit(traitContext.sawStall or 0)
-    else
-        Saws.stallOnFruit = traitContext.sawStall or 0
-    end
+    applyBaselineHazardTraits(traitContext)
 
     local adjustedContext, appliedTraits = FloorTraits:apply(self.currentFloorData.traits, traitContext)
     traitContext = adjustedContext or traitContext
@@ -813,120 +969,20 @@ function Game:setupFloor(floorNum)
     self.transitionTraits = buildModifierSections(self)
 
     Upgrades:applyPersistentEffects(true)
-    traitContext.rockSpawnChance = Rocks:getSpawnChance()
-    traitContext.sawSpeedMult = Saws.speedMult
-    traitContext.sawSpinMult = Saws.spinMult
-    if Saws.getStallOnFruit then
-        traitContext.sawStall = Saws:getStallOnFruit()
-    else
-        traitContext.sawStall = Saws.stallOnFruit or 0
-    end
-    traitContext.conveyors = numConveyors
+
+    finalizeTraitContext(traitContext, numConveyors)
     Upgrades:notify("floorStart", { floor = floorNum, context = traitContext })
 
-    -- Spawn saws FIRST so they reserve their track cells
     local halfTiles = math.floor((TRACK_LENGTH / Arena.tileSize) / 2)
-    local bladeRadius = 16 -- blade radius
+    local bladeRadius = 16
 
-    for _ = 1, numSaws do
-        local dir = (love.math.random() < 0.5) and "horizontal" or "vertical"
-        local placed = false
-        local attempts = 0
-        local maxAttempts = 60
-
-        while not placed and attempts < maxAttempts do
-            attempts = attempts + 1
-
-            if dir == "horizontal" then
-                local row = love.math.random(2, Arena.rows - 1)
-                local col = love.math.random(1 + halfTiles, Arena.cols - halfTiles)
-                local fx, fy = Arena:getCenterOfTile(col, row)
-
-                if SnakeUtils.trackIsFree(fx, fy, "horizontal", TRACK_LENGTH) then
-                    Saws:spawn(fx, fy, bladeRadius, 8, "horizontal")
-                    SnakeUtils.occupySawTrack(fx, fy, "horizontal", bladeRadius, TRACK_LENGTH)
-                    placed = true
-                end
-            else
-                local side = (love.math.random() < 0.5) and "left" or "right"
-                local col = (side == "left") and 1 or Arena.cols
-                local row = love.math.random(1 + halfTiles, Arena.rows - halfTiles)
-                local fx, fy = Arena:getCenterOfTile(col, row)
-
-                if SnakeUtils.trackIsFree(fx, fy, "vertical", TRACK_LENGTH) then
-                    Saws:spawn(fx, fy, bladeRadius, 8, "vertical", side)
-                    SnakeUtils.occupySawTrack(fx, fy, "vertical", bladeRadius, TRACK_LENGTH, side)
-                    placed = true
-                end
-            end
-        end
-    end
-
-    -- Conveyors fill in around the existing hazards without blocking saw placement
-    local conveyorTrackLength = TRACK_LENGTH
-    local horizontalConveyorPossible = (1 + halfTiles) <= (Arena.cols - halfTiles)
-    local verticalConveyorPossible = (1 + halfTiles) <= (Arena.rows - halfTiles)
-    for _ = 1, numConveyors do
-        local placed = false
-        local attempts = 0
-        local maxAttempts = 60
-
-        while not placed and attempts < maxAttempts do
-            attempts = attempts + 1
-            local dir
-            if horizontalConveyorPossible and verticalConveyorPossible then
-                dir = (love.math.random() < 0.5) and "horizontal" or "vertical"
-            elseif horizontalConveyorPossible then
-                dir = "horizontal"
-            elseif verticalConveyorPossible then
-                dir = "vertical"
-            else
-                break
-            end
-
-            if dir == "horizontal" then
-                local minCol = 1 + halfTiles
-                local maxCol = Arena.cols - halfTiles
-                local col = love.math.random(minCol, maxCol)
-                local row = love.math.random(1, Arena.rows)
-                local fx, fy = Arena:getCenterOfTile(col, row)
-
-                if SnakeUtils.trackIsFree(fx, fy, dir, conveyorTrackLength) then
-                    Conveyors:spawn(fx, fy, dir, conveyorTrackLength)
-                    SnakeUtils.occupyTrack(fx, fy, dir, conveyorTrackLength)
-                    placed = true
-                end
-            else
-                local col = love.math.random(1, Arena.cols)
-                local rowMin = 1 + halfTiles
-                local rowMax = Arena.rows - halfTiles
-                local row = love.math.random(rowMin, rowMax)
-                local fx, fy = Arena:getCenterOfTile(col, row)
-
-                if SnakeUtils.trackIsFree(fx, fy, dir, conveyorTrackLength) then
-                    Conveyors:spawn(fx, fy, dir, conveyorTrackLength)
-                    SnakeUtils.occupyTrack(fx, fy, dir, conveyorTrackLength)
-                    placed = true
-                end
-            end
-        end
-    end
-
-    -- Now spawn rocks
-    for i = 1, numRocks do
-        local fx, fy = SnakeUtils.getSafeSpawn(Snake:getSegments(), Fruit, Rocks, safeZone)
-        if fx then
-            Rocks:spawn(fx, fy, "small")
-            local c, r = Arena:getTileFromWorld(fx, fy)
-            SnakeUtils.setOccupied(c, r, true)
-        end
-    end
+    spawnSaws(numSaws, halfTiles, bladeRadius)
+    spawnConveyors(numConveyors, halfTiles)
+    spawnRocks(numRocks, safeZone)
 
     Fruit:spawn(Snake:getSegments(), Rocks, safeZone)
 
     SnakeUtils.releaseCells(reservedCells)
-
-    --FloatingText:add("Floor " .. floorNum, self.screenWidth/2, self.screenHeight/2, {1,1,0}, 2)
 end
 
 function Game:draw()


### PR DESCRIPTION
## Summary
- extract helper functions in `game.lua` to apply palettes, reset entities, prepare occupancy, and spawn hazards
- simplify `Game:setupFloor` to use the new helpers for trait setup and hazard spawning

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc53055750832fb7c0a8be53d9f87f