### PR TITLE
Adjust arena highlight position

### DIFF
--- a/arena.lua
+++ b/arena.lua
@@ -166,7 +166,7 @@ function Arena:drawBorder()
     love.graphics.rectangle("line", bx, by, bw, bh, radius, radius)
 
     -- Highlight pass for the top + left edges
-    local highlightShift = 1
+    local highlightShift = 3
     local function appendArcPoints(points, cx, cy, radius, startAngle, endAngle, segments, skipFirst)
         if segments < 1 then
             segments = 1


### PR DESCRIPTION
## Summary
- shift the arena highlight drawing 2 pixels further up and left for better alignment

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd6b5430ec832fb3db01166eb0551b