### PR TITLE
Rebalance Metronome Totem and Aurora Band

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -356,7 +356,7 @@ local english = {
             },
             metronome_totem = {
                 name = "Metronome Totem",
-                description = "Each fruit adds 0.35s to the combo timer.",
+                description = "Each fruit adds 0.35s to the combo timer. The exit requires +1 fruit.",
                 timer_bonus = "+0.35s",
             },
             adrenaline_surge = {
@@ -436,7 +436,7 @@ local english = {
             },
             aurora_band = {
                 name = "Aurora Band",
-                description = "Combo window increases by 0.35s. The exit requires +1 fruit.",
+                description = "Combo window increases by 0.35s.",
             },
             caravan_contract = {
                 name = "Caravan Contract",

--- a/upgrades.lua
+++ b/upgrades.lua
@@ -416,6 +416,12 @@ local pool = {
         descKey = "upgrades.metronome_totem.description",
         rarity = "common",
         tags = {"combo"},
+        onAcquire = function(state)
+            state.effects.fruitGoalDelta = (state.effects.fruitGoalDelta or 0) + 1
+            if UI.adjustFruitGoal then
+                UI:adjustFruitGoal(1)
+            end
+        end,
         handlers = {
             fruitCollected = function(data)
                 local FruitEvents = require("fruitevents")
@@ -913,10 +919,6 @@ local pool = {
         tags = {"combo", "risk"},
         onAcquire = function(state)
             state.effects.comboWindowBonus = (state.effects.comboWindowBonus or 0) + 0.35
-            state.effects.fruitGoalDelta = (state.effects.fruitGoalDelta or 0) + 1
-            if UI.adjustFruitGoal then
-                UI:adjustFruitGoal(1)
-            end
         end,
     }),
     register({


### PR DESCRIPTION
## Summary
- move the +1 fruit exit penalty from Aurora Band to Metronome Totem so the uncommon upgrade remains stronger
- update upgrade descriptions to reflect the new penalties and benefits

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dea439ef10832f913b88d577be2506