### PR TITLE
Handle saw body collisions and penalties

### DIFF
--- a/movement.lua
+++ b/movement.lua
@@ -423,6 +423,10 @@ function Movement:update(dt)
                 return sawState, sawCause
         end
 
+        if Snake.checkSawBodyCollision then
+                Snake:checkSawBodyCollision()
+        end
+
         if Fruit:checkCollisionWith(headX, headY) then
                 return "scored"
         end

--- a/saws.lua
+++ b/saws.lua
@@ -182,6 +182,10 @@ function Saws:getAll()
     return current
 end
 
+function Saws:getCenter(saw)
+    return getSawCenter(saw)
+end
+
 function Saws:reset()
     current = {}
     slots = {}


### PR DESCRIPTION
## Summary
- detect saw hits along the snake body, remove the severed tail, and dock collected fruit and score accordingly
- render the severed body portion as a temporary second segment and keep state tidy across loads
- expose a helper to fetch saw centers and call the new body-cut handler during movement updates

## Testing
- Not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68de1f407930832f8065ff729c3a69f9