### PR TITLE
Add blooming shader effect to the main menu

### DIFF
--- a/menu.lua
+++ b/menu.lua
@@ -21,7 +21,7 @@ local funChallenge = nil
 local funChallengeAnim = 0
 local analogAxisDirections = { horizontal = nil, vertical = nil }
 
-local BACKGROUND_EFFECT_TYPE = "menuBreeze"
+local BACKGROUND_EFFECT_TYPE = "menuBloom"
 local backgroundEffectCache = {}
 local backgroundEffect = nil
 


### PR DESCRIPTION
## Summary
- add a new menuBloom shader that renders a soft, petal-inspired bloom for the menu backdrop
- switch the title screen to use the blooming shader for a more subtle presentation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de02068ddc832f890c0e365c8c3b5b