### PR TITLE
Increase Titanblood Pact growth penalty

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -497,7 +497,7 @@ local english = {
             },
             titanblood_pact = {
                 name = "Titanblood Pact",
-                description = "Gain +3 crash shields and +2s saw stall duration. Grow by +5 and gain +1 extra growth.",
+                description = "Gain +3 crash shields and +2s saw stall duration. Grow by +5 and gain +2 extra growth.",
             },
             chronospiral_core = {
                 name = "Chronospiral Core",

--- a/upgrades.lua
+++ b/upgrades.lua
@@ -1300,7 +1300,7 @@ local pool = {
             for _ = 1, 5 do
                 Snake:grow()
             end
-            Snake.extraGrowth = (Snake.extraGrowth or 0) + 1
+            Snake.extraGrowth = (Snake.extraGrowth or 0) + 2
         end,
     }),
     register({


### PR DESCRIPTION
## Summary
- increase Titanblood Pact's extra growth penalty to +2 to offset its strong defensive bonuses
- update the English description to match the new tradeoff

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de08e90204832f93bb8e33fad06e72