### PR TITLE
Add additional daily fun challenges

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -90,6 +90,21 @@ local english = {
                     progress = "No-turn chain: ${current}/${goal}",
                     complete = "Smooth operator! Chain hit ${current}.",
                 },
+                floor_conqueror = {
+                    title = "Floor Conqueror",
+                    description = "Clear ${goal} floors in a single run.",
+                },
+                apple_hoarder = {
+                    title = "Apple Hoarder",
+                    description = "Collect ${goal} apples in a single run.",
+                    progress = "Run apples: ${current}/${goal}",
+                },
+                streak_perfectionist = {
+                    title = "Streak Perfectionist",
+                    description = "Collect ${goal} fruit without turning in a single run.",
+                    progress = "No-turn chain: ${current}/${goal}",
+                    complete = "Flawless flow! Chain reached ${current}.",
+                },
             },
         },
         settings = {

--- a/funchallenges.lua
+++ b/funchallenges.lua
@@ -412,6 +412,33 @@ FunChallenges.challenges = {
         completeKey = "menu.fun_daily.streak_pusher.complete",
         xpReward = 70,
     },
+    {
+        id = "floor_conqueror",
+        titleKey = "menu.fun_daily.floor_conqueror.title",
+        descriptionKey = "menu.fun_daily.floor_conqueror.description",
+        sessionStat = "floorsCleared",
+        goal = 10,
+        xpReward = 100,
+    },
+    {
+        id = "apple_hoarder",
+        titleKey = "menu.fun_daily.apple_hoarder.title",
+        descriptionKey = "menu.fun_daily.apple_hoarder.description",
+        sessionStat = "applesEaten",
+        goal = 90,
+        progressKey = "menu.fun_daily.apple_hoarder.progress",
+        xpReward = 90,
+    },
+    {
+        id = "streak_perfectionist",
+        titleKey = "menu.fun_daily.streak_perfectionist.title",
+        descriptionKey = "menu.fun_daily.streak_perfectionist.description",
+        sessionStat = "fruitWithoutTurning",
+        goal = 15,
+        progressKey = "menu.fun_daily.streak_perfectionist.progress",
+        completeKey = "menu.fun_daily.streak_perfectionist.complete",
+        xpReward = 90,
+    },
 }
 
 FunChallenges.lookup = buildChallengeLookup(FunChallenges.challenges)


### PR DESCRIPTION
## Summary
- add three new daily fun challenges covering deeper floor clears, apple collection, and longer no-turn streaks
- provide English localization strings for the new challenges

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ded0cd63e8832f95cfca925e0e4b26