### PR TITLE
Adjust Aegis Winder fruit requirement

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -378,7 +378,7 @@ local english = {
             },
             pocket_springs = {
                 name = "Aegis Winder",
-                description = "After collecting twenty-five fruit, forge a single crash shield charge.",
+                description = "After collecting twenty fruit, forge a single crash shield charge.",
             },
             mapmakers_compass = {
                 name = "Mapmaker's Compass",

--- a/upgrades.lua
+++ b/upgrades.lua
@@ -17,7 +17,7 @@ local defaultEffects = UpgradeHelpers.defaultEffects
 local celebrateUpgrade = UpgradeHelpers.celebrateUpgrade
 local getEventPosition = UpgradeHelpers.getEventPosition
 
-local POCKET_SPRINGS_FRUIT_TARGET = 25
+local POCKET_SPRINGS_FRUIT_TARGET = 20
 
 local function stoneSkinShieldHandler(data, state)
     if not state then return end


### PR DESCRIPTION
## Summary
- reduce the Aegis Winder pocket springs fruit target from 25 to 20
- update the English description to reflect the new threshold

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dea8c7495c832fbc1158ef3f323693