### PR TITLE
Fix Temporal Anchor time dilation speed scaling

### DIFF
--- a/snake.lua
+++ b/snake.lua
@@ -1038,7 +1038,7 @@ function Snake:update(dt)
         end
 
         if scale ~= 1 then
-            speed = speed / scale
+            speed = speed * scale
         end
     end
 


### PR DESCRIPTION
## Summary
- ensure the Temporal Anchor time dilation ability actually slows the snake by applying its time scale as a multiplier

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dea4fa9908832fbfee693dd230c4ff