### PR TITLE
Prevent analog stick from snapping snake direction

### DIFF
--- a/gameinput.lua
+++ b/gameinput.lua
@@ -143,7 +143,9 @@ function GameInput:handleGamepadAxis(axis, value)
     local digitalKey = config.slot .. "Digital"
     if state[digitalKey] ~= direction then
         state[digitalKey] = direction
-        if direction then
+
+        local allowDigital = not (self.game.state == "playing" and not self.transition:isShopActive())
+        if allowDigital and direction then
             self:handleGamepadButton(direction)
         end
     end


### PR DESCRIPTION
## Summary
- stop translating analog stick movement into digital button presses while actively playing
- allow the analog vector to drive the snake direction without being overridden by snapped inputs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd94041b30832fa195fb20b2d50547