### PR TITLE
Add themed background shaders for each floor

### DIFF
--- a/floors.lua
+++ b/floors.lua
@@ -29,6 +29,11 @@ local Floors = {
                         snake       = {0.12, 0.9, 0.48, 1},  -- vivid spring green snake
                         rock        = {0.74, 0.59, 0.38, 1}, -- sun-baked sandstone, pops from grass
                 },
+                backgroundEffect = {
+                        type = "forestCanopy",
+                        backdropIntensity = 0.65,
+                        arenaIntensity = 0.38,
+                },
                 traits = {"sunlitSanctuary"},
         },
     [2] = {
@@ -40,6 +45,11 @@ local Floors = {
             arenaBorder= {0.2, 0.28, 0.42, 1},  -- cool blue edge
             snake      = {0.6, 0.65, 0.7, 1},   -- pale stone
             rock       = {0.38, 0.43, 0.52, 1}, -- cool steel-blue highlights
+        },
+        backgroundEffect = {
+            type = "echoMist",
+            backdropIntensity = 0.6,
+            arenaIntensity = 0.32,
         },
         traits = {"echoingStillness"},
     },
@@ -56,6 +66,8 @@ local Floors = {
         },
         backgroundEffect = {
             type = "mushroomPulse",
+            backdropIntensity = 0.95,
+            arenaIntensity = 0.62,
         },
         traits = {"glowingSpores"},
     },
@@ -70,6 +82,11 @@ local Floors = {
             rock       = {0.34, 0.55, 0.6, 1},    -- sea-washed teal stone
             sawColor   = {0.5, 0.8, 0.85, 1},    -- oxidized steel
         },
+        backgroundEffect = {
+            type = "tidalCurrent",
+            backdropIntensity = 0.72,
+            arenaIntensity = 0.42,
+        },
         traits = {"waterloggedCatacombs"},
     },
     [5] = {
@@ -82,6 +99,11 @@ local Floors = {
             snake      = {0.95, 0.85, 0.55, 1}, -- faded gold
             rock       = {0.46, 0.38, 0.28, 1},   -- weathered ochre brick
             sawColor   = {0.7, 0.7, 0.75, 1},   -- pale tarnished steel
+        },
+        backgroundEffect = {
+            type = "emberDrift",
+            backdropIntensity = 0.6,
+            arenaIntensity = 0.35,
         },
         traits = {"ancientMachinery", "echoingStillness"},
     },
@@ -96,6 +118,11 @@ local Floors = {
             rock       = {0.45, 0.5, 0.68, 1},   -- frosted indigo crystal
             sawColor   = {0.65, 0.85, 1.0, 1},  -- crystalline edges
         },
+        backgroundEffect = {
+            type = "auroraVeil",
+            backdropIntensity = 0.6,
+            arenaIntensity = 0.4,
+        },
         traits = {"crystallineResonance", "glowingSpores"},
     },
     [7] = {
@@ -108,6 +135,11 @@ local Floors = {
             snake      = {0.86, 0.84, 0.75, 1},  -- ashen ivory
             rock       = {0.63, 0.5, 0.4, 1},  -- bleached bone stacks
             sawColor   = {0.76, 0.62, 0.52, 1},  -- aged bronze
+        },
+        backgroundEffect = {
+            type = "echoMist",
+            backdropIntensity = 0.5,
+            arenaIntensity = 0.28,
         },
         traits = {"boneHarvest"},
     },
@@ -122,6 +154,11 @@ local Floors = {
             rock       = {0.18, 0.23, 0.32, 1},  -- cold navy basalt
             sawColor   = {0.55, 0.25, 0.6, 1},  -- eerie violet shimmer
         },
+        backgroundEffect = {
+            type = "voidPulse",
+            backdropIntensity = 0.68,
+            arenaIntensity = 0.4,
+        },
         traits = {"echoingStillness", "restlessEarth"},
     },
     [9] = {
@@ -134,6 +171,11 @@ local Floors = {
             snake      = {1.0, 0.55, 0.25, 1},  -- ember orange
             rock       = {0.52, 0.22, 0.16, 1},  -- ember-scarred basalt
             sawColor   = {1.0, 0.25, 0.25, 1},  -- glowing hot red
+        },
+        backgroundEffect = {
+            type = "emberDrift",
+            backdropIntensity = 0.65,
+            arenaIntensity = 0.4,
         },
         traits = {"infernalPressure"},
     },
