### PR TITLE
Add ruin motes shader for Ancient Ruins floor

### DIFF
--- a/floors.lua
+++ b/floors.lua
@@ -106,9 +106,9 @@ local Floors = {
             sawColor   = {0.7, 0.7, 0.75, 1},   -- pale tarnished steel
         },
         backgroundEffect = {
-            type = "emberDrift",
-            backdropIntensity = 0.6,
-            arenaIntensity = 0.35,
+            type = "ruinMotes",
+            backdropIntensity = 0.58,
+            arenaIntensity = 0.32,
         },
         backgroundTheme = "machine",
         traits = {"ancientMachinery", "echoingStillness"},


### PR DESCRIPTION
## Summary
- add a simpler `ruinMotes` background shader with dust motes tuned to the Ancient Ruins palette
- switch the Ancient Ruins floor to use the new shader and adjust its intensities

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68de05a78760832f916e79ef44dc37f1