### PR TITLE
Enable analog keyboard movement

### DIFF
--- a/app.lua
+++ b/app.lua
@@ -123,6 +123,10 @@ function App:keypressed(key)
     return self:forwardEvent("keypressed", key)
 end
 
+function App:keyreleased(key)
+    return self:forwardEvent("keyreleased", key)
+end
+
 function App:joystickpressed(joystick, button)
     return self:forwardEvent("joystickpressed", joystick, button)
 end

--- a/controls.lua
+++ b/controls.lua
@@ -2,19 +2,25 @@ local Snake = require("snake")
 
 local Controls = {}
 
+local analogKeyMap = {
+    up = "up",
+    w = "up",
+    down = "down",
+    s = "down",
+    left = "left",
+    a = "left",
+    right = "right",
+    d = "right",
+}
+
+Controls.analogState = {
+    up = false,
+    down = false,
+    left = false,
+    right = false,
+}
+
 local gameplayKeyHandlers = {
-    up = function()
-        Snake:setDirection("up")
-    end,
-    down = function()
-        Snake:setDirection("down")
-    end,
-    left = function()
-        Snake:setDirection("left")
-    end,
-    right = function()
-        Snake:setDirection("right")
-    end,
     space = function()
         Snake:activateDash()
     end,
@@ -34,10 +40,64 @@ local function togglePause(game)
     end
 end
 
+local function applyAnalogDirection(game)
+    if game and game.state ~= "playing" then
+        return
+    end
+
+    local state = Controls.analogState
+    if not state then
+        return
+    end
+
+    local dx = 0
+    if state.right then
+        dx = dx + 1
+    end
+    if state.left then
+        dx = dx - 1
+    end
+
+    local dy = 0
+    if state.down then
+        dy = dy + 1
+    end
+    if state.up then
+        dy = dy - 1
+    end
+
+    if Snake.reverseState then
+        dx = -dx
+        dy = -dy
+    end
+
+    if dx ~= 0 or dy ~= 0 then
+        Snake:setDirectionVector(dx, dy)
+    end
+end
+
+function Controls:resetAnalog()
+    local state = self.analogState
+    if not state then
+        return
+    end
+
+    state.up = false
+    state.down = false
+    state.left = false
+    state.right = false
+end
+
 function Controls:keypressed(game, key)
     if key == "escape" and game.state ~= "gameover" then
         togglePause(game)
         return
+    end
+
+    local mapped = analogKeyMap[key]
+    if mapped then
+        self.analogState[mapped] = true
+        applyAnalogDirection(game)
     end
 
     if game.state ~= "playing" then
@@ -48,6 +108,16 @@ function Controls:keypressed(game, key)
     if handler then
         handler()
     end
+end
+
+function Controls:keyreleased(game, key)
+    local mapped = analogKeyMap[key]
+    if not mapped then
+        return
+    end
+
+    self.analogState[mapped] = false
+    applyAnalogDirection(game)
 end
 
 return Controls

--- a/game.lua
+++ b/game.lua
@@ -102,6 +102,7 @@ function Game:load()
     self.transition = TransitionManager.new(self)
     self.input = GameInput.new(self, self.transition)
     self.input:resetAxes()
+    Controls:resetAnalog()
 
     self.mode = GameModes:get()
     if self.mode and self.mode.load then
@@ -136,6 +137,7 @@ function Game:reset()
     if self.input then
         self.input:resetAxes()
     end
+    Controls:resetAnalog()
 end
 
 function Game:enter()
@@ -693,6 +695,10 @@ function Game:keypressed(key)
         end
 
         Controls:keypressed(self, key)
+end
+
+function Game:keyreleased(key)
+        Controls:keyreleased(self, key)
 end
 
 function Game:mousepressed(x, y, button)

--- a/gamestate.lua
+++ b/gamestate.lua
@@ -21,6 +21,7 @@ local transitionBlockedEvents = {
     mousepressed = true,
     mousereleased = true,
     keypressed = true,
+    keyreleased = true,
     joystickpressed = true,
     joystickreleased = true,
     joystickaxis = true,

--- a/main.lua
+++ b/main.lua
@@ -14,6 +14,7 @@ local handlers = {
     mousereleased = "mousereleased",
     wheelmoved = "wheelmoved",
     keypressed = "keypressed",
+    keyreleased = "keyreleased",
     joystickpressed = "joystickpressed",
     joystickreleased = "joystickreleased",
     joystickaxis = "joystickaxis",


### PR DESCRIPTION
## Summary
- add keyboard analog state tracking so simultaneous directions produce diagonal movement without snapping
- forward keyreleased events through the app and reset analog state when starting or resetting a run

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd96204d84832fad60a7c8a13975f8