### PR TITLE
Rename Pocket Springs upgrade and lower fruit threshold

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -371,8 +371,8 @@ local english = {
                 description = "Snake moves 15% slower. The exit unlocks one fruit later.",
             },
             pocket_springs = {
-                name = "Pocket Springs",
-                description = "After collecting thirty fruit, forge a single crash shield charge.",
+                name = "Aegis Winder",
+                description = "After collecting twenty-five fruit, forge a single crash shield charge.",
             },
             mapmakers_compass = {
                 name = "Mapmaker's Compass",

--- a/upgrades.lua
+++ b/upgrades.lua
@@ -18,7 +18,7 @@ local defaultEffects = UpgradeHelpers.defaultEffects
 local celebrateUpgrade = UpgradeHelpers.celebrateUpgrade
 local getEventPosition = UpgradeHelpers.getEventPosition
 
-local POCKET_SPRINGS_FRUIT_TARGET = 30
+local POCKET_SPRINGS_FRUIT_TARGET = 25
 
 local function stoneSkinShieldHandler(data, state)
     if not state then return end


### PR DESCRIPTION
## Summary
- rename the Pocket Springs upgrade to Aegis Winder to align with its mechanics
- reduce the fruit requirement for triggering the crash shield to 25 and update the localization copy

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de0ddb912c832fb6e9afa834860e5a