### PR TITLE
Refactor game preparation helpers

### DIFF
--- a/gameutils.lua
+++ b/gameutils.lua
@@ -13,22 +13,30 @@ local UI = require("ui")
 
 local GameUtils = {}
 
+local function loadCoreSystems(sw, sh)
+    Snake:load(sw, sh)
+    Snake:resetModifiers()
+    PauseMenu:load(sw, sh)
+end
+
+local function resetGameplaySystems()
+    Movement:reset()
+    Score:reset()
+    FloatingText:reset()
+    Particles:reset()
+    Rocks:reset()
+    Conveyors:reset()
+    Saws:reset()
+    UI:reset()
+end
+
 function GameUtils:prepareGame(sw, sh)
-        Snake:load(sw, sh)
-        Snake:resetModifiers()
-        PauseMenu:load(sw, sh)
-        Movement:reset()
-        Score:reset()
-        FloatingText:reset()
-        Particles:reset()
-        Rocks:reset()
-        Conveyors:reset()
-        Saws:reset()
-        UI:reset()
+    loadCoreSystems(sw, sh)
+    resetGameplaySystems()
 
-        --SnakeUtils.initOccupancy()
+    --SnakeUtils.initOccupancy()
 
-        Fruit:spawn(Snake:getSegments(), Rocks, Snake:getSafeZone(3))
+    Fruit:spawn(Snake:getSegments(), Rocks, Snake:getSafeZone(3))
 end
 
 return GameUtils


### PR DESCRIPTION
## Summary
- extract dedicated helpers for loading core systems and resetting gameplay subsystems
- use the new helpers from `GameUtils:prepareGame` to simplify the setup flow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc59e29244832f89db0d04636d755c