### PR TITLE
Fix Stonebreaker Hymn charge display in HUD

### DIFF
--- a/upgrades.lua
+++ b/upgrades.lua
@@ -1532,7 +1532,7 @@ function Upgrades:getHUDIndicators()
                 progress = 1
                 isReady = true
             else
-                progress = clamp(current / rate, 0, 1)
+                progress = clamp(current, 0, 1)
                 if progress >= 0.999 then
                     isReady = true
                 end


### PR DESCRIPTION
## Summary
- correct the Stonebreaker Hymn HUD indicator to track the stored shatter progress directly instead of dividing by the per-fruit rate
- ensure the upgrade only reports "ready" when the stored progress reaches the real charge threshold

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de073f0c20832f9f08f1e5f1c56ccc