### PR TITLE
Keep saw animations active during descent

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -319,6 +319,11 @@ end
 function Game:updateDescending(dt)
     Snake:update(dt)
 
+    -- Keep saw blades animating while the snake descends into the exit hole
+    if Saws and Saws.update then
+        Saws:update(dt)
+    end
+
     local segments = Snake:getSegments()
     local tail = segments[#segments]
     if not tail then


### PR DESCRIPTION
## Summary
- continue updating saw blades while the snake descends into the exit so their animations stay alive

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68decea6c42c832fb0e6aad3e7478a10