### PR TITLE
Ensure slow time affects snake and fix hourglass icon

### DIFF
--- a/snake.lua
+++ b/snake.lua
@@ -45,9 +45,27 @@ Snake.stoneSkinSawGrace = 0
 Snake.dash = nil
 Snake.timeDilation = nil
 
+local function resolveTimeDilationScale(ability)
+    if ability and ability.active then
+        local scale = ability.timeScale or 1
+        if not (scale and scale > 0) then
+            scale = 0.05
+        end
+        return scale
+    end
+
+    return 1
+end
+
 -- getters / mutators (safe API for upgrades)
 function Snake:getSpeed()
-    return (self.baseSpeed or 1) * (self.speedMult or 1)
+    local speed = (self.baseSpeed or 1) * (self.speedMult or 1)
+    local scale = resolveTimeDilationScale(self.timeDilation)
+    if scale ~= 1 then
+        speed = speed * scale
+    end
+
+    return speed
 end
 
 function Snake:addSpeedMultiplier(mult)
@@ -1031,17 +1049,6 @@ function Snake:update(dt)
         end
     end
 
-    if self.timeDilation and self.timeDilation.active then
-        local scale = self.timeDilation.timeScale or 1
-        if not (scale and scale > 0) then
-            scale = 0.05
-        end
-
-        if scale ~= 1 then
-            speed = speed * scale
-        end
-    end
-
     hole = descendingHole
     if hole and head then
         local dx = hole.x - head.drawX
@@ -1384,23 +1391,14 @@ function Snake:getTimeDilationState()
         duration = ability.duration or 0,
         cooldown = ability.cooldown or 0,
         cooldownTimer = ability.cooldownTimer or 0,
-        timeScale = ability.timeScale or 1,
+        timeScale = resolveTimeDilationScale(ability),
         floorCharges = ability.floorCharges,
         maxFloorUses = ability.maxFloorUses,
     }
 end
 
 function Snake:getTimeScale()
-    local ability = self.timeDilation
-    if ability and ability.active then
-        local scale = ability.timeScale or 1
-        if scale < 0.05 then
-            scale = 0.05
-        end
-        return scale
-    end
-
-    return 1
+    return resolveTimeDilationScale(self.timeDilation)
 end
 
 function Snake:updateReverseState(reversed)

--- a/ui.lua
+++ b/ui.lua
@@ -1076,7 +1076,6 @@ local function drawIndicatorIcon(icon, accentColor, x, y, radius, overlay)
         love.graphics.circle("line", 0, 0, radius * 0.95, 28)
     elseif icon == "hourglass" then
         local bowl = {
-            -radius * 0.7, -radius * 0.78,
             radius * 0.7, -radius * 0.78,
             radius * 0.32, -radius * 0.12,
             radius * 0.32, radius * 0.12,
@@ -1084,6 +1083,7 @@ local function drawIndicatorIcon(icon, accentColor, x, y, radius, overlay)
             -radius * 0.7, radius * 0.78,
             -radius * 0.32, radius * 0.12,
             -radius * 0.32, -radius * 0.12,
+            -radius * 0.7, -radius * 0.78,
         }
         love.graphics.polygon("fill", bowl)
         love.graphics.setColor(base[1], base[2], base[3], (base[4] or 1) * 0.6)


### PR DESCRIPTION
## Summary
- ensure the time dilation effect scales the snake's speed consistently by centralizing the scale lookup
- expose the normalized slow-time scale to state queries to keep HUD feedback accurate
- tweak the hourglass indicator polygon so both sides pinch inward evenly

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68deaa64df84832fb96d4875fd1dde2a