### PR TITLE
Ensure restocked shop cards fade out completely

### DIFF
--- a/shop.lua
+++ b/shop.lua
@@ -831,11 +831,11 @@ function Shop:draw(screenW, screenH)
         else
             if discardData then
                 scale = scale * (1 - 0.05 * fadeEase)
-                alpha = alpha * (1 - 0.55 * fadeEase)
+                alpha = alpha * math.max(0, 1 - fadeEase)
             else
                 yOffset = yOffset - 32 * fadeEase
                 scale = scale * (1 - 0.2 * fadeEase)
-                alpha = alpha * (1 - 0.9 * fadeEase)
+                alpha = alpha * math.max(0, 1 - fadeEase)
             end
         end
 


### PR DESCRIPTION
## Summary
- ensure the shop restock animation reduces card opacity all the way to zero before removal

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68decd48cc74832f99ceda8b036efac5