### PR TITLE
Simplify mode select presentation

### DIFF
--- a/modeselect.lua
+++ b/modeselect.lua
@@ -16,48 +16,9 @@ local ANALOG_DEADZONE = 0.35
 local buttonList = ButtonList.new()
 local analogAxisDirections = { horizontal = nil, vertical = nil }
 
-local function clamp01(value)
-    if value < 0 then
-        return 0
-    elseif value > 1 then
-        return 1
-    end
-    return value
-end
-
-local function lighten(color, amount, alpha)
-    local r = color[1] or 0
-    local g = color[2] or 0
-    local b = color[3] or 0
-    local a = alpha or color[4] or 1
-
-    amount = clamp01(amount or 0)
-
-    return {
-        clamp01(r + (1 - r) * amount),
-        clamp01(g + (1 - g) * amount),
-        clamp01(b + (1 - b) * amount),
-        clamp01(a),
-    }
-end
-
-local function darken(color, amount, alpha)
-    local r = color[1] or 0
-    local g = color[2] or 0
-    local b = color[3] or 0
-    local a = alpha or color[4] or 1
-
-    amount = clamp01(amount or 0)
-
-    return {
-        clamp01(r * (1 - amount)),
-        clamp01(g * (1 - amount)),
-        clamp01(b * (1 - amount)),
-        clamp01(a),
-    }
-end
-
 local function withAlpha(color, alpha)
+    color = color or {1, 1, 1, 1}
+
     return {
         color[1] or 0,
         color[2] or 0,
@@ -66,7 +27,7 @@ local function withAlpha(color, alpha)
     }
 end
 
-local BACKGROUND_EFFECT_TYPE = "modeRibbon"
+local BACKGROUND_EFFECT_TYPE = "modeGradient"
 local backgroundEffectCache = {}
 local backgroundEffect = nil
 
@@ -82,8 +43,7 @@ local function configureBackgroundEffect()
 
     Shaders.configure(effect, {
         bgColor = Theme.bgColor,
-        accentColor = Theme.borderColor,
-        edgeColor = Theme.progressColor,
+        accentColor = Theme.progressColor,
     })
 
     backgroundEffect = effect
@@ -101,14 +61,6 @@ local function drawBackground(sw, sh)
         local intensity = backgroundEffect.backdropIntensity or select(1, Shaders.getDefaultIntensities(backgroundEffect))
         Shaders.draw(backgroundEffect, 0, 0, sw, sh, intensity)
     end
-
-    local softGlow = lighten(Theme.progressColor or {1, 1, 1, 1}, 0.35, 0.08)
-    love.graphics.setColor(softGlow)
-    love.graphics.circle("fill", sw * 0.22, sh * 0.18, sw * 0.35)
-    love.graphics.circle("fill", sw * 0.78, sh * 0.72, sw * 0.42)
-
-    love.graphics.setColor(1, 1, 1, 0.04)
-    love.graphics.rectangle("fill", 0, 0, sw, sh)
 
     love.graphics.setColor(1, 1, 1, 1)
 end
@@ -267,11 +219,6 @@ function ModeSelect:draw()
     love.graphics.setColor(withAlpha(Theme.mutedTextColor or Theme.textColor, 0.8))
     love.graphics.printf(Localization:get("modeselect.tagline"), 0, 120, sw, "center")
 
-    local softButtonColor = lighten(Theme.buttonColor, 0.30, 1)
-    local softHoverColor = lighten(Theme.buttonHover or Theme.buttonColor, 0.38, 1)
-    local softPressColor = darken(Theme.buttonPress or Theme.buttonColor, 0.20, 1)
-    local softBorderColor = lighten(Theme.borderColor or Theme.buttonColor, 0.10, 1)
-
     for _, btn in buttonList:iter() do
         if btn.modeKey ~= "back" then
             local modeLabel = Localization:get(btn.modeLabelKey or btn.textKey)
@@ -294,18 +241,6 @@ function ModeSelect:draw()
         end
     end
 
-    local previousRadius = UI.spacing.buttonRadius
-    local previousButtonColor = UI.colors.button
-    local previousHoverColor = UI.colors.buttonHover
-    local previousPressColor = UI.colors.buttonPress
-    local previousBorderColor = UI.colors.border
-
-    UI.spacing.buttonRadius = 24
-    UI.colors.button = softButtonColor
-    UI.colors.buttonHover = softHoverColor
-    UI.colors.buttonPress = softPressColor
-    UI.colors.border = softBorderColor
-
     local function drawModeCard(btn)
         local card = btn.card
         if not card then return end
@@ -313,28 +248,14 @@ function ModeSelect:draw()
         local x, y = card.x, card.y
         local w, h = card.w, card.h
         local radius = card.radius or 32
