### PR TITLE
Refactor game transitions and input handling

### DIFF
--- a/systems/gameinput.lua
+++ b/systems/gameinput.lua
@@ -1,0 +1,139 @@
+local Controls = require("controls")
+local PauseMenu = require("pausemenu")
+local Shop = require("shop")
+local Achievements = require("achievements")
+
+local GameInput = {}
+GameInput.__index = GameInput
+
+local directionButtonMap = { dpleft = "left", dpright = "right", dpup = "up", dpdown = "down" }
+local ANALOG_DEADZONE = 0.5
+local axisButtonMap = {
+    leftx = { slot = "horizontal", negative = "dpleft", positive = "dpright" },
+    rightx = { slot = "horizontal", negative = "dpleft", positive = "dpright" },
+    lefty = { slot = "vertical", negative = "dpup", positive = "dpdown" },
+    righty = { slot = "vertical", negative = "dpup", positive = "dpdown" },
+    [1] = { slot = "horizontal", negative = "dpleft", positive = "dpright" },
+    [2] = { slot = "vertical", negative = "dpup", positive = "dpdown" },
+}
+
+local buttonAliases = {
+    a = "dash",
+    rightshoulder = "dash",
+    righttrigger = "dash",
+    x = "slow",
+    leftshoulder = "slow",
+    lefttrigger = "slow",
+}
+
+local playingButtonHandlers = {
+    start = function(game)
+        if game.state == "playing" then
+            game.state = "paused"
+        end
+    end,
+    dash = function(game)
+        if game.state == "playing" then
+            Controls:keypressed(game, "space")
+        end
+    end,
+    slow = function(game)
+        if game.state == "playing" then
+            Controls:keypressed(game, "lshift")
+        end
+    end,
+}
+
+local function resolvePlayingAction(button)
+    return buttonAliases[button] or button
+end
+
+function GameInput.new(game, transition)
+    return setmetatable({
+        game = game,
+        transition = transition,
+        axisState = { horizontal = nil, vertical = nil },
+    }, GameInput)
+end
+
+function GameInput:resetAxes()
+    self.axisState.horizontal = nil
+    self.axisState.vertical = nil
+end
+
+function GameInput:applyPauseMenuSelection(selection)
+    if selection == "resume" then
+        self.game.state = "playing"
+    elseif selection == "menu" then
+        Achievements:save()
+        return "menu"
+    end
+end
+
+function GameInput:handlePauseMenuInput(button)
+    if button == "start" then
+        return self:applyPauseMenuSelection("resume")
+    end
+
+    local action = PauseMenu:gamepadpressed(nil, button)
+    if action then
+        return self:applyPauseMenuSelection(action)
+    end
+end
+
+function GameInput:handlePlayingButton(button)
+    local direction = directionButtonMap[button]
+    if direction then
+        Controls:keypressed(self.game, direction)
+        return
+    end
+
+    local handler = playingButtonHandlers[resolvePlayingAction(button)]
+    if handler then
+        return handler(self.game)
+    end
+end
+
+function GameInput:handleGamepadButton(button)
+    if self.transition:handleShopInput("gamepadpressed", nil, button) then
+        return
+    end
+
+    if self.game.state == "paused" then
+        return self:handlePauseMenuInput(button)
+    end
+
+    return self:handlePlayingButton(button)
+end
+
+function GameInput:handleGamepadAxis(axis, value)
+    if self.transition:isShopActive() and Shop.gamepadaxis then
+        Shop:gamepadaxis(nil, axis, value)
+    end
+
+    local config = axisButtonMap[axis]
+    if not config then
+        return
+    end
+
+    local state = self.axisState
+    local direction
+    if value >= ANALOG_DEADZONE then
+        direction = config.positive
+    elseif value <= -ANALOG_DEADZONE then
+        direction = config.negative
+    end
+
+    if state[config.slot] ~= direction then
+        state[config.slot] = direction
+        if direction then
+            self:handleGamepadButton(direction)
+        end
+    end
+end
+
+function GameInput:handleShopInput(methodName, ...)
+    return self.transition:handleShopInput(methodName, ...)
+end
+
+return GameInput

--- a/systems/transitionmanager.lua
+++ b/systems/transitionmanager.lua
@@ -1,0 +1,236 @@
+local Audio = require("audio")
+local Floors = require("floors")
+local SessionStats = require("sessionstats")
+local PlayerStats = require("playerstats")
+local Shop = require("shop")
+
+local TransitionManager = {}
+TransitionManager.__index = TransitionManager
+
+local function shallowCopy(values)
+    local copy = {}
+    if not values then
+        return copy
+    end
+
+    for key, value in pairs(values) do
+        copy[key] = value
+    end
+
+    return copy
+end
+
+function TransitionManager.new(game)
+    return setmetatable({
+        game = game,
+        phase = nil,
+        timer = 0,
+        duration = 0,
+        data = {},
+        shopCloseRequested = false,
+    }, TransitionManager)
+end
+
+function TransitionManager:reset()
+    self.phase = nil
+    self.timer = 0
+    self.duration = 0
+    self.data = {}
+    self.shopCloseRequested = false
+end
+
+function TransitionManager:isActive()
+    return self.phase ~= nil
+end
+
+function TransitionManager:isShopActive()
+    return self.phase == "shop"
+end
+
+function TransitionManager:getPhase()
+    return self.phase
+end
+
+function TransitionManager:getTimer()
+    return self.timer
+end
+
+function TransitionManager:getDuration()
+    return self.duration
+end
+
+function TransitionManager:getData()
+    return self.data
+end
+
+function TransitionManager:setData(values)
+    self.data = shallowCopy(values)
+end
+
+function TransitionManager:mergeData(values)
+    if not values then
+        return
+    end
+
+    for key, value in pairs(values) do
+        self.data[key] = value
+    end
+end
+
+function TransitionManager:startPhase(phase, duration)
+    self.game.state = "transition"
+    self.phase = phase
+    self.timer = 0
+    self.duration = duration or 0
+end
+
+function TransitionManager:clearPhase()
+    self.phase = nil
+    self.timer = 0
+    self.duration = 0
+end
+
+function TransitionManager:openShop()
+    Shop:start(self.game.floor)
+    self.shopCloseRequested = false
+    self.phase = "shop"
+    self.timer = 0
+    self.duration = 0
+    Audio:playSound("shop_open")
+end
+
+function TransitionManager:startFloorIntro(duration, extra)
+    extra = shallowCopy(extra)
+    if not extra.transitionResumePhase then
+        extra.transitionResumePhase = "fadein"
+    end
+
+    if extra.transitionResumePhase == "fadein" and not extra.transitionResumeFadeDuration then
+        extra.transitionResumeFadeDuration = 1.2
+    elseif extra.transitionResumePhase ~= "fadein" then
+        extra.transitionResumeFadeDuration = nil
+    end
+
+    self:mergeData(extra)
+    self:startPhase("floorintro", duration or 3.5)
+    Audio:playSound("floor_intro")
+end
+
+function TransitionManager:startFadeIn(duration)
+    self:startPhase("fadein", duration or 1.2)
+end
+
+function TransitionManager:startFloorTransition(advance, skipFade)
+    local game = self.game
+
+    local pendingFloor = advance and (game.floor + 1) or nil
+    local floorData = Floors[pendingFloor or game.floor] or Floors[1]
+
+    if advance then
+        local floorTime = game.floorTimer or 0
+        if floorTime and floorTime > 0 then
+            SessionStats:add("totalFloorTime", floorTime)
+            SessionStats:updateMin("fastestFloorClear", floorTime)
+            SessionStats:updateMax("slowestFloorClear", floorTime)
+            SessionStats:set("lastFloorClearTime", floorTime)
+        end
+        game.floorTimer = 0
+
+        local currentFloor = game.floor or 1
+        local nextFloor = currentFloor + 1
+        PlayerStats:add("floorsCleared", 1)
+        PlayerStats:updateMax("deepestFloorReached", nextFloor)
+        SessionStats:add("floorsCleared", 1)
+        SessionStats:updateMax("deepestFloorReached", nextFloor)
+        Audio:playSound("floor_advance")
+    end
+
+    self:setData({
+        transitionAdvance = advance,
+        pendingFloor = pendingFloor,
+        transitionFloorData = floorData,
+        floorApplied = false,
+    })
+
+    self.shopCloseRequested = false
+    self:startPhase("fadeout", skipFade and 0 or 1.2)
+end
+
+function TransitionManager:update(dt)
+    if not self:isActive() then
+        return
+    end
+
+    self.timer = self.timer + dt
+    local phase = self.phase
+
+    if phase == "fadeout" then
+        if self.timer >= self.duration then
+            local data = self.data
+            if data.transitionAdvance and not data.floorApplied and data.pendingFloor then
+                self.game.floor = data.pendingFloor
+                self.game:setupFloor(self.game.floor)
+                data.floorApplied = true
+            end
+
+            self:openShop()
+        end
+        return
+    end
+
+    if phase == "shop" then
+        Shop:update(dt)
+        if self.shopCloseRequested and Shop:isSelectionComplete() then
+            self.shopCloseRequested = false
+            self:startFloorIntro()
+        end
+        return
+    end
+
+    if phase == "floorintro" then
+        if self.timer >= self.duration then
+            local data = self.data
+            local resumePhase = data.transitionResumePhase or "fadein"
+            local fadeDuration = data.transitionResumeFadeDuration
+
+            data.transitionResumePhase = nil
+            data.transitionResumeFadeDuration = nil
+
+            if resumePhase == "fadein" then
+                self:startFadeIn(fadeDuration)
+            else
+                self.game.state = "playing"
+                self:clearPhase()
+            end
+        end
+        return
+    end
+
+    if phase == "fadein" then
+        if self.timer >= self.duration then
+            self.game.state = "playing"
+            self:clearPhase()
+        end
+        return
+    end
+end
+
+function TransitionManager:handleShopInput(methodName, ...)
+    if not self:isShopActive() then
+        return false
+    end
+
+    local handler = Shop[methodName]
+    if not handler then
+        return true
+    end
+
+    local result = handler(Shop, ...)
+    if result then
+        self.shopCloseRequested = true
+    end
+
+    return true
+end
+
+return TransitionManager


### PR DESCRIPTION
## Summary
- introduce a transition manager to encapsulate floor/shop/fade sequencing
- add a dedicated game input helper for controller and shop handling
- update the main game state to delegate transition drawing and input forwarding to the new systems

## Testing
- `luac -p game.lua systems/transitionmanager.lua systems/gameinput.lua` *(fails: luac not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc5fbef148832fa5c9795dce3783b5