### PR TITLE
Fix shader color send argument for mushroom pulse effect

### DIFF
--- a/arena.lua
+++ b/arena.lua
@@ -109,7 +109,7 @@ local function getColorComponents(color, fallback)
         a = 1
     end
 
-    return r, g, b, a
+    return {r, g, b, a}
 end
 
 local function selectGlowColor(palette)


### PR DESCRIPTION
## Summary
- return color components as a table when configuring the mushroom pulse shader
- ensure sendColor receives the expected table argument to avoid runtime errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dda6dcdf88832fb49d8bcbccea4b34