-
-        love.graphics.setColor(0, 0, 0, 0.28)
-        love.graphics.rectangle("fill", x, y + 6, w, h, radius + 6, radius + 6)
-
-        local baseColor = lighten(Theme.panelColor or Theme.bgColor, 0.32, 0.96)
-        love.graphics.setColor(baseColor)
-        love.graphics.rectangle("fill", x, y, w, h, radius, radius)
-
-        local highlightColor = withAlpha(lighten(baseColor, 0.35, baseColor[4] or 1), 0.35)
-        love.graphics.setColor(highlightColor)
-        love.graphics.rectangle("fill", x, y, w, h * 0.45, radius, radius)
-
-        local accent = withAlpha(lighten(Theme.progressColor or {1, 1, 1, 1}, 0.15, 1), btn.focused and 0.22 or 0.15)
-        love.graphics.setColor(accent)
-        love.graphics.circle("fill", x + w - 96, y + 58, 132)
-        love.graphics.circle("fill", x + 86, y + h - 74, 108)
-
-        love.graphics.setColor(withAlpha(Theme.highlightColor or {1, 1, 1, 1}, 0.35))
-        love.graphics.setLineWidth(2)
-        love.graphics.rectangle("line", x, y, w, h, radius, radius)
-
-        love.graphics.setLineWidth(1)
+        UI.drawPanel(x, y, w, h, {
+            radius = radius,
+            shadowOffset = UI.spacing.shadowOffset,
+            focused = btn.focused,
+            focusColor = Theme.progressColor,
+            focusAlpha = 0.9,
+            borderWidth = 2,
+        })
     end
 
     for _, btn in buttonList:iter() do
@@ -344,12 +265,6 @@ function ModeSelect:draw()
     end
 
     buttonList:draw()
-
-    UI.colors.button = previousButtonColor
-    UI.colors.buttonHover = previousHoverColor
-    UI.colors.buttonPress = previousPressColor
-    UI.colors.border = previousBorderColor
-    UI.spacing.buttonRadius = previousRadius
 
     for _, btn in buttonList:iter() do
         if btn.modeKey ~= "back" and btn.card then
@@ -369,7 +284,7 @@ function ModeSelect:draw()
             if btn.unlocked and btn.score then
                 local scoreText = Localization:get("modeselect.high_score", { score = tostring(btn.score) })
                 love.graphics.setFont(UI.fonts.body)
-                love.graphics.setColor(withAlpha(Theme.progressColor, 0.95))
+                love.graphics.setColor(withAlpha(Theme.progressColor or Theme.textColor, 0.95))
                 local tw = UI.fonts.body:getWidth(scoreText)
                 local scoreY = card.y + card.h - card.paddingY - btn.h - UI.fonts.body:getHeight() - 12
                 love.graphics.print(scoreText, card.x + card.w - card.paddingX - tw, scoreY)

--- a/shaders.lua
+++ b/shaders.lua
@@ -878,6 +878,47 @@ registerEffect({
         return drawShader(effect, x, y, w, h, intensity)
     end,
 })
+-- Simple gradient wash for mode selection
+registerEffect({
+    type = "modeGradient",
+    backdropIntensity = 0.46,
+    arenaIntensity = 0.28,
+    source = [[
+        extern float time;
+        extern vec2 resolution;
+        extern vec2 origin;
+        extern vec4 baseColor;
+        extern vec4 accentColor;
+        extern float intensity;
+
+        vec4 effect(vec4 color, Image tex, vec2 texture_coords, vec2 screen_coords)
+        {
+            vec2 uv = (screen_coords - origin) / resolution;
+            uv = clamp(uv, 0.0, 1.0);
+
+            float vertical = smoothstep(0.0, 1.0, uv.y);
+            float wave = sin((uv.x + time * 0.18) * 2.6) * 0.5 + 0.5;
+            float mixAmount = clamp(vertical * 0.55 + wave * 0.25, 0.0, 1.0) * intensity;
+
+            vec3 col = mix(baseColor.rgb, accentColor.rgb, mixAmount);
+            col = mix(baseColor.rgb, col, 0.82);
+
+            return vec4(col, baseColor.a) * color;
+        }
+    ]],
+    configure = function(effect, palette)
+        local shader = effect.shader
+
+        local base = getColorComponents(palette and (palette.bgColor or palette.baseColor), Theme.bgColor)
+        local accent = getColorComponents(palette and (palette.accentColor or palette.primary), Theme.progressColor)
+
+        sendColor(shader, "baseColor", base)
+        sendColor(shader, "accentColor", accent)
+    end,
+    draw = function(effect, x, y, w, h, intensity)
+        return drawShader(effect, x, y, w, h, intensity)
+    end,
+})
 -- Directional ribbons for mode selection energy
 registerEffect({
     type = "modeRibbon",


### PR DESCRIPTION
## Summary
- replace the mode selection background effect with a lightweight gradient shader
- render mode cards with the shared UI panel frame and remove bespoke glow layers
- keep mode information updates intact while simplifying button styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deacb1f280832fb582aedd8344c667