### PR TITLE
Refactor game loop helpers and transitions

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -37,11 +37,21 @@ local GameInput = require("gameinput")
 local Game = {}
 
 local clamp01 = Easing.clamp01
-local lerp = Easing.lerp
-local easeInOutCubic = Easing.easeInOutCubic
 local easeOutExpo = Easing.easeOutExpo
 local easeOutBack = Easing.easeOutBack
 local easedProgress = Easing.easedProgress
+
+local function callMode(self, methodName, ...)
+    local mode = self.mode
+    if not mode then
+        return
+    end
+
+    local handler = mode[methodName]
+    if handler then
+        return handler(self, ...)
+    end
+end
 
 local function buildModifierSections(self)
     local sections = {}
@@ -105,9 +115,7 @@ function Game:load()
     self.input:resetAxes()
 
     self.mode = GameModes:get()
-    if self.mode and self.mode.load then
-        self.mode.load(self)
-    end
+    callMode(self, "load")
 
     if Snake.adrenaline then
         Snake.adrenaline.active = false
@@ -142,45 +150,44 @@ end
 function Game:enter()
     UI.clearButtons()
     self:load()
-        Audio:playMusic("game")
-        SessionStats:reset()
-        PlayerStats:add("sessionsPlayed", 1)
-        Achievements:checkAll({
-                sessionsPlayed = PlayerStats:get("sessionsPlayed"),
-        })
-        if self.mode and self.mode.enter then
-                self.mode.enter(self)
-        end
+
+    Audio:playMusic("game")
+    SessionStats:reset()
+    PlayerStats:add("sessionsPlayed", 1)
+
+    Achievements:checkAll({
+        sessionsPlayed = PlayerStats:get("sessionsPlayed"),
+    })
+
+    callMode(self, "enter")
 end
 
 function Game:leave()
-        if self.mode and self.mode.leave then
-                self.mode.leave(self)
-        end
+    callMode(self, "leave")
 
-        if Snake and Snake.resetModifiers then
-                Snake:resetModifiers()
-        end
+    if Snake and Snake.resetModifiers then
+        Snake:resetModifiers()
+    end
 
-        if UI and UI.setUpgradeIndicators then
-                UI:setUpgradeIndicators(nil)
-        end
+    if UI and UI.setUpgradeIndicators then
+        UI:setUpgradeIndicators(nil)
+    end
 end
 
 function Game:beginDeath()
-        if self.state ~= "dying" then
-                self.state = "dying"
-                local trail = Snake:getSegments()
-                Death:spawnFromSnake(trail, SnakeUtils.SEGMENT_SIZE)
-                Audio:playSound("death")
-        end
+    if self.state ~= "dying" then
+        self.state = "dying"
+        local trail = Snake:getSegments()
+        Death:spawnFromSnake(trail, SnakeUtils.SEGMENT_SIZE)
+        Audio:playSound("death")
+    end
 end
 
 function Game:startDescending(holeX, holeY, holeRadius)
-        self.state = "descending"
-        self.hole = {x = holeX, y = holeY, radius = holeRadius or 24}
-        Snake:startDescending(self.hole.x, self.hole.y, self.hole.radius)
-        Audio:playSound("exit_enter")
+    self.state = "descending"
+    self.hole = { x = holeX, y = holeY, radius = holeRadius or 24 }
+    Snake:startDescending(self.hole.x, self.hole.y, self.hole.radius)
+    Audio:playSound("exit_enter")
 end
 
 -- start a floor transition
@@ -198,490 +205,513 @@ function Game:startFadeIn(duration)
 end
 
 function Game:updateDescending(dt)
-        Snake:update(dt)
+    Snake:update(dt)
 
-        local segments = Snake:getSegments()
-        local tail = segments[#segments]
-        if not tail then
-                Snake:finishDescending()
-                self:startFloorTransition(true)
-                return
-        end
+    local segments = Snake:getSegments()
+    local tail = segments[#segments]
+    if not tail then
+        Snake:finishDescending()
+        self:startFloorTransition(true)
+        return
+    end
 
-        local dx, dy = tail.drawX - self.hole.x, tail.drawY - self.hole.y
-        local dist = math.sqrt(dx * dx + dy * dy)
-        if dist < self.hole.radius then
-                Snake:finishDescending()
-                self:startFloorTransition(true)
-        end
+    local dx, dy = tail.drawX - self.hole.x, tail.drawY - self.hole.y
+    local dist = math.sqrt(dx * dx + dy * dy)
+    if dist < self.hole.radius then
+        Snake:finishDescending()
+        self:startFloorTransition(true)
+    end
 end
 
 function Game:updateGameplay(dt)
-        local fruitX, fruitY = Fruit:getPosition()
+    local fruitX, fruitY = Fruit:getPosition()
 
-        if Upgrades and Upgrades.recordFloorReplaySnapshot then
-                Upgrades:recordFloorReplaySnapshot(self)
+    if Upgrades and Upgrades.recordFloorReplaySnapshot then
+        Upgrades:recordFloorReplaySnapshot(self)
+    end
+
+    local moveResult, cause = Movement:update(dt)
+
+    if moveResult == "dead" then
+        if Upgrades.tryFloorReplay and Upgrades:tryFloorReplay(self, cause) then
+            return
         end
+        self.deathCause = cause
+        self:beginDeath()
+        return
+    end
 
-        local moveResult, cause = Movement:update(dt)
+    if moveResult == "scored" then
+        FruitEvents.handleConsumption(fruitX, fruitY)
 
-        if moveResult == "dead" then
-                if Upgrades.tryFloorReplay and Upgrades:tryFloorReplay(self, cause) then
-                        return
-                end
-                self.deathCause = cause
-                self:beginDeath()
-                return
+        if UI:isGoalReached() then
+            Arena:spawnExit()
         end
+    end
 
-        if moveResult == "scored" then
-                FruitEvents.handleConsumption(fruitX, fruitY)
-
-                if UI:isGoalReached() then
-                        Arena:spawnExit()
-                end
+    local snakeX, snakeY = Snake:getHead()
+    if Arena:checkExitCollision(snakeX, snakeY) then
+        local hx, hy, hr = Arena:getExitCenter()
+        if hx and hy then
+            self:startDescending(hx, hy, hr)
         end
-
-        local snakeX, snakeY = Snake:getHead()
-        if Arena:checkExitCollision(snakeX, snakeY) then
-                local hx, hy, hr = Arena:getExitCenter()
-                if hx and hy then
-                        self:startDescending(hx, hy, hr)
-                end
-        end
+    end
 end
 
 function Game:updateEntities(dt)
-        Face:update(dt)
-        Popup:update(dt)
-        Fruit:update(dt)
-        Rocks:update(dt)
-        Conveyors:update(dt)
-        Saws:update(dt)
-        Arena:update(dt)
-        Particles:update(dt)
-        UpgradeVisuals:update(dt)
-        Achievements:update(dt)
-        FloatingText:update(dt)
-        Score:update(dt)
+    Face:update(dt)
+    Popup:update(dt)
+    Fruit:update(dt)
+    Rocks:update(dt)
+    Conveyors:update(dt)
+    Saws:update(dt)
+    Arena:update(dt)
+    Particles:update(dt)
+    UpgradeVisuals:update(dt)
+    Achievements:update(dt)
+    FloatingText:update(dt)
+    Score:update(dt)
 end
 
 function Game:handleDeath(dt)
-        if self.state ~= "dying" then return end
+    if self.state ~= "dying" then
+        return
+    end
 
-        Death:update(dt)
-        if not Death:isFinished() then return end
+    Death:update(dt)
+    if not Death:isFinished() then
+        return
+    end
 
-        Achievements:save()
-        local result = Score:handleGameOver(self.deathCause)
-        if result then
-                return { state = "gameover", data = result }
-        end
+    Achievements:save()
+    local result = Score:handleGameOver(self.deathCause)
+    if result then
+        return { state = "gameover", data = result }
+    end
 end
 
 local function drawPlayfieldLayers(self, stateOverride)
-        local renderState = stateOverride or self.state
+    local renderState = stateOverride or self.state
 
-        Arena:drawBackground()
-        Death:applyShake()
+    Arena:drawBackground()
+    Death:applyShake()
 
-        Fruit:draw()
-        Rocks:draw()
-        Conveyors:draw()
-        Saws:draw()
-        Arena:drawExit()
+    Fruit:draw()
+    Rocks:draw()
+    Conveyors:draw()
+    Saws:draw()
+    Arena:drawExit()
 
-        if renderState == "descending" then
-                self:drawDescending()
-        elseif renderState == "dying" then
-                Death:draw()
-        elseif renderState ~= "gameover" then
-                Snake:draw()
-        end
+    if renderState == "descending" then
+        self:drawDescending()
+    elseif renderState == "dying" then
+        Death:draw()
+    elseif renderState ~= "gameover" then
+        Snake:draw()
+    end
 
-        Particles:draw()
-        UpgradeVisuals:draw()
-        Popup:draw()
-        Arena:drawBorder()
+    Particles:draw()
+    UpgradeVisuals:draw()
+    Popup:draw()
+    Arena:drawBorder()
 end
 
 local function drawInterfaceLayers(self)
-        FloatingText:draw()
+    FloatingText:draw()
 
-        drawAdrenalineGlow(self)
+    drawAdrenalineGlow(self)
 
-        Death:drawFlash(self.screenWidth, self.screenHeight)
-        PauseMenu:draw(self.screenWidth, self.screenHeight)
-        UI:draw()
-        Achievements:draw()
+    Death:drawFlash(self.screenWidth, self.screenHeight)
+    PauseMenu:draw(self.screenWidth, self.screenHeight)
+    UI:draw()
+    Achievements:draw()
 
-        if self.mode and self.mode.draw then
-                self.mode.draw(self, self.screenWidth, self.screenHeight)
+    callMode(self, "draw", self.screenWidth, self.screenHeight)
+end
+
+local function drawTransitionFadeOut(self, timer, duration)
+    local progress = easedProgress(timer, duration)
+    local overlayAlpha = progress * 0.9
+    local scale = 1 - 0.04 * easeOutExpo(progress)
+    local yOffset = 24 * progress
+
+    love.graphics.push()
+    love.graphics.translate(self.screenWidth / 2, self.screenHeight / 2 + yOffset)
+    love.graphics.scale(scale, scale)
+    love.graphics.translate(-self.screenWidth / 2, -self.screenHeight / 2)
+    love.graphics.setColor(Theme.bgColor)
+    love.graphics.rectangle("fill", 0, 0, self.screenWidth, self.screenHeight)
+    love.graphics.pop()
+
+    love.graphics.setColor(0, 0, 0, overlayAlpha)
+    love.graphics.rectangle("fill", 0, 0, self.screenWidth, self.screenHeight)
+
+    love.graphics.setBlendMode("add")
+    love.graphics.setColor(1, 1, 1, overlayAlpha * 0.25)
+    local radius = math.sqrt(self.screenWidth * self.screenWidth + self.screenHeight * self.screenHeight)
+    love.graphics.circle("fill", self.screenWidth / 2, self.screenHeight / 2, radius, 64)
+    local time = love.timer and love.timer.getTime and love.timer.getTime() or 0
+    love.graphics.setColor(1, 0.84, 0.48, overlayAlpha * 0.16)
+    local burstRadius = radius * (0.32 + 0.4 * progress)
+    local burstArms = 5
+    love.graphics.setLineWidth(2 + progress * 3)
+    for i = 1, burstArms do
+        local armAngle = time * 0.45 + (i / burstArms) * math.pi * 2
+        love.graphics.arc("line", "open", self.screenWidth / 2, self.screenHeight / 2, burstRadius, armAngle, armAngle + math.pi * (0.25 + 0.35 * progress))
+    end
+    love.graphics.setLineWidth(1)
+    love.graphics.setBlendMode("alpha")
+    love.graphics.setColor(1, 1, 1, 1)
+
+    return true
+end
+
+local function drawTransitionShop(self, timer)
+    local entrance = easeOutBack(clamp01(timer / 0.6))
+    local scale = 0.92 + 0.08 * entrance
+    local yOffset = (1 - entrance) * 40
+
+    love.graphics.setColor(0, 0, 0, 0.9)
+    love.graphics.rectangle("fill", 0, 0, self.screenWidth, self.screenHeight)
+    love.graphics.push()
+    love.graphics.translate(self.screenWidth / 2, self.screenHeight / 2 + yOffset)
+    love.graphics.scale(scale, scale)
+    love.graphics.translate(-self.screenWidth / 2, -self.screenHeight / 2)
+    Shop:draw(self.screenWidth, self.screenHeight)
+    love.graphics.pop()
+    love.graphics.setColor(1, 1, 1, 1)
+
+    return true
+end
+
+local function drawTraitEntries(self, timer, outroAlpha, fadeAlpha)
+    local sections = self.transitionTraits or buildModifierSections(self)
+    if not (sections and #sections > 0) then
+        return
+    end
+
+    local entries = {}
+    local maxTraits = 4
+    local totalTraits = 0
+    local shownTraits = 0
+
+    for _, section in ipairs(sections) do
+        if section.items and #section.items > 0 then
+            local visible = {}
+            for _, trait in ipairs(section.items) do
+                totalTraits = totalTraits + 1
+                if shownTraits < maxTraits then
+                    table.insert(visible, trait)
+                    shownTraits = shownTraits + 1
+                end
+            end
+
+            if #visible > 0 then
+                table.insert(entries, {
+                    type = "header",
+                    title = section.title or Localization:get("game.floor_traits.default_title"),
+                })
+                for _, trait in ipairs(visible) do
+                    table.insert(entries, {
+                        type = "trait",
+                        name = trait.name,
+                    })
+                end
+            end
         end
+    end
+
+    local remaining = math.max(0, totalTraits - shownTraits)
+    if remaining > 0 then
+        local suffixKey = (remaining == 1)
+            and "game.floor_traits.more_modifiers_one"
+            or "game.floor_traits.more_modifiers_other"
+        table.insert(entries, {
+            type = "note",
+            text = Localization:get(suffixKey, {
+                count = remaining,
+            }),
+        })
+    end
+
+    local y = self.screenHeight / 2 + 64
+    local width = self.screenWidth * 0.45
+    local x = (self.screenWidth - width) / 2
+    local index = 0
+
+    for _, entry in ipairs(entries) do
+        index = index + 1
+        local traitAlpha = fadeAlpha(0.9 + (index - 1) * 0.22, 0.4)
+        local traitOffset = (1 - easeOutExpo(clamp01((timer - (0.9 + (index - 1) * 0.22)) / 0.55))) * 16 * outroAlpha
+
+        if entry.type == "header" then
+            local headerHeight = UI.fonts.button:getHeight() + 4
+            if traitAlpha > 0 then
+                love.graphics.setFont(UI.fonts.button)
+                local shadow = Theme.shadowColor or { 0, 0, 0, 0.5 }
+                love.graphics.setColor(shadow[1], shadow[2], shadow[3], (shadow[4] or 1) * traitAlpha)
+                love.graphics.printf(entry.title or Localization:get("game.floor_traits.default_title"), x + 2, y + traitOffset + 2, width, "center")
+                love.graphics.setColor(1, 1, 1, traitAlpha)
+                love.graphics.printf(entry.title or Localization:get("game.floor_traits.default_title"), x, y + traitOffset, width, "center")
+            end
+            y = y + headerHeight
+        elseif entry.type == "trait" then
+            local lineHeight = UI.fonts.button:getHeight()
+            if traitAlpha > 0 then
+                love.graphics.setFont(UI.fonts.button)
+                local shadow = Theme.shadowColor or { 0, 0, 0, 0.5 }
+                love.graphics.setColor(shadow[1], shadow[2], shadow[3], (shadow[4] or 1) * traitAlpha)
+                love.graphics.printf("• " .. (entry.name or ""), x + 2, y + traitOffset + 2, width, "center")
+                love.graphics.setColor(1, 1, 1, traitAlpha)
+                love.graphics.printf("• " .. (entry.name or ""), x, y + traitOffset, width, "center")
+            end
+            y = y + lineHeight + 6
+        elseif entry.type == "note" then
+            local noteHeight = UI.fonts.body:getHeight()
+            if traitAlpha > 0 then
+                love.graphics.setFont(UI.fonts.body)
+                local shadow = Theme.shadowColor or { 0, 0, 0, 0.5 }
+                love.graphics.setColor(shadow[1], shadow[2], shadow[3], (shadow[4] or 1) * traitAlpha)
+                love.graphics.printf(entry.text or "", x + 2, y + traitOffset + 2, width, "center")
+                love.graphics.setColor(1, 1, 1, traitAlpha)
+                love.graphics.printf(entry.text or "", x, y + traitOffset, width, "center")
+            end
+            y = y + noteHeight
+        end
+    end
+end
+
+local function drawTransitionFloorIntro(self, timer, duration, data)
+    local floorData = data.transitionFloorData or self.currentFloorData
+    if not floorData then
+        return
+    end
+
+    local progress = easedProgress(timer, duration)
+    local outroDuration = math.min(0.6, duration > 0 and duration * 0.5 or 0)
+    local outroProgress = 0
+    if outroDuration > 0 then
+        local outroStart = math.max(0, duration - outroDuration)
+        outroProgress = clamp01((timer - outroStart) / outroDuration)
+    end
+    local outroAlpha = 1 - outroProgress
+
+    local overlayAlpha = math.min(0.75, progress * 0.85)
+    if outroProgress > 0 then
+        overlayAlpha = overlayAlpha + (1 - overlayAlpha) * outroProgress
+    end
+    love.graphics.setColor(0, 0, 0, overlayAlpha)
+    love.graphics.rectangle("fill", 0, 0, self.screenWidth, self.screenHeight)
+
+    love.graphics.push("all")
+    love.graphics.setBlendMode("add")
+    local bloomProgress = 0.55 + 0.45 * progress
+    local bloomIntensity = bloomProgress * (0.45 + 0.55 * outroAlpha)
+    if Arena.drawBackgroundEffect then
+        Arena:drawBackgroundEffect(0, 0, self.screenWidth, self.screenHeight, bloomIntensity)
+    end
+    love.graphics.pop()
+    love.graphics.setColor(1, 1, 1, 1)
+
+    local function fadeAlpha(delay, fadeDuration)
+        local alpha = progress * clamp01((timer - delay) / (fadeDuration or 0.35))
+        return alpha * outroAlpha
+    end
+
+    local nameAlpha = fadeAlpha(0.0, 0.45)
+    if nameAlpha > 0 then
+        local titleProgress = easeOutBack(clamp01((timer - 0.1) / 0.6))
+        local titleScale = 0.9 + 0.1 * titleProgress
+        local yOffset = (1 - titleProgress) * 36 * outroAlpha
+        love.graphics.setFont(UI.fonts.title)
+        love.graphics.push()
+        love.graphics.translate(self.screenWidth / 2, self.screenHeight / 2 - 80 + yOffset)
+        love.graphics.scale(titleScale, titleScale)
+        love.graphics.translate(-self.screenWidth / 2, -(self.screenHeight / 2 - 80 + yOffset))
+        local shadow = Theme.shadowColor or { 0, 0, 0, 0.5 }
+        love.graphics.setColor(shadow[1], shadow[2], shadow[3], (shadow[4] or 1) * nameAlpha)
+        love.graphics.printf(floorData.name, 2, self.screenHeight / 2 - 78 + yOffset, self.screenWidth, "center")
+        love.graphics.setColor(1, 1, 1, nameAlpha)
+        love.graphics.printf(floorData.name, 0, self.screenHeight / 2 - 80 + yOffset, self.screenWidth, "center")
+        love.graphics.pop()
+    end
+
+    if floorData.flavor and floorData.flavor ~= "" then
+        local flavorAlpha = fadeAlpha(0.45, 0.4)
+        if flavorAlpha > 0 then
+            local flavorProgress = easeOutExpo(clamp01((timer - 0.45) / 0.65))
+            local flavorOffset = (1 - flavorProgress) * 24 * outroAlpha
+            love.graphics.setFont(UI.fonts.button)
+            love.graphics.push()
+            love.graphics.translate(0, flavorOffset)
+            local shadow = Theme.shadowColor or { 0, 0, 0, 0.5 }
+            love.graphics.setColor(shadow[1], shadow[2], shadow[3], (shadow[4] or 1) * flavorAlpha)
+            love.graphics.printf(floorData.flavor, 2, self.screenHeight / 2 + 2, self.screenWidth, "center")
+            love.graphics.setColor(1, 1, 1, flavorAlpha)
+            love.graphics.printf(floorData.flavor, 0, self.screenHeight / 2, self.screenWidth, "center")
+            love.graphics.pop()
+        end
+    end
+
+    drawTraitEntries(self, timer, outroAlpha, fadeAlpha)
+
+    love.graphics.setColor(1, 1, 1, 1)
+
+    return true
 end
 
 function Game:drawTransition()
-        if not (self.transition and self.transition:isActive()) then
-                return
+    if not (self.transition and self.transition:isActive()) then
+        return
+    end
+
+    local phase = self.transition:getPhase()
+    local timer = self.transition:getTimer() or 0
+    local duration = self.transition:getDuration() or 0
+    local data = self.transition:getData() or {}
+
+    if phase == "fadeout" then
+        if drawTransitionFadeOut(self, timer, duration) then
+            return
         end
-
-        local phase = self.transition:getPhase()
-        local timer = self.transition:getTimer() or 0
-        local duration = self.transition:getDuration() or 0
-        local data = self.transition:getData() or {}
-
-        if phase == "fadeout" then
-                local progress = easedProgress(timer, duration)
-                local overlayAlpha = progress * 0.9
-                local scale = 1 - 0.04 * easeOutExpo(progress)
-                local yOffset = 24 * progress
-
-                love.graphics.push()
-                love.graphics.translate(self.screenWidth / 2, self.screenHeight / 2 + yOffset)
-                love.graphics.scale(scale, scale)
-                love.graphics.translate(-self.screenWidth / 2, -self.screenHeight / 2)
-                love.graphics.setColor(Theme.bgColor)
-                love.graphics.rectangle("fill", 0, 0, self.screenWidth, self.screenHeight)
-                love.graphics.pop()
-
-                love.graphics.setColor(0, 0, 0, overlayAlpha)
-                love.graphics.rectangle("fill", 0, 0, self.screenWidth, self.screenHeight)
-
-                love.graphics.setBlendMode("add")
-                love.graphics.setColor(1, 1, 1, overlayAlpha * 0.25)
-                local radius = math.sqrt(self.screenWidth * self.screenWidth + self.screenHeight * self.screenHeight)
-                love.graphics.circle("fill", self.screenWidth / 2, self.screenHeight / 2, radius, 64)
-                local time = love.timer and love.timer.getTime and love.timer.getTime() or 0
-                love.graphics.setColor(1, 0.84, 0.48, overlayAlpha * 0.16)
-                local burstRadius = radius * (0.32 + 0.4 * progress)
-                local burstArms = 5
-                love.graphics.setLineWidth(2 + progress * 3)
-                for i = 1, burstArms do
-                        local armAngle = time * 0.45 + (i / burstArms) * math.pi * 2
-                        love.graphics.arc("line", "open", self.screenWidth / 2, self.screenHeight / 2, burstRadius, armAngle, armAngle + math.pi * (0.25 + 0.35 * progress))
-                end
-                love.graphics.setLineWidth(1)
-                love.graphics.setBlendMode("alpha")
-                love.graphics.setColor(1, 1, 1, 1)
-                return
+    elseif phase == "shop" then
+        if drawTransitionShop(self, timer) then
+            return
         end
-
-        if phase == "shop" then
-                local entrance = easeOutBack(clamp01(timer / 0.6))
-                local scale = 0.92 + 0.08 * entrance
-                local yOffset = (1 - entrance) * 40
-
-                love.graphics.setColor(0, 0, 0, 0.9)
-                love.graphics.rectangle("fill", 0, 0, self.screenWidth, self.screenHeight)
-                love.graphics.push()
-                love.graphics.translate(self.screenWidth / 2, self.screenHeight / 2 + yOffset)
-                love.graphics.scale(scale, scale)
-                love.graphics.translate(-self.screenWidth / 2, -self.screenHeight / 2)
-                Shop:draw(self.screenWidth, self.screenHeight)
-                love.graphics.pop()
-                love.graphics.setColor(1, 1, 1, 1)
-                return
+    elseif phase == "floorintro" then
+        if drawTransitionFloorIntro(self, timer, duration, data) then
+            return
         end
+    elseif phase == "fadein" then
+        local progress = easedProgress(timer, duration)
+        local alpha = 1 - progress
+        local scale = 1 + 0.03 * alpha
+        local yOffset = alpha * 20
 
-        if phase == "floorintro" then
-                local floorData = data.transitionFloorData or self.currentFloorData
-                if floorData then
-                        local progress = easedProgress(timer, duration)
-                        local outroDuration = math.min(0.6, duration > 0 and duration * 0.5 or 0)
-                        local outroProgress = 0
-                        if outroDuration > 0 then
-                                local outroStart = math.max(0, duration - outroDuration)
-                                outroProgress = clamp01((timer - outroStart) / outroDuration)
-                        end
-                        local outroAlpha = 1 - outroProgress
+        love.graphics.push()
+        love.graphics.translate(self.screenWidth / 2, self.screenHeight / 2 + yOffset)
+        love.graphics.scale(scale, scale)
+        love.graphics.translate(-self.screenWidth / 2, -self.screenHeight / 2)
+        drawPlayfieldLayers(self, "playing")
+        love.graphics.pop()
 
-                        local overlayAlpha = math.min(0.75, progress * 0.85)
-                        if outroProgress > 0 then
-                                overlayAlpha = overlayAlpha + (1 - overlayAlpha) * outroProgress
-                        end
-                        love.graphics.setColor(0, 0, 0, overlayAlpha)
-                        love.graphics.rectangle("fill", 0, 0, self.screenWidth, self.screenHeight)
+        drawInterfaceLayers(self)
 
-                        love.graphics.push("all")
-                        love.graphics.setBlendMode("add")
-                        local bloomProgress = 0.55 + 0.45 * progress
-                        local bloomIntensity = bloomProgress * (0.45 + 0.55 * outroAlpha)
-                        if Arena.drawBackgroundEffect then
-                                Arena:drawBackgroundEffect(0, 0, self.screenWidth, self.screenHeight, bloomIntensity)
-                        end
-                        love.graphics.pop()
-                        love.graphics.setColor(1, 1, 1, 1)
-
-                        local function fadeAlpha(delay, fadeDuration)
-                                local alpha = progress * clamp01((timer - delay) / (fadeDuration or 0.35))
-                                return alpha * outroAlpha
-                        end
-
-                        local nameAlpha = fadeAlpha(0.0, 0.45)
-                        if nameAlpha > 0 then
-                                local titleProgress = easeOutBack(clamp01((timer - 0.1) / 0.6))
-                                local titleScale = 0.9 + 0.1 * titleProgress
-                                local yOffset = (1 - titleProgress) * 36 * outroAlpha
-                                love.graphics.setFont(UI.fonts.title)
-                                love.graphics.push()
-                                love.graphics.translate(self.screenWidth / 2, self.screenHeight / 2 - 80 + yOffset)
-                                love.graphics.scale(titleScale, titleScale)
-                                love.graphics.translate(-self.screenWidth / 2, -(self.screenHeight / 2 - 80 + yOffset))
-                                local shadow = Theme.shadowColor or {0, 0, 0, 0.5}
-                                love.graphics.setColor(shadow[1], shadow[2], shadow[3], (shadow[4] or 1) * nameAlpha)
-                                love.graphics.printf(floorData.name, 2, self.screenHeight / 2 - 78 + yOffset, self.screenWidth, "center")
-                                love.graphics.setColor(1, 1, 1, nameAlpha)
-                                love.graphics.printf(floorData.name, 0, self.screenHeight / 2 - 80 + yOffset, self.screenWidth, "center")
-                                love.graphics.pop()
-                        end
-
-                        if floorData.flavor and floorData.flavor ~= "" then
-                                local flavorAlpha = fadeAlpha(0.45, 0.4)
-                                if flavorAlpha > 0 then
-                                        local flavorProgress = easeOutExpo(clamp01((timer - 0.45) / 0.65))
-                                        local flavorOffset = (1 - flavorProgress) * 24 * outroAlpha
-                                        love.graphics.setFont(UI.fonts.button)
-                                        love.graphics.push()
-                                        love.graphics.translate(0, flavorOffset)
-                                        local shadow = Theme.shadowColor or {0, 0, 0, 0.5}
-                                        love.graphics.setColor(shadow[1], shadow[2], shadow[3], (shadow[4] or 1) * flavorAlpha)
-                                        love.graphics.printf(floorData.flavor, 2, self.screenHeight / 2 + 2, self.screenWidth, "center")
-                                        love.graphics.setColor(1, 1, 1, flavorAlpha)
-                                        love.graphics.printf(floorData.flavor, 0, self.screenHeight / 2, self.screenWidth, "center")
-                                        love.graphics.pop()
-                                end
-                        end
-
-                        local sections = self.transitionTraits or buildModifierSections(self)
-                        if sections and #sections > 0 then
-                                local entries = {}
-                                local maxTraits = 4
-                                local totalTraits = 0
-                                local shownTraits = 0
-
-                                for _, section in ipairs(sections) do
-                                        if section.items and #section.items > 0 then
-                                                local visible = {}
-                                                for _, trait in ipairs(section.items) do
-                                                        totalTraits = totalTraits + 1
-                                                        if shownTraits < maxTraits then
-                                                                table.insert(visible, trait)
-                                                                shownTraits = shownTraits + 1
-                                                        end
-                                                end
-
-                                                if #visible > 0 then
-                                                        table.insert(entries, {
-                                                                type = "header",
-                                                                title = section.title or Localization:get("game.floor_traits.default_title"),
-                                                        })
-                                                        for _, trait in ipairs(visible) do
-                                                                table.insert(entries, {
-                                                                        type = "trait",
-                                                                        name = trait.name,
-                                                                })
-                                                        end
-                                                end
-                                        end
-                                end
-
-                                local remaining = math.max(0, totalTraits - shownTraits)
-                                if remaining > 0 then
-                                        local suffixKey = (remaining == 1)
-                                                and "game.floor_traits.more_modifiers_one"
-                                                or "game.floor_traits.more_modifiers_other"
-                                        table.insert(entries, {
-                                                type = "note",
-                                                text = Localization:get(suffixKey, {
-                                                        count = remaining,
-                                                }),
-                                        })
-                                end
-
-                                local y = self.screenHeight / 2 + 64
-                                local width = self.screenWidth * 0.45
-                                local x = (self.screenWidth - width) / 2
-                                local index = 0
-
-                                for _, entry in ipairs(entries) do
-                                        index = index + 1
-                                        local traitAlpha = fadeAlpha(0.9 + (index - 1) * 0.22, 0.4)
-                                        local traitOffset = (1 - easeOutExpo(clamp01((timer - (0.9 + (index - 1) * 0.22)) / 0.55))) * 16 * outroAlpha
-
-                                        if entry.type == "header" then
-                                                local headerHeight = UI.fonts.button:getHeight() + 4
-                                                if traitAlpha > 0 then
-                                                        love.graphics.setFont(UI.fonts.button)
-                                                        local shadow = Theme.shadowColor or {0, 0, 0, 0.5}
-                                                        love.graphics.setColor(shadow[1], shadow[2], shadow[3], (shadow[4] or 1) * traitAlpha)
-                                                        love.graphics.printf(entry.title or Localization:get("game.floor_traits.default_title"), x + 2, y + traitOffset + 2, width, "center")
-                                                        love.graphics.setColor(1, 1, 1, traitAlpha)
-                                                        love.graphics.printf(entry.title or Localization:get("game.floor_traits.default_title"), x, y + traitOffset, width, "center")
-                                                end
-                                                y = y + headerHeight
-                                        elseif entry.type == "trait" then
-                                                local lineHeight = UI.fonts.button:getHeight()
-                                                if traitAlpha > 0 then
-                                                        love.graphics.setFont(UI.fonts.button)
-                                                        local shadow = Theme.shadowColor or {0, 0, 0, 0.5}
-                                                        love.graphics.setColor(shadow[1], shadow[2], shadow[3], (shadow[4] or 1) * traitAlpha)
-                                                        love.graphics.printf("• " .. (entry.name or ""), x + 2, y + traitOffset + 2, width, "center")
-                                                        love.graphics.setColor(1, 1, 1, traitAlpha)
-                                                        love.graphics.printf("• " .. (entry.name or ""), x, y + traitOffset, width, "center")
-                                                end
-                                                y = y + lineHeight + 6
-                                        elseif entry.type == "note" then
-                                                local noteHeight = UI.fonts.body:getHeight()
-                                                if traitAlpha > 0 then
-                                                        love.graphics.setFont(UI.fonts.body)
-                                                        local shadow = Theme.shadowColor or {0, 0, 0, 0.5}
-                                                        love.graphics.setColor(shadow[1], shadow[2], shadow[3], (shadow[4] or 1) * traitAlpha)
-                                                        love.graphics.printf(entry.text or "", x + 2, y + traitOffset + 2, width, "center")
-                                                        love.graphics.setColor(1, 1, 1, traitAlpha)
-                                                        love.graphics.printf(entry.text or "", x, y + traitOffset, width, "center")
-                                                end
-                                                y = y + noteHeight
-                                        end
-                                end
-                        end
-                end
-
-                love.graphics.setColor(1, 1, 1, 1)
-                return
-        end
-
-        if phase == "fadein" then
-                local progress = easedProgress(timer, duration)
-                local alpha = 1 - progress
-                local scale = 1 + 0.03 * alpha
-                local yOffset = alpha * 20
-
-                love.graphics.push()
-                love.graphics.translate(self.screenWidth / 2, self.screenHeight / 2 + yOffset)
-                love.graphics.scale(scale, scale)
-                love.graphics.translate(-self.screenWidth / 2, -self.screenHeight / 2)
-                drawPlayfieldLayers(self, "playing")
-                love.graphics.pop()
-
-                drawInterfaceLayers(self)
-
-                love.graphics.setColor(0, 0, 0, alpha * 0.85)
-                love.graphics.rectangle("fill", 0, 0, self.screenWidth, self.screenHeight)
-                love.graphics.setBlendMode("add")
-                love.graphics.setColor(1, 1, 1, alpha * 0.2)
-                local radius = math.sqrt(self.screenWidth * self.screenWidth + self.screenHeight * self.screenHeight) * 0.75
-                love.graphics.circle("fill", self.screenWidth / 2, self.screenHeight / 2, radius, 64)
-                love.graphics.setBlendMode("alpha")
-                love.graphics.setColor(1, 1, 1, 1)
-        end
+        love.graphics.setColor(0, 0, 0, alpha * 0.85)
+        love.graphics.rectangle("fill", 0, 0, self.screenWidth, self.screenHeight)
+        love.graphics.setBlendMode("add")
+        love.graphics.setColor(1, 1, 1, alpha * 0.2)
+        local radius = math.sqrt(self.screenWidth * self.screenWidth + self.screenHeight * self.screenHeight) * 0.75
+        love.graphics.circle("fill", self.screenWidth / 2, self.screenHeight / 2, radius, 64)
+        love.graphics.setBlendMode("alpha")
+        love.graphics.setColor(1, 1, 1, 1)
+    end
 end
 
 function Game:drawStateTransition(direction, progress, eased, alpha)
-        local isFloorTransition = (self.state == "transition")
+    local isFloorTransition = (self.state == "transition")
 
-        if direction == "out" and not isFloorTransition then
-                return nil
-        end
+    if direction == "out" and not isFloorTransition then
+        return nil
+    end
 
-        self:draw()
+    self:draw()
 
-        if isFloorTransition then
-                love.graphics.setColor(1, 1, 1, 1)
-                return { skipOverlay = true }
-        end
+    if isFloorTransition then
+        love.graphics.setColor(1, 1, 1, 1)
+        return { skipOverlay = true }
+    end
 
-        if direction == "in" then
-                local width = self.screenWidth or love.graphics.getWidth()
-                local height = self.screenHeight or love.graphics.getHeight()
+    if direction == "in" then
+        local width = self.screenWidth or love.graphics.getWidth()
+        local height = self.screenHeight or love.graphics.getHeight()
 
-                if alpha and alpha > 0 then
-                        love.graphics.setColor(0, 0, 0, alpha)
-                        love.graphics.rectangle("fill", 0, 0, width, height)
-                end
-
-                love.graphics.setColor(1, 1, 1, 1)
-                return { skipOverlay = true }
+        if alpha and alpha > 0 then
+            love.graphics.setColor(0, 0, 0, alpha)
+            love.graphics.rectangle("fill", 0, 0, width, height)
         end
 
         love.graphics.setColor(1, 1, 1, 1)
-        return true
+        return { skipOverlay = true }
+    end
+
+    love.graphics.setColor(1, 1, 1, 1)
+    return true
 end
 
 function Game:drawDescending()
-        if not self.hole then
-                Snake:draw()
-                return
-        end
+    if not self.hole then
+        Snake:draw()
+        return
+    end
 
-        local hx, hy, hr = self.hole.x, self.hole.y, self.hole.radius
+    local hx, hy, hr = self.hole.x, self.hole.y, self.hole.radius
 
-        love.graphics.setColor(0.05, 0.05, 0.05, 1)
-        love.graphics.circle("fill", hx, hy, hr)
+    love.graphics.setColor(0.05, 0.05, 0.05, 1)
+    love.graphics.circle("fill", hx, hy, hr)
 
-        Snake:drawClipped(hx, hy, hr)
+    Snake:drawClipped(hx, hy, hr)
 
-        love.graphics.setColor(0, 0, 0, 1)
-        local previousLineWidth = love.graphics.getLineWidth()
-        love.graphics.setLineWidth(2)
-        love.graphics.circle("line", hx, hy, hr)
-        love.graphics.setLineWidth(previousLineWidth)
-        love.graphics.setColor(1, 1, 1, 1)
+    love.graphics.setColor(0, 0, 0, 1)
+    local previousLineWidth = love.graphics.getLineWidth()
+    love.graphics.setLineWidth(2)
+    love.graphics.circle("line", hx, hy, hr)
+    love.graphics.setLineWidth(previousLineWidth)
+    love.graphics.setColor(1, 1, 1, 1)
 end
 
 function Game:update(dt)
-        if self.state == "paused" then
-                PauseMenu:update(dt, true)
-                return
+    if self.state == "paused" then
+        PauseMenu:update(dt, true)
+        return
+    end
+
+    PauseMenu:update(dt, false)
+
+    local timeScale = 1
+    if Snake.getTimeScale then
+        local scale = Snake:getTimeScale()
+        if scale and scale > 0 then
+            timeScale = scale
         end
+    end
+    local scaledDt = dt * timeScale
 
-        PauseMenu:update(dt, false)
+    local isRunActive = (self.state == "playing" or self.state == "descending")
+    if isRunActive then
+        SessionStats:add("timeAlive", scaledDt)
+        self.runTimer = (self.runTimer or 0) + scaledDt
+    end
 
-        local timeScale = 1
-        if Snake.getTimeScale then
-                local scale = Snake:getTimeScale()
-                if scale and scale > 0 then
-                        timeScale = scale
-                end
-        end
-        local scaledDt = dt * timeScale
+    if self.state == "playing" then
+        self.floorTimer = (self.floorTimer or 0) + scaledDt
+    end
 
-        local isRunActive = (self.state == "playing" or self.state == "descending")
-        if isRunActive then
-                SessionStats:add("timeAlive", scaledDt)
-                self.runTimer = (self.runTimer or 0) + scaledDt
-        end
+    FruitEvents.update(scaledDt)
 
-        if self.state == "playing" then
-                self.floorTimer = (self.floorTimer or 0) + scaledDt
-        end
+    if self.transition and self.transition:isActive() then
+        self.transition:update(scaledDt)
+        return
+    end
 
-        FruitEvents.update(scaledDt)
+    if self.state == "descending" then
+        self:updateDescending(scaledDt)
+        return
+    end
 
-        if self.transition and self.transition:isActive() then
-                self.transition:update(scaledDt)
-                return
-        end
+    callMode(self, "update", scaledDt)
 
-        if self.state == "descending" then
-                self:updateDescending(scaledDt)
-                return
-        end
+    if self.state == "playing" then
+        self:updateGameplay(scaledDt)
+    end
 
-        if self.mode and self.mode.update then
-                self.mode.update(self, scaledDt)
-        end
+    self:updateEntities(scaledDt)
+    UI:setUpgradeIndicators(Upgrades:getHUDIndicators())
 
-        if self.state == "playing" then
-                self:updateGameplay(scaledDt)
-        end
-
-        self:updateEntities(scaledDt)
-        UI:setUpgradeIndicators(Upgrades:getHUDIndicators())
-
-        local result = self:handleDeath(scaledDt)
-        if result then
-                return result
-        end
+    local result = self:handleDeath(scaledDt)
+    if result then
+        return result
+    end
 end
 
 function Game:setupFloor(floorNum)
@@ -710,70 +740,70 @@ function Game:setupFloor(floorNum)
 end
 
 function Game:draw()
-        love.graphics.clear()
+    love.graphics.clear()
 
-        if Arena.drawBackdrop then
-                Arena:drawBackdrop(self.screenWidth, self.screenHeight)
-        else
-                love.graphics.setColor(Theme.bgColor)
-                love.graphics.rectangle("fill", 0, 0, self.screenWidth, self.screenHeight)
-                love.graphics.setColor(1, 1, 1, 1)
-        end
+    if Arena.drawBackdrop then
+        Arena:drawBackdrop(self.screenWidth, self.screenHeight)
+    else
+        love.graphics.setColor(Theme.bgColor)
+        love.graphics.rectangle("fill", 0, 0, self.screenWidth, self.screenHeight)
+        love.graphics.setColor(1, 1, 1, 1)
+    end
 
-        if self.transition and self.transition:isActive() then
-                self:drawTransition()
-                return
-        end
+    if self.transition and self.transition:isActive() then
+        self:drawTransition()
+        return
+    end
 
-        drawPlayfieldLayers(self)
-        drawInterfaceLayers(self)
+    drawPlayfieldLayers(self)
+    drawInterfaceLayers(self)
 end
 
 function Game:keypressed(key)
-        if self.input and self.input:handleShopInput("keypressed", key) then
-                return
-        end
+    if self.input and self.input:handleShopInput("keypressed", key) then
+        return
+    end
 
-        Controls:keypressed(self, key)
+    Controls:keypressed(self, key)
 end
 
 function Game:mousepressed(x, y, button)
-        if self.state == "paused" then
-                PauseMenu:mousepressed(x, y, button)
-                return
-        end
+    if self.state == "paused" then
+        PauseMenu:mousepressed(x, y, button)
+        return
+    end
 
-        if self.input then
-                self.input:handleShopInput("mousepressed", x, y, button)
-        end
+    if self.input then
+        self.input:handleShopInput("mousepressed", x, y, button)
+    end
 end
 
 function Game:mousereleased(x, y, button)
-        if self.state ~= "paused" or button ~= 1 then
-                return
-        end
+    if self.state ~= "paused" or button ~= 1 then
+        return
+    end
 
-        local selection = PauseMenu:mousereleased(x, y, button)
-        if not selection then
-                return
-        end
+    local selection = PauseMenu:mousereleased(x, y, button)
+    if not selection then
+        return
+    end
 
-        if self.input then
-                return self.input:applyPauseMenuSelection(selection)
-        end
+    if self.input then
+        return self.input:applyPauseMenuSelection(selection)
+    end
 end
 
 function Game:gamepadpressed(_, button)
-        if self.input then
-                return self.input:handleGamepadButton(button)
-        end
+    if self.input then
+        return self.input:handleGamepadButton(button)
+    end
 end
 Game.joystickpressed = Game.gamepadpressed
 
 function Game:gamepadaxis(_, axis, value)
-        if self.input then
-                return self.input:handleGamepadAxis(axis, value)
-        end
+    if self.input then
+        return self.input:handleGamepadAxis(axis, value)
+    end
 end
 Game.joystickaxis = Game.gamepadaxis
 


### PR DESCRIPTION
## Summary
- add a reusable `callMode` helper so game mode callbacks no longer require repeated guards
- extract the complex transition drawing branches into focused helper functions and simplify the main draw routine
- normalize indentation across the game module and remove unused locals for a cleaner baseline

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68de2e81958c832f9c613b9b5ae3d51d