### PR TITLE
Add ROUNDS-inspired beats to gameplay enhancement plan

### DIFF
--- a/Docs/gameplay_enhancements.md
+++ b/Docs/gameplay_enhancements.md
@@ -15,3 +15,12 @@ This document captures potential levers for increasing tension, moment-to-moment
 - **Dynamic objectives:** Surface rotating mini-challenges (avoid conveyor hits for two floors, rescue trapped fruit) that tap into the achievement framework for on-the-run rewards.
 - **Milestone-based unlocks:** Tie new cosmetics or upgrade rarities to cumulative feats—such as total perfect floors or combo streak lengths—to encourage repeated runs.
 - **Synergy scouting:** Track recently unlocked upgrades and suggest loadout pairings during downtime screens to keep players chasing fresh build experiments.
+
+## ROUNDS-Inspired Enhancements
+- **Shorter, punchier encounter sets:** Experiment with mini-gauntlets that chain two or three micro-floors together before a breather screen. Borrowing *ROUNDS*' sub-minute cadence can keep the session lively while respecting the existing floor-based structure.
+- **Comeback-biased upgrade drafts:** When players fall behind on objectives or take multiple deaths in a row, surface a weighted pick list of power-ups the way *ROUNDS* hands the next card to the underdog. This maintains tension and encourages riskier play without erasing skill differentials.
+- **Themed synergy tags:** Introduce simple tags on upgrades ("Bounce", "Dash", "Shield") inside the UI to hint at combo potential, mirroring how *ROUNDS* celebrates loose archetypes. Tags can drive contextual tooltips that highlight related picks the player already owns.
+- **Celebratory pick moments:** When offering mid-run choices—fruit mutators, achievement rewards, or shop bundles—temporarily dim the arena, zoom the camera, and present oversized cards or panels. Leaning into *ROUNDS*' theatrical draft treatment reinforces that these decisions define the run.
+- **Expressive yet readable hit feedback:** Layer screen shakes, outline pulses, and knockback exaggeration onto existing hazard collisions to ensure important events land with the same clarity *ROUNDS* achieves through diegetic effects. Keep the motion brief so precision platforming remains fair.
+- **Compact, destructible arena variants:** Prototype bite-sized rooms that can crumble or reconfigure after repeated hazard triggers, creating evolving layouts reminiscent of *ROUNDS*' destructible cover while still serving our fruit-chasing loop.
+- **Loop-friendly restart flow:** Streamline post-run menus with a single "Rematch" or "Retry floor" action that skips deep menu nesting, acknowledging the party-game pacing that keeps *ROUNDS* sticky during couch sessions.


### PR DESCRIPTION
## Summary
- add a new section to the gameplay enhancements doc focused on lessons from ROUNDS
- outline actionable ideas for pacing, upgrade presentation, and feedback drawn from the reference game
- highlight UI and flow refinements that can preserve couch-friendly momentum

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68defc545c34832fa223b681160c1832