### PR TITLE
Disable floor-specific background shapes

### DIFF
--- a/backgroundambience.lua
+++ b/backgroundambience.lua
@@ -956,11 +956,6 @@ function BackgroundAmbience.configure(floorData)
         return
     end
 
-    local shapesEnabled = false
-    if floorData and floorData.name then
-        shapesEnabled = floorData.name:lower() == "echoing caverns"
-    end
-
     BackgroundAmbience.current = {
         theme = theme,
         variant = variant or floorData.backgroundVariant,
@@ -968,7 +963,7 @@ function BackgroundAmbience.configure(floorData)
         seed = computeSeed(floorData),
         shapes = nil,
         bounds = nil,
-        shapesEnabled = shapesEnabled,
+        shapesEnabled = false,
     }
 end
 


### PR DESCRIPTION
## Summary
- stop enabling background shape rendering for specific floors by defaulting the configuration to shapes disabled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de1cbadf14832fa5c19d44ba43cb5f