### PR TITLE
Refactor audio source loading

### DIFF
--- a/audio.lua
+++ b/audio.lua
@@ -6,34 +6,59 @@ local Audio = {
     currentMusic = nil,
 }
 
-function Audio:load()
-    -- Sound Effects
-    self.sounds.fruit = love.audio.newSource("Assets/Sounds/drop_003.ogg", "static")
-    self.sounds.hover = love.audio.newSource("Assets/Sounds/tick_002.ogg", "static")
-    self.sounds.click = love.audio.newSource("Assets/Sounds/select.ogg", "static")
-    self.sounds.achievement = love.audio.newSource("Assets/Sounds/Retro Event Acute 11.wav", "static")
-    self.sounds.shield_gain = love.audio.newSource("Assets/Sounds/switch_001.ogg", "static")
-    self.sounds.shield_break = love.audio.newSource("Assets/Sounds/abs-cancel-1.wav", "static")
-    self.sounds.death = love.audio.newSource("Assets/Sounds/error_007.ogg", "static")
-    self.sounds.exit_spawn = love.audio.newSource("Assets/Sounds/toggle_001.ogg", "static")
-    self.sounds.exit_enter = love.audio.newSource("Assets/Sounds/abs-confirm-1.wav", "static")
-    self.sounds.floor_advance = love.audio.newSource("Assets/Sounds/Retro PickUp 18.wav", "static")
-    --self.sounds.floor_intro = love.audio.newSource("Assets/Sounds/Retro Event Acute 08.wav", "static")
-    self.sounds.shop_open = love.audio.newSource("Assets/Sounds/apple.wav", "static")
-    self.sounds.shop_focus = love.audio.newSource("Assets/Sounds/paper.wav", "static")
-    self.sounds.shop_card_deal = love.audio.newSource("Assets/Sounds/deal1.ogg", "static")
-    self.sounds.shop_card_select = love.audio.newSource("Assets/Sounds/deal2.ogg", "static")
-    self.sounds.shop_purchase = love.audio.newSource("Assets/Sounds/paper.wav", "static")
-    self.sounds.goal_reached = love.audio.newSource("Assets/Sounds/harp strum 5.wav", "static")
-    self.sounds.wall_portal = love.audio.newSource("Assets/Sounds/Glyph Activation Light 01.wav", "static")
-    self.sounds.shield_wall = love.audio.newSource("Assets/Sounds/Activate Glyph Forcefield.wav", "static")
-    self.sounds.shield_rock = love.audio.newSource("Assets/Sounds/Rotate Stone 03.wav", "static")
-    self.sounds.shield_saw = love.audio.newSource("Assets/Sounds/Arcane Wind Chime Gust.wav", "static")
+local SOUND_DEFINITIONS = {
+    fruit = "Assets/Sounds/drop_003.ogg",
+    hover = "Assets/Sounds/tick_002.ogg",
+    click = "Assets/Sounds/select.ogg",
+    achievement = "Assets/Sounds/Retro Event Acute 11.wav",
+    shield_gain = "Assets/Sounds/switch_001.ogg",
+    shield_break = "Assets/Sounds/abs-cancel-1.wav",
+    death = "Assets/Sounds/error_007.ogg",
+    exit_spawn = "Assets/Sounds/toggle_001.ogg",
+    exit_enter = "Assets/Sounds/abs-confirm-1.wav",
+    floor_advance = "Assets/Sounds/Retro PickUp 18.wav",
+    --floor_intro = "Assets/Sounds/Retro Event Acute 08.wav", -- currently unused
+    shop_open = "Assets/Sounds/apple.wav",
+    shop_focus = "Assets/Sounds/paper.wav",
+    shop_card_deal = "Assets/Sounds/deal1.ogg",
+    shop_card_select = "Assets/Sounds/deal2.ogg",
+    shop_purchase = "Assets/Sounds/paper.wav",
+    goal_reached = "Assets/Sounds/harp strum 5.wav",
+    wall_portal = "Assets/Sounds/Glyph Activation Light 01.wav",
+    shield_wall = "Assets/Sounds/Activate Glyph Forcefield.wav",
+    shield_rock = "Assets/Sounds/Rotate Stone 03.wav",
+    shield_saw = "Assets/Sounds/Arcane Wind Chime Gust.wav",
+}
 
-    -- Music Tracks
-    self.musicTracks.menu = love.audio.newSource("Assets/Music/Menu2.ogg", "stream")
-    self.musicTracks.game = love.audio.newSource("Assets/Music/Game2.ogg", "stream")
-    self.musicTracks.scorescreen = love.audio.newSource("Assets/Music/Scorescreen.ogg", "stream")
+local MUSIC_DEFINITIONS = {
+    menu = "Assets/Music/Menu2.ogg",
+    game = "Assets/Music/Game2.ogg",
+    scorescreen = "Assets/Music/Scorescreen.ogg",
+}
+
+local function loadSources(definitions, defaultType)
+    local sources = {}
+
+    for name, spec in pairs(definitions) do
+        local path = spec
+        local sourceType = defaultType
+
+        if type(spec) == "table" then
+            path = spec.path or spec[1]
+            sourceType = spec.type or spec[2] or defaultType
+        end
+
+        if path then
+            sources[name] = love.audio.newSource(path, sourceType)
+        end
+    end
+
+    return sources
+end
+
+function Audio:load()
+    self.sounds = loadSources(SOUND_DEFINITIONS, "static")
+    self.musicTracks = loadSources(MUSIC_DEFINITIONS, "stream")
 
     for _, track in pairs(self.musicTracks) do
         track:setLooping(true)


### PR DESCRIPTION
## Summary
- replace the ad-hoc sound initialization with data-driven definitions
- centralize music track loading through the same helper to reduce duplication

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc5abb4e58832fb2445ec5c6713ba2