### PR TITLE
Make shaders react to combos and special events

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -22,6 +22,7 @@ local Arena = require("arena")
 local UI = require("ui")
 local Theme = require("theme")
 local FruitEvents = require("fruitevents")
+local Shaders = require("shaders")
 local GameModes = require("gamemodes")
 local GameUtils = require("gameutils")
 local Saws = require("saws")
@@ -750,6 +751,7 @@ function Game:update(dt)
     updateRunTimers(self, scaledDt)
 
     FruitEvents.update(scaledDt)
+    Shaders.update(scaledDt)
 
     if self.transition and self.transition:isActive() then
         self.transition:update(scaledDt)


### PR DESCRIPTION
## Summary
- add reactive shader state that boosts intensity and tinting when combos climb or special events trigger
- notify shaders from fruit combo logic so rewards, boosts, and dragonfruit moments pulse the background
- update the main game loop to advance shader reactions every frame

## Testing
- Not run (Lua runtime not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68deb117b9cc832fb2d7f498811bc397