### PR TITLE
Reset powerup state when runs end

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -153,9 +153,17 @@ function Game:enter()
 end
 
 function Game:leave()
-	if self.mode and self.mode.leave then
-		self.mode.leave(self)
-	end
+        if self.mode and self.mode.leave then
+                self.mode.leave(self)
+        end
+
+        if Snake and Snake.resetModifiers then
+                Snake:resetModifiers()
+        end
+
+        if UI and UI.setUpgradeIndicators then
+                UI:setUpgradeIndicators(nil)
+        end
 end
 
 function Game:beginDeath()

--- a/snake.lua
+++ b/snake.lua
@@ -96,10 +96,7 @@ function Snake:resetModifiers()
     self.stoneSkinSawGrace = 0
     self.dash = nil
     self.timeDilation = nil
-    if self.adrenaline then
-        self.adrenaline.active = false
-        self.adrenaline.timer = 0
-    end
+    self.adrenaline = nil
     UI:setCrashShields(self.crashShields or 0, { silent = true, immediate = true })
 end
 


### PR DESCRIPTION
## Summary
- reset the snake's modifiers when leaving a run and clear the HUD powerup indicators
- drop the adrenaline data during modifier resets so it cannot reactivate in later runs

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd649ca634832f8e7ac5b8d845fa19