### PR TITLE
Polish release configuration and settings handling

### DIFF
--- a/conf.lua
+++ b/conf.lua
@@ -1,12 +1,12 @@
 function love.conf(t)
-	t.console = true
-	--t.window.vsync = 0
-	t.window.msaa = 8
-	t.window.stencil = 8
-	t.modules.physics = false
-	t.modules.touch = false
+    t.console = false
+    --t.window.vsync = 0
+    t.window.msaa = 8
+    t.window.stencil = 8
+    t.modules.physics = false
+    t.modules.touch = false
 
-	t.identity = "Noodl Demo"
-	t.window.title = "Noodl Demo"
-	t.window.icon = "Assets/Snake.png"
+    t.identity = "noodl"
+    t.window.title = "Noodl"
+    t.window.icon = "Assets/Snake.png"
 end


### PR DESCRIPTION
## Summary
- turn off the Windows console window and update the identity/title to the final "Noodl" branding
- guard the settings loader against corrupt files and non-table data while preserving defaults
- serialize settings deterministically and fall back to defaults when invalid data is encountered

## Testing
- ⚠️ `luac -p settings.lua` *(command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc64774564832f83366411d57a9534