### PR TITLE
Expand background ambience to screen bounds

### DIFF
--- a/backgroundambience.lua
+++ b/backgroundambience.lua
@@ -909,7 +909,8 @@ function BackgroundAmbience.draw(arena)
         return
     end
 
-    local x, y, w, h = arena:getBounds()
+    local screenWidth, screenHeight = love.graphics.getDimensions()
+    local x, y, w, h = 0, 0, screenWidth, screenHeight
     local bounds = state.bounds or {}
 
     if not state.shapes or not bounds or bounds.w ~= w or bounds.h ~= h or bounds.x ~= x or bounds.y ~= y then


### PR DESCRIPTION
## Summary
- update the background ambience renderer to use the full screen dimensions so themed shapes stretch across the display

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddf4291e60832fbaf80593ca9c411c