@@ -148,6 +190,11 @@ local Floors = {
             rock       = {0.4, 0.24, 0.32, 1},  -- molten plum glass
             sawColor   = {1.0, 0.35, 0.18, 1},   -- forgefire
         },
+        backgroundEffect = {
+            type = "voidPulse",
+            backdropIntensity = 0.7,
+            arenaIntensity = 0.45,
+        },
         traits = {"obsidianResonance", "infernalPressure"},
     },
     [11] = {
@@ -160,6 +207,11 @@ local Floors = {
             snake      = {0.88, 0.52, 0.28, 1},  -- wind-burnt scales
             rock       = {0.42, 0.28, 0.24, 1},  -- charred copper shale
             sawColor   = {0.95, 0.4, 0.2, 1},    -- cindersteel
+        },
+        backgroundEffect = {
+            type = "emberDrift",
+            backdropIntensity = 0.58,
+            arenaIntensity = 0.34,
         },
         traits = {"ashenTithe", "boneHarvest"},
     },
@@ -174,6 +226,11 @@ local Floors = {
             rock       = {0.4, 0.32, 0.52, 1},   -- spectral amethyst shale
             sawColor   = {0.8, 0.65, 1.0, 1},    -- spirit steel
         },
+        backgroundEffect = {
+            type = "auroraVeil",
+            backdropIntensity = 0.58,
+            arenaIntensity = 0.38,
+        },
         traits = {"spectralEchoes", "glowingSpores"},
     },
     [13] = {
@@ -186,6 +243,11 @@ local Floors = {
             snake      = {0.9, 0.15, 0.25, 1},  -- crimson glow
             rock       = {0.36, 0.24, 0.26, 1}, -- ember-lit ashstone
             sawColor   = {1.0, 0.1, 0.2, 1},    -- hellsteel
+        },
+        backgroundEffect = {
+            type = "voidPulse",
+            backdropIntensity = 0.7,
+            arenaIntensity = 0.44,
         },
         traits = {"ashenTithe", "infernalPressure"},
     },
@@ -200,6 +262,11 @@ local Floors = {
             rock       = {0.62, 0.6, 0.68, 1},   -- pearlescent pillars
             sawColor   = {0.95, 0.7, 0.5, 1},     -- rosy sunlit brass
         },
+        backgroundEffect = {
+            type = "auroraVeil",
+            backdropIntensity = 0.62,
+            arenaIntensity = 0.36,
+        },
         traits = {"divineAscent", "spectralEchoes"},
     },
     [15] = {
@@ -212,6 +279,11 @@ local Floors = {
             snake      = {0.98, 0.85, 0.4, 1},   -- auric serpent
             rock       = {0.55, 0.52, 0.48, 1},  -- dusk-touched marble
             sawColor   = {1.0, 0.65, 0.3, 1},    -- radiant brass
+        },
+        backgroundEffect = {
+            type = "auroraVeil",
+            backdropIntensity = 0.6,
+            arenaIntensity = 0.34,
         },
         traits = {"divineAscent", "crystallineResonance"},
     },

--- a/shaders.lua
+++ b/shaders.lua
@@ -1,0 +1,567 @@
+local Theme = require("theme")
+
+local Shaders = {}
+
+local function getColorComponents(color, fallback)
+    color = color or fallback or {0, 0, 0, 1}
+
+    local r = color[1] or 0
+    local g = color[2] or 0
+    local b = color[3] or 0
+    local a = color[4]
+
+    if a == nil then
+        a = 1
+    end
+
+    return {r, g, b, a}
+end
+
+local function shaderHasUniform(shader, name)
+    if not shader or not shader.hasUniform then
+        return true
+    end
+
+    return shader:hasUniform(name)
+end
+
+local function sendColor(shader, name, color)
+    if shaderHasUniform(shader, name) then
+        shader:sendColor(name, color)
+    end
+end
+
+local function sendVec2(shader, name, value)
+    if shaderHasUniform(shader, name) then
+        shader:send(name, value)
+    end
+end
+
+local function sendFloat(shader, name, value)
+    if shaderHasUniform(shader, name) then
+        shader:send(name, value)
+    end
+end
+
+local function drawShader(effect, x, y, w, h, intensity, sendUniforms)
+    if not (effect and effect.shader) then
+        return false
+    end
+
+    if w <= 0 or h <= 0 then
+        return false
+    end
+
+    local shader = effect.shader
+    local actualIntensity = intensity or 1.0
+
+    if shaderHasUniform(shader, "origin") then
+        shader:send("origin", {x, y})
+    end
+
+    if shaderHasUniform(shader, "resolution") then
+        shader:send("resolution", {w, h})
+    end
+
+    local now = (love.timer and love.timer.getTime and love.timer.getTime()) or 0
+
+    if shaderHasUniform(shader, "time") then
+        shader:send("time", now)
+    end
+
+    if shaderHasUniform(shader, "intensity") then
+        shader:send("intensity", actualIntensity)
+    end
+
+    if sendUniforms then
+        sendUniforms(shader, now, x, y, w, h, actualIntensity)
+    end
+
+    love.graphics.push("all")
+    love.graphics.setShader(shader)
+    love.graphics.setColor(1, 1, 1, 1)
+    love.graphics.rectangle("fill", x, y, w, h)
+    love.graphics.pop()
+
+    return true
+end
+
+local effectDefinitions = {}
+
+local function registerEffect(def)
+    effectDefinitions[def.type] = def
+end
+-- Forest canopy shimmer for lush floors
+registerEffect({
+    type = "forestCanopy",
+    backdropIntensity = 0.75,
+    arenaIntensity = 0.45,
+    source = [[
+        extern float time;
+        extern vec2 resolution;
+        extern vec2 origin;
+        extern vec4 baseColor;
+        extern vec4 lightColor;
+        extern vec4 accentColor;
+        extern float intensity;
+
+        vec4 effect(vec4 color, Image tex, vec2 texture_coords, vec2 screen_coords)
+        {
+            vec2 uv = (screen_coords - origin) / resolution;
+            uv = clamp(uv, 0.0, 1.0);
+
+            float sway = sin((uv.x - 0.5) * 5.5 + time * 0.15) * 0.25 + 0.5;
+            float rays = sin((uv.y * 1.8 + time * 0.1) + cos(uv.x * 6.0)) * 0.3 + 0.5;
+            float mixRay = clamp((sway * 0.6 + rays * 0.4) * intensity, 0.0, 1.0);
+
+            float canopy = smoothstep(0.0, 1.0, 1.0 - uv.y);
+            float vignette = 1.0 - smoothstep(0.4, 0.95, distance(uv, vec2(0.5)));
+
+            vec3 col = mix(baseColor.rgb, lightColor.rgb, mixRay * canopy);
+            col = mix(col, accentColor.rgb, mixRay * 0.2);
+            col = mix(baseColor.rgb, col, clamp(vignette, 0.0, 1.0));
+
+            return vec4(col, baseColor.a) * color;
+        }
+    ]],
+    configure = function(effect, palette)
+        local shader = effect.shader
+
+        local base = getColorComponents(palette and palette.bgColor, Theme.bgColor)
+        local light = getColorComponents(palette and palette.arenaBorder, Theme.arenaBorder)
+        local accent = getColorComponents(palette and palette.snake, Theme.snakeDefault)
+
+        sendColor(shader, "baseColor", base)
+        sendColor(shader, "lightColor", light)
+        sendColor(shader, "accentColor", accent)
+    end,
+    draw = function(effect, x, y, w, h, intensity)
+        return drawShader(effect, x, y, w, h, intensity)
+    end,
+})
+-- Cool cavern mist and echoing shimmer
+registerEffect({
+    type = "echoMist",
+    backdropIntensity = 0.7,
+    arenaIntensity = 0.4,
+    source = [[
+        extern float time;
+        extern vec2 resolution;
+        extern vec2 origin;
+        extern vec4 baseColor;
+        extern vec4 mistColor;
+        extern vec4 accentColor;
+        extern float intensity;
+
+        vec4 effect(vec4 color, Image tex, vec2 texture_coords, vec2 screen_coords)
+        {
+            vec2 uv = (screen_coords - origin) / resolution;
+            uv = clamp(uv, 0.0, 1.0);
+
+            float waveA = sin(uv.y * 4.2 - time * 0.2);
+            float waveB = sin((uv.x + uv.y) * 5.0 + time * 0.15);
+            float layering = mix(waveA, waveB, 0.5);
+            float depth = smoothstep(0.0, 1.0, uv.y);
+            float mist = clamp((layering * 0.25 + 0.5) * intensity, 0.0, 1.0);
+            float glimmer = clamp((sin(uv.x * 10.0 + time * 0.4) * 0.15 + 0.5) * intensity * 0.5, 0.0, 1.0);
+
+            vec3 col = mix(baseColor.rgb, mistColor.rgb, mist * 0.7);
+            col = mix(col, accentColor.rgb, glimmer * (0.3 + depth * 0.2));
+
+            float fade = smoothstep(0.0, 0.6, uv.y);
+            col = mix(baseColor.rgb, col, clamp(fade + 0.15, 0.0, 1.0));
+
+            return vec4(col, baseColor.a) * color;
+        }
+    ]],
+    configure = function(effect, palette)
+        local shader = effect.shader
+
+        local base = getColorComponents(palette and palette.bgColor, Theme.bgColor)
+        local mist = getColorComponents(palette and (palette.arenaBorder or palette.rock), Theme.arenaBorder)
+        local accent = getColorComponents(palette and (palette.snake or palette.sawColor), Theme.snakeDefault)
+
+        sendColor(shader, "baseColor", base)
+        sendColor(shader, "mistColor", mist)
+        sendColor(shader, "accentColor", accent)
+    end,
+    draw = function(effect, x, y, w, h, intensity)
+        return drawShader(effect, x, y, w, h, intensity)
+    end,
+})
+-- Mushroom pulse shader (existing behaviour)
+registerEffect({
+    type = "mushroomPulse",
+    backdropIntensity = 1.0,
+    arenaIntensity = 0.68,
+    source = [[
+        extern float time;
+        extern vec2 resolution;
+        extern vec2 origin;
+        extern vec4 baseColor;
+        extern vec4 accentColor;
+        extern vec4 glowColor;
+        extern float intensity;
+
+        float bloomShape(vec2 p, vec2 center, float sharpness)
+        {
+            vec2 diff = p - center;
+            float distSq = dot(diff, diff);
+            return exp(-distSq * sharpness);
+        }
+
+        vec4 effect(vec4 color, Image tex, vec2 texture_coords, vec2 screen_coords)
+        {
+            vec2 uv = (screen_coords - origin) / resolution;
+            vec2 centered = uv - vec2(0.5);
+
+            float aspect = resolution.x / max(resolution.y, 0.0001);
+            centered.x *= aspect;
+
+            float dist = length(centered);
+
+            float breathing = sin(time * 0.6) * 0.5 + 0.5;
+            float drift = time * 0.35;
+
+            vec2 offset1 = vec2(cos(drift), sin(drift * 0.8)) * (0.18 + 0.08 * intensity);
+            vec2 offset2 = vec2(cos(drift * 1.3 + 2.2), sin(drift * 0.9 + 1.4)) * (0.26 + 0.1 * intensity);
+            vec2 offset3 = vec2(cos(drift * 0.7 - 1.1), sin(drift * 1.1 - 2.4)) * (0.32 + 0.12 * intensity);
+
+            float sharp1 = 10.0 - intensity * 2.0;
+            float sharp2 = 7.5 - intensity * 1.5;
+            float sharp3 = 5.0 - intensity;
+
+            float bloom1 = bloomShape(centered, offset1, sharp1);
+            float bloom2 = bloomShape(centered, offset2, sharp2);
+            float bloom3 = bloomShape(centered, offset3, sharp3);
+
+            float combinedBloom = bloom1 * (0.55 + 0.25 * intensity);
+            combinedBloom += bloom2 * (0.45 + 0.3 * breathing * intensity);
+            combinedBloom += bloom3 * (0.35 + 0.25 * intensity);
+
+            float petalWave = sin((centered.x + centered.y) * 6.0 + time * 0.5);
+            float waveMix = clamp(petalWave * 0.5 + 0.5, 0.0, 1.0) * (0.25 + 0.35 * intensity);
+
+            vec3 base = baseColor.rgb;
+            vec3 accent = mix(base, accentColor.rgb, 0.7);
+            vec3 glow = mix(accentColor.rgb, glowColor.rgb, 0.6);
+
+            float accentMix = clamp(combinedBloom, 0.0, 1.0);
+            float glowMix = clamp(combinedBloom * 0.6 + waveMix, 0.0, 1.0);
+
+            vec3 colorBlend = mix(base, accent, accentMix);
+            colorBlend = mix(colorBlend, glow, glowMix);
+
+            float innerEdge = max(0.12, 0.28 - 0.1 * intensity);
+            float outerEdge = min(0.96, 0.82 + 0.12 * intensity);
+            float vignette = 1.0 - smoothstep(innerEdge, outerEdge, dist + breathing * 0.1 * intensity);
+
+            vec3 finalColor = mix(base, colorBlend, clamp(vignette, 0.0, 1.0));
+
+            return vec4(finalColor, baseColor.a) * color;
+        }
+    ]],
+    configure = function(effect, palette)
+        local shader = effect.shader
+
+        local base = getColorComponents(palette and palette.bgColor, Theme.bgColor)
+        local accent = getColorComponents(palette and palette.arenaBorder, Theme.arenaBorder)
+        local glow = getColorComponents(palette and (palette.snake or palette.sawColor), Theme.snakeDefault)
+
+        sendColor(shader, "baseColor", base)
+        sendColor(shader, "accentColor", accent)
+        sendColor(shader, "glowColor", glow)
+    end,
+    draw = function(effect, x, y, w, h, intensity)
+        return drawShader(effect, x, y, w, h, intensity)
+    end,
+})
+-- Gentle tidal movement for waterlogged floors
+registerEffect({
+    type = "tidalCurrent",
+    backdropIntensity = 0.8,
+    arenaIntensity = 0.5,
+    source = [[
+        extern float time;
+        extern vec2 resolution;
+        extern vec2 origin;
+        extern vec4 baseColor;
+        extern vec4 deepColor;
+        extern vec4 foamColor;
+        extern float intensity;
+
+        vec4 effect(vec4 color, Image tex, vec2 texture_coords, vec2 screen_coords)
+        {
+            vec2 uv = (screen_coords - origin) / resolution;
+            uv = clamp(uv, 0.0, 1.0);
+
+            float wave = sin((uv.x + time * 0.15) * 3.5);
+            float wave2 = sin((uv.x * 4.0 - uv.y * 2.0) + time * 0.12);
+            float ripple = (wave * 0.6 + wave2 * 0.4) * 0.5 + 0.5;
+
+            float depth = smoothstep(0.0, 1.0, uv.y);
+
+            vec3 layer = mix(baseColor.rgb, deepColor.rgb, depth * 0.8 + ripple * 0.2 * intensity);
+            vec3 foam = mix(deepColor.rgb, foamColor.rgb, clamp(ripple * 0.5 + 0.5, 0.0, 1.0));
+            vec3 col = mix(layer, foam, 0.25 * intensity);
+
+            float vignette = 1.0 - smoothstep(0.35, 0.9, distance(uv, vec2(0.5)));
+            col = mix(col, baseColor.rgb, (1.0 - vignette) * 0.6);
+
+            return vec4(col, baseColor.a) * color;
+        }
+    ]],
+    configure = function(effect, palette)
+        local shader = effect.shader
+
+        local base = getColorComponents(palette and palette.bgColor, Theme.bgColor)
+        local deep = getColorComponents(palette and (palette.arenaBorder or palette.rock), Theme.arenaBorder)
+        local foam = getColorComponents(palette and (palette.snake or palette.sawColor), Theme.snakeDefault)
+
+        sendColor(shader, "baseColor", base)
+        sendColor(shader, "deepColor", deep)
+        sendColor(shader, "foamColor", foam)
+    end,
+    draw = function(effect, x, y, w, h, intensity)
+        return drawShader(effect, x, y, w, h, intensity)
+    end,
+})
+-- Ember drift for warm and ashen floors
+registerEffect({
+    type = "emberDrift",
+    backdropIntensity = 0.7,
+    arenaIntensity = 0.42,
+    source = [[
+        extern float time;
+        extern vec2 resolution;
+        extern vec2 origin;
+        extern vec4 baseColor;
+        extern vec4 emberColor;
+        extern vec4 glowColor;
+        extern float intensity;
+
+        vec4 effect(vec4 color, Image tex, vec2 texture_coords, vec2 screen_coords)
+        {
+            vec2 uv = (screen_coords - origin) / resolution;
+            uv = clamp(uv, 0.0, 1.0);
+
+            float drift = time * 0.12;
+            float trail = fract(uv.y + drift);
+            float sparks = sin((uv.x + trail * 2.5) * 12.0);
+            float flicker = sin((uv.x * 10.0) + time * 0.4);
+            float motes = clamp(sin((uv.y + time * 0.3) * 6.0 + uv.x * 2.0) * 0.2 + 0.5, 0.0, 1.0);
+            float ember = clamp((sparks * 0.2 + flicker * 0.1 + motes) * intensity, 0.0, 1.0);
+
+            vec3 col = mix(baseColor.rgb, emberColor.rgb, ember * 0.6);
+            col = mix(col, glowColor.rgb, ember * 0.3);
+
+            float vignette = 1.0 - smoothstep(0.45, 0.95, distance(uv, vec2(0.5)));
+            col = mix(baseColor.rgb, col, vignette);
+
+            return vec4(col, baseColor.a) * color;
+        }
+    ]],
+    configure = function(effect, palette)
+        local shader = effect.shader
+
+        local base = getColorComponents(palette and palette.bgColor, Theme.bgColor)
+        local ember = getColorComponents(palette and (palette.rock or palette.arenaBorder), Theme.rock)
+        local glow = getColorComponents(palette and (palette.snake or palette.sawColor), Theme.snakeDefault)
+
+        sendColor(shader, "baseColor", base)
+        sendColor(shader, "emberColor", ember)
+        sendColor(shader, "glowColor", glow)
+    end,
+    draw = function(effect, x, y, w, h, intensity)
+        return drawShader(effect, x, y, w, h, intensity)
+    end,
+})
+-- Aurora veil for crystalline and celestial floors
+registerEffect({
+    type = "auroraVeil",
+    backdropIntensity = 0.65,
+    arenaIntensity = 0.4,
+    source = [[
+        extern float time;
+        extern vec2 resolution;
+        extern vec2 origin;
+        extern vec4 baseColor;
+        extern vec4 auroraPrimary;
+        extern vec4 auroraSecondary;
+        extern float intensity;
+
+        vec4 effect(vec4 color, Image tex, vec2 texture_coords, vec2 screen_coords)
+        {
+            vec2 uv = (screen_coords - origin) / resolution;
+            uv = clamp(uv, 0.0, 1.0);
+
+            float wave = sin((uv.x * 4.0 + time * 0.12) + sin(uv.y * 3.0) * 0.5);
+            float wave2 = sin((uv.x * 6.0 - uv.y * 2.0) - time * 0.08);
+            float band = clamp((wave * 0.35 + wave2 * 0.25) * intensity + 0.5, 0.0, 1.0);
+            float vertical = smoothstep(0.0, 1.0, uv.y);
+
+            vec3 col = mix(baseColor.rgb, auroraPrimary.rgb, band * 0.7);
+            col = mix(col, auroraSecondary.rgb, band * 0.5 * (0.4 + vertical * 0.6));
+            float glow = smoothstep(0.1, 0.9, band) * 0.3;
+            col += auroraSecondary.rgb * glow * 0.2;
+            col = mix(baseColor.rgb, col, 0.6 + 0.3 * band);
+            col = clamp(col, 0.0, 1.0);
+
+            return vec4(col, baseColor.a) * color;
+        }
+    ]],
+    configure = function(effect, palette)
+        local shader = effect.shader
+
+        local base = getColorComponents(palette and palette.bgColor, Theme.bgColor)
+        local primary = getColorComponents(palette and (palette.arenaBorder or palette.rock), Theme.arenaBorder)
+        local secondary = getColorComponents(palette and (palette.snake or palette.sawColor), Theme.snakeDefault)
+
+        sendColor(shader, "baseColor", base)
+        sendColor(shader, "auroraPrimary", primary)
+        sendColor(shader, "auroraSecondary", secondary)
+    end,
+    draw = function(effect, x, y, w, h, intensity)
+        return drawShader(effect, x, y, w, h, intensity)
+    end,
+})
+-- Void pulse for deep abyssal floors
+registerEffect({
+    type = "voidPulse",
+    backdropIntensity = 0.75,
+    arenaIntensity = 0.48,
+    source = [[
+        extern float time;
+        extern vec2 resolution;
+        extern vec2 origin;
+        extern vec4 baseColor;
+        extern vec4 rimColor;
+        extern vec4 pulseColor;
+        extern float intensity;
+
+        vec4 effect(vec4 color, Image tex, vec2 texture_coords, vec2 screen_coords)
+        {
+            vec2 uv = (screen_coords - origin) / resolution;
+            uv = clamp(uv, 0.0, 1.0);
+
+            float dist = distance(uv, vec2(0.5));
+            float pulse = sin(dist * 6.0 - time * 0.7) * 0.5 + 0.5;
+            float slow = sin(time * 0.25) * 0.5 + 0.5;
+            float rim = smoothstep(0.25, 0.85, dist);
+
+            vec3 col = mix(baseColor.rgb, pulseColor.rgb, pulse * intensity * (1.0 - rim));
+            col = mix(col, rimColor.rgb, (1.0 - rim) * 0.35 + slow * 0.15 * intensity);
+
+            float vignette = smoothstep(0.4, 0.95, dist);
+            col = mix(col, baseColor.rgb, clamp(vignette, 0.0, 1.0));
+
+            return vec4(col, baseColor.a) * color;
+        }
+    ]],
+    configure = function(effect, palette)
+        local shader = effect.shader
+
+        local base = getColorComponents(palette and palette.bgColor, Theme.bgColor)
+        local rim = getColorComponents(palette and (palette.arenaBorder or palette.rock), Theme.arenaBorder)
+        local pulse = getColorComponents(palette and (palette.snake or palette.sawColor), Theme.snakeDefault)
+
+        sendColor(shader, "baseColor", base)
+        sendColor(shader, "rimColor", rim)
+        sendColor(shader, "pulseColor", pulse)
+    end,
+    draw = function(effect, x, y, w, h, intensity)
+        return drawShader(effect, x, y, w, h, intensity)
+    end,
+})
+local function createEffect(def)
+    local shader = love.graphics.newShader(def.source)
+
+    local defaultBackdrop = def.backdropIntensity or 1.0
+    local defaultArena = def.arenaIntensity or 0.6
+
+    local effect = {
+        type = def.type,
+        shader = shader,
+        backdropIntensity = defaultBackdrop,
+        arenaIntensity = defaultArena,
+        defaultBackdropIntensity = defaultBackdrop,
+        defaultArenaIntensity = defaultArena,
+        definition = def,
+    }
+
+    return effect
+end
+
+function Shaders.ensure(cache, typeName)
+    if not typeName then
+        return nil
+    end
+
+    cache = cache or {}
+
+    local effect = cache[typeName]
+    if effect and effect.shader then
+        return effect
+    end
+
+    local def = effectDefinitions[typeName]
+    if not def then
+        return nil
+    end
+
+    local ok, newEffect = pcall(createEffect, def)
+    if not ok then
+        return nil
+    end
+
+    cache[typeName] = newEffect
+    return newEffect
+end
+
+function Shaders.configure(effect, palette, effectData)
+    if not effect then
+        return false
+    end
+
+    local def = effect.definition
+    if not def then
+        return false
+    end
+
+    if def.configure then
+        def.configure(effect, palette, effectData)
+        return true
+    end
+
+    return false
+end
+
+function Shaders.draw(effect, x, y, w, h, intensity)
+    if not effect then
+        return false
+    end
+
+    local def = effect.definition
+    if not def or not def.draw then
+        return false
+    end
+
+    return def.draw(effect, x, y, w, h, intensity)
+end
+
+function Shaders.getDefaultIntensities(effect)
+    if not effect then
+        return 1.0, 0.6
+    end
+
+    local backdrop = effect.defaultBackdropIntensity or effect.backdropIntensity or 1.0
+    local arena = effect.defaultArenaIntensity or effect.arenaIntensity or 0.6
+
+    return backdrop, arena
+end
+
+function Shaders.has(typeName)
+    return effectDefinitions[typeName] ~= nil
+end
+
+return Shaders


### PR DESCRIPTION
## Summary
- add a reusable shaders module with multiple soft background effects that match each biome
- update the arena to use the shader manager and draw effects for the backdrop and playfield
- assign thematic background effects to every floor definition with gentle intensities

## Testing
- luac -p arena.lua *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ddaaf46cc0832fa2bdf73cf35b5926