### PR TITLE
Fix saw collision offset to match visual position

### DIFF
--- a/saws.lua
+++ b/saws.lua
@@ -98,6 +98,23 @@ local function getSawCenter(saw)
     return saw.x, py
 end
 
+local function getSawCollisionCenter(saw)
+    local px, py = getSawCenter(saw)
+    if not (px and py) then
+        return px, py
+    end
+
+    local sinkOffset = SINK_OFFSET + (saw.sinkProgress or 0) * SINK_DISTANCE
+    if saw.dir == "horizontal" then
+        py = py + sinkOffset
+    else
+        local sinkDir = (saw.side == "left") and -1 or 1
+        px = px + sinkDir * sinkOffset
+    end
+
+    return px, py
+end
+
 local function removeSaw(target)
     if not target then
         return
@@ -184,6 +201,10 @@ end
 
 function Saws:getCenter(saw)
     return getSawCenter(saw)
+end
+
+function Saws:getCollisionCenter(saw)
+    return getSawCollisionCenter(saw)
 end
 
 function Saws:reset()
@@ -468,7 +489,7 @@ end
 function Saws:checkCollision(x, y, w, h)
     for _, saw in ipairs(self:getAll()) do
         if not ((saw.sinkProgress or 0) > 0 or (saw.sinkTarget or 0) > 0) then
-            local px, py = getSawCenter(saw)
+            local px, py = getSawCollisionCenter(saw)
 
             -- Circle vs AABB
             local closestX = math.max(x, math.min(px, x + w))

--- a/snake.lua
+++ b/snake.lua
@@ -1521,11 +1521,11 @@ local function isSawActive(saw)
 end
 
 local function getSawCenterPosition(saw)
-    if not (Saws and Saws.getCenter) then
+    if not (Saws and Saws.getCollisionCenter) then
         return nil, nil
     end
 
-    return Saws:getCenter(saw)
+    return Saws:getCollisionCenter(saw)
 end
 
 local function addSeveredTrail(pieceTrail, segmentEstimate)


### PR DESCRIPTION
## Summary
- adjust saw collision center calculations to include their rendered sink offset
- expose the collision-aware center and use it for snake body checks and environment collision tests

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dea95d3a94832f83f7731ac974a61c