### PR TITLE
Add morphing pulse background effect for Mushroom Grotto

### DIFF
--- a/floors.lua
+++ b/floors.lua
@@ -54,6 +54,9 @@ local Floors = {
             rock       = {0.48, 0.32, 0.55, 1}, -- luminous violet slate
             sawColor   = {0.85, 0.6, 0.9, 1},   -- bright fungal pink-pop
         },
+        backgroundEffect = {
+            type = "mushroomPulse",
+        },
         traits = {"glowingSpores"},
     },
     [4] = {

--- a/floorsetup.lua
+++ b/floorsetup.lua
@@ -247,6 +247,7 @@ end
 
 function FloorSetup.prepare(floorNum, floorData)
     applyPalette(floorData and floorData.palette)
+    Arena:setBackgroundEffect(floorData and floorData.backgroundEffect, floorData and floorData.palette)
     resetFloorEntities()
     local safeZone, reservedCells = prepareOccupancy()
 

--- a/game.lua
+++ b/game.lua
@@ -707,8 +707,13 @@ end
 function Game:draw()
         love.graphics.clear()
 
-        love.graphics.setColor(Theme.bgColor)
-        love.graphics.rectangle("fill", 0, 0, self.screenWidth, self.screenHeight)
+        if Arena.drawBackdrop then
+                Arena:drawBackdrop(self.screenWidth, self.screenHeight)
+        else
+                love.graphics.setColor(Theme.bgColor)
+                love.graphics.rectangle("fill", 0, 0, self.screenWidth, self.screenHeight)
+                love.graphics.setColor(1, 1, 1, 1)
+        end
 
         if self.transition and self.transition:isActive() then
                 self:drawTransition()


### PR DESCRIPTION
## Summary
- add a backgroundEffect flag to Mushroom Grotto and pipe it through the floor setup pipeline
- implement a shader-driven mushroomPulse backdrop that blends palette colours over time for the screen and arena
- draw the new animated backdrop when the effect is active while keeping other floors unchanged

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dda48a8940832fa87a05d01cba0636