### PR TITLE
Redesign mode select screen with softer styling

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -104,9 +104,11 @@ local english = {
         },
         modeselect = {
             title = "Select Game Mode",
+            tagline = "Find the vibe for your next run.",
             locked_prefix = "Locked — ${description}",
             back_to_menu = "Back to Menu",
             high_score = "High Score: ${score}",
+            launch_button = "Play ${mode}",
         },
         achievements = {
             title = "Achievements",

--- a/modeselect.lua
+++ b/modeselect.lua
@@ -16,6 +16,56 @@ local ANALOG_DEADZONE = 0.35
 local buttonList = ButtonList.new()
 local analogAxisDirections = { horizontal = nil, vertical = nil }
 
+local function clamp01(value)
+    if value < 0 then
+        return 0
+    elseif value > 1 then
+        return 1
+    end
+    return value
+end
+
+local function lighten(color, amount, alpha)
+    local r = color[1] or 0
+    local g = color[2] or 0
+    local b = color[3] or 0
+    local a = alpha or color[4] or 1
+
+    amount = clamp01(amount or 0)
+
+    return {
+        clamp01(r + (1 - r) * amount),
+        clamp01(g + (1 - g) * amount),
+        clamp01(b + (1 - b) * amount),
+        clamp01(a),
+    }
+end
+
+local function darken(color, amount, alpha)
+    local r = color[1] or 0
+    local g = color[2] or 0
+    local b = color[3] or 0
+    local a = alpha or color[4] or 1
+
+    amount = clamp01(amount or 0)
+
+    return {
+        clamp01(r * (1 - amount)),
+        clamp01(g * (1 - amount)),
+        clamp01(b * (1 - amount)),
+        clamp01(a),
+    }
+end
+
+local function withAlpha(color, alpha)
+    return {
+        color[1] or 0,
+        color[2] or 0,
+        color[3] or 0,
+        (color[4] or 1) * (alpha or 1),
+    }
+end
+
 local BACKGROUND_EFFECT_TYPE = "modeRibbon"
 local backgroundEffectCache = {}
 local backgroundEffect = nil
@@ -51,6 +101,14 @@ local function drawBackground(sw, sh)
         local intensity = backgroundEffect.backdropIntensity or select(1, Shaders.getDefaultIntensities(backgroundEffect))
         Shaders.draw(backgroundEffect, 0, 0, sw, sh, intensity)
     end
+
+    local softGlow = lighten(Theme.progressColor or {1, 1, 1, 1}, 0.35, 0.08)
+    love.graphics.setColor(softGlow)
+    love.graphics.circle("fill", sw * 0.22, sh * 0.18, sw * 0.35)
+    love.graphics.circle("fill", sw * 0.78, sh * 0.72, sw * 0.42)
+
+    love.graphics.setColor(1, 1, 1, 0.04)
+    love.graphics.rectangle("fill", 0, 0, sw, sh)
 
     love.graphics.setColor(1, 1, 1, 1)
 end
@@ -126,11 +184,16 @@ function ModeSelect:enter()
     local sw, sh = Screen:get()
     local centerX = sw / 2
 
-    local buttonWidth = math.min(600, sw - 100)
-    local buttonHeight = 90
-    local spacing = 20
-    local x = centerX - buttonWidth / 2
-    local y = 160
+    local cardWidth = math.min(720, sw - 160)
+    local buttonWidth = cardWidth - 64
+    local buttonHeight = 72
+    local cardPaddingX = 32
+    local cardPaddingY = 32
+    local extraContentHeight = 96
+    local cardHeight = cardPaddingY * 2 + extraContentHeight + buttonHeight
+    local spacing = 26
+    local x = centerX - cardWidth / 2 + cardPaddingX
+    local y = 180
 
     local defs = {}
 
@@ -144,11 +207,10 @@ function ModeSelect:enter()
         defs[#defs + 1] = {
             id = "mode_" .. key,
             x = x,
-            y = y,
+            y = y + cardHeight - cardPaddingY - buttonHeight,
             w = buttonWidth,
             h = buttonHeight,
-            textKey = mode.labelKey,
-            text = Localization:get(mode.labelKey),
+            text = Localization:get("modeselect.launch_button", { mode = Localization:get(mode.labelKey) }),
             action = nil,
             descriptionKey = descKey,
             unlockDescriptionKey = unlockKey,
@@ -156,15 +218,25 @@ function ModeSelect:enter()
             score = score,
             modeKey = key,
             unlocked = isUnlocked,
+            modeLabelKey = mode.labelKey,
+            card = {
+                x = centerX - cardWidth / 2,
+                y = y,
+                w = cardWidth,
+                h = cardHeight,
+                paddingX = cardPaddingX,
+                paddingY = cardPaddingY,
+                radius = 36,
+            },
         }
 
-        y = y + buttonHeight + spacing
+        y = y + cardHeight + spacing
     end
 
     defs[#defs + 1] = {
         id = "modeBack",
-        x = x,
-        y = y + 10,
+        x = centerX - 110,
+        y = y + 14,
         w = 220,
         h = 44,
         textKey = "modeselect.back_to_menu",
@@ -191,12 +263,21 @@ function ModeSelect:draw()
     love.graphics.setColor(Theme.textColor)
     love.graphics.printf(Localization:get("modeselect.title"), 0, 40, sw, "center")
 
-    for _, btn in buttonList:iter() do
-        if btn.textKey then
-            btn.text = Localization:get(btn.textKey)
-        end
+    love.graphics.setFont(UI.fonts.subtitle)
+    love.graphics.setColor(withAlpha(Theme.mutedTextColor or Theme.textColor, 0.8))
+    love.graphics.printf(Localization:get("modeselect.tagline"), 0, 120, sw, "center")
 
+    local softButtonColor = lighten(Theme.buttonColor, 0.30, 1)
+    local softHoverColor = lighten(Theme.buttonHover or Theme.buttonColor, 0.38, 1)
+    local softPressColor = darken(Theme.buttonPress or Theme.buttonColor, 0.20, 1)
+    local softBorderColor = lighten(Theme.borderColor or Theme.buttonColor, 0.10, 1)
+
+    for _, btn in buttonList:iter() do
         if btn.modeKey ~= "back" then
+            local modeLabel = Localization:get(btn.modeLabelKey or btn.textKey)
+            btn.modeTitle = modeLabel
+            btn.text = Localization:get("modeselect.launch_button", { mode = modeLabel })
+
             if btn.unlocked and btn.descriptionKey then
                 btn.description = Localization:get(btn.descriptionKey)
             else
@@ -208,25 +289,96 @@ function ModeSelect:draw()
                 end
                 btn.description = Localization:get("modeselect.locked_prefix", { description = unlockDescription })
             end
+        elseif btn.textKey then
+            btn.text = Localization:get(btn.textKey)
+        end
+    end
+
+    local previousRadius = UI.spacing.buttonRadius
+    local previousButtonColor = UI.colors.button
+    local previousHoverColor = UI.colors.buttonHover
+    local previousPressColor = UI.colors.buttonPress
+    local previousBorderColor = UI.colors.border
+
+    UI.spacing.buttonRadius = 24
+    UI.colors.button = softButtonColor
+    UI.colors.buttonHover = softHoverColor
+    UI.colors.buttonPress = softPressColor
+    UI.colors.border = softBorderColor
+
+    local function drawModeCard(btn)
+        local card = btn.card
+        if not card then return end
+
+        local x, y = card.x, card.y
+        local w, h = card.w, card.h
+        local radius = card.radius or 32
+
+        love.graphics.setColor(0, 0, 0, 0.28)
+        love.graphics.rectangle("fill", x, y + 6, w, h, radius + 6, radius + 6)
+
+        local baseColor = lighten(Theme.panelColor or Theme.bgColor, 0.32, 0.96)
+        love.graphics.setColor(baseColor)
+        love.graphics.rectangle("fill", x, y, w, h, radius, radius)
+
+        local highlightColor = withAlpha(lighten(baseColor, 0.35, baseColor[4] or 1), 0.35)
+        love.graphics.setColor(highlightColor)
+        love.graphics.rectangle("fill", x, y, w, h * 0.45, radius, radius)
+
+        local accent = withAlpha(lighten(Theme.progressColor or {1, 1, 1, 1}, 0.15, 1), btn.focused and 0.22 or 0.15)
+        love.graphics.setColor(accent)
+        love.graphics.circle("fill", x + w - 96, y + 58, 132)
+        love.graphics.circle("fill", x + 86, y + h - 74, 108)
+
+        love.graphics.setColor(withAlpha(Theme.highlightColor or {1, 1, 1, 1}, 0.35))
+        love.graphics.setLineWidth(2)
+        love.graphics.rectangle("line", x, y, w, h, radius, radius)
+
+        love.graphics.setLineWidth(1)
+    end
+
+    for _, btn in buttonList:iter() do
+        if btn.modeKey ~= "back" then
+            drawModeCard(btn)
         end
     end
 
     buttonList:draw()
 
+    UI.colors.button = previousButtonColor
+    UI.colors.buttonHover = previousHoverColor
+    UI.colors.buttonPress = previousPressColor
+    UI.colors.border = previousBorderColor
+    UI.spacing.buttonRadius = previousRadius
+
     for _, btn in buttonList:iter() do
-        if btn.description and btn.description ~= "" then
+        if btn.modeKey ~= "back" and btn.card then
+            local card = btn.card
+            if btn.description and btn.description ~= "" then
+                love.graphics.setFont(UI.fonts.heading)
+                local titleColor = btn.unlocked and Theme.textColor or Theme.lockedCardColor
+                love.graphics.setColor(titleColor)
+                love.graphics.printf(btn.modeTitle or btn.text or "", card.x + card.paddingX, card.y + card.paddingY, card.w - card.paddingX * 2, "left")
+
+                love.graphics.setFont(UI.fonts.body)
+                local descColor = btn.unlocked and withAlpha(Theme.mutedTextColor or Theme.textColor, 0.85) or withAlpha(Theme.lockedCardColor, 0.9)
+                love.graphics.setColor(descColor)
+                love.graphics.printf(btn.description, card.x + card.paddingX, card.y + card.paddingY + 42, card.w - card.paddingX * 2, "left")
+            end
+
+            if btn.unlocked and btn.score then
+                local scoreText = Localization:get("modeselect.high_score", { score = tostring(btn.score) })
+                love.graphics.setFont(UI.fonts.body)
+                love.graphics.setColor(withAlpha(Theme.progressColor, 0.95))
+                local tw = UI.fonts.body:getWidth(scoreText)
+                local scoreY = card.y + card.h - card.paddingY - btn.h - UI.fonts.body:getHeight() - 12
+                love.graphics.print(scoreText, card.x + card.w - card.paddingX - tw, scoreY)
+            end
+        elseif btn.modeKey == "back" and btn.description and btn.description ~= "" then
             love.graphics.setFont(UI.fonts.body)
             local descColor = btn.unlocked and Theme.textColor or Theme.lockedCardColor
             love.graphics.setColor(descColor)
             love.graphics.printf(btn.description, btn.x + 20, btn.y + btn.h - 32, btn.w - 40, "left")
-        end
-
-        if btn.unlocked and btn.score and btn.modeKey ~= "back" then
-            local scoreText = Localization:get("modeselect.high_score", { score = tostring(btn.score) })
-            love.graphics.setFont(UI.fonts.body)
-            love.graphics.setColor(Theme.progressColor)
-            local tw = UI.fonts.body:getWidth(scoreText)
-            love.graphics.print(scoreText, btn.x + btn.w - tw - 20, btn.y + 12)
         end
     end
 end


### PR DESCRIPTION
## Summary
- wrap each game mode in a soft card layout with updated spacing, call-to-action buttons, and per-card typography
- soften the background and button styling with subtle glow accents while keeping interactions intact
- add localization strings for the new screen tagline and play button label

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de18371e18832fb7035a6d9fd89109