### PR TITLE
Restore Verdant Garden bloom and disable extra background shapes

### DIFF
--- a/backgroundambience.lua
+++ b/backgroundambience.lua
@@ -956,6 +956,11 @@ function BackgroundAmbience.configure(floorData)
         return
     end
 
+    local shapesEnabled = false
+    if floorData and floorData.name then
+        shapesEnabled = floorData.name:lower() == "echoing caverns"
+    end
+
     BackgroundAmbience.current = {
         theme = theme,
         variant = variant or floorData.backgroundVariant,
@@ -963,6 +968,7 @@ function BackgroundAmbience.configure(floorData)
         seed = computeSeed(floorData),
         shapes = nil,
         bounds = nil,
+        shapesEnabled = shapesEnabled,
     }
 end
 
@@ -984,6 +990,10 @@ end
 function BackgroundAmbience.draw(arena)
     local state = BackgroundAmbience.current
     if not state then
+        return
+    end
+
+    if not state.shapesEnabled then
         return
     end
 

--- a/shaders.lua
+++ b/shaders.lua
@@ -122,16 +122,20 @@ registerEffect({
 
             vec3 col = baseColor.rgb;
 
-            float canopyLight = smoothstep(0.35, 0.0, uv.y);
-            col = mix(col, lightColor.rgb, canopyLight * 0.3 * intensity);
+            float canopyLight = smoothstep(0.55, 0.0, uv.y);
+            col = mix(col, lightColor.rgb, canopyLight * 0.2 * intensity);
+
+            float bloomMask = smoothstep(0.6, 0.18, distance(uv, vec2(0.5, 0.35)));
+            vec3 bloomColor = mix(lightColor.rgb, accentColor.rgb, 0.25);
+            col += bloomColor * bloomMask * 0.12 * intensity;
 
             for (int i = 0; i < 3; ++i)
             {
                 float fi = float(i);
-                float density = 3.0 + fi * 2.2;
-                float speed = 0.05 + fi * 0.035;
-                float size = 0.22 - fi * 0.05;
-                float layerStrength = 0.22 + fi * 0.1;
+                float density = 2.6 + fi * 2.0;
+                float speed = 0.04 + fi * 0.03;
+                float size = 0.2 - fi * 0.045;
+                float layerStrength = 0.18 + fi * 0.08;
 
                 vec2 grid = (uv + vec2(0.0, time * speed)) * density;
                 vec2 cell = floor(grid);
@@ -141,11 +145,13 @@ registerEffect({
                 float d = distance(cellUV, rand);
                 float particle = exp(-d * d / (size * size + 1e-5));
 
-                vec3 glowColor = mix(lightColor.rgb, accentColor.rgb, 0.35 + fi * 0.25);
-                col = mix(col, glowColor, clamp(particle * layerStrength * intensity, 0.0, 1.0));
+                vec3 glowColor = mix(lightColor.rgb, accentColor.rgb, 0.3 + fi * 0.22);
+                float softness = smoothstep(0.0, 1.0, 1.0 - d * 1.3);
+                float blend = clamp(particle * layerStrength * intensity * (0.6 + softness * 0.4), 0.0, 1.0);
+                col = mix(col, glowColor, blend);
             }
 
-            float vignette = smoothstep(0.95, 0.45, distance(uv, vec2(0.5)));
+            float vignette = smoothstep(0.92, 0.48, distance(uv, vec2(0.5)));
             col = mix(baseColor.rgb, col, clamp(vignette, 0.0, 1.0));
 
             return vec4(col, baseColor.a) * color;


### PR DESCRIPTION
## Summary
- tune the Verdant Garden forest canopy shader to add soft bloom and reduce harsh highlights
- gate background ambience shape rendering so only Echoing Caverns retains the layered silhouettes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de04b675d0832fac718632175fe8fc