### PR TITLE
Add rock shatter sound for Stonebreaker effects

### DIFF
--- a/audio.lua
+++ b/audio.lua
@@ -28,6 +28,7 @@ local SOUND_DEFINITIONS = {
     shield_wall = "Assets/Sounds/Activate Glyph Forcefield.wav",
     shield_rock = "Assets/Sounds/Rotate Stone 03.wav",
     shield_saw = "Assets/Sounds/Arcane Wind Chime Gust.wav",
+    rock_shatter = "Assets/Sounds/Activate Plinth 03.wav",
 }
 
 local MUSIC_DEFINITIONS = {

--- a/rocks.lua
+++ b/rocks.lua
@@ -2,6 +2,7 @@ local Particles = require("particles")
 local Theme = require("theme")
 local Arena = require("arena")
 local SnakeUtils = require("snakeutils")
+local Audio = require("audio")
 
 local Rocks = {}
 local current = {}
@@ -249,6 +250,7 @@ function Rocks:shatterNearest(x, y, count)
         if not bestIndex then break end
 
         removeRockAt(bestIndex, true)
+        Audio:playSound("rock_shatter")
     end
 end
 


### PR DESCRIPTION
## Summary
- add a dedicated rock shatter sound effect sourced from Activate Plinth 03
- trigger the shatter sound when Stonebreaker-style effects pulverize nearby rocks

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df0549e4a0832fabed1667e2202403