### PR TITLE
Add visual ideas inspired by ROUNDS

### DIFF
--- a/Docs/rounds_visual_ideas.md
+++ b/Docs/rounds_visual_ideas.md
@@ -1,0 +1,26 @@
+# Visual Takeaways from *ROUNDS*
+
+This note distills visual presentation ideas from the lessons document to guide potential updates to Noodl's look and feel.
+
+## Arena & Combat Presentation
+- **One-screen, compact arenas.** Keep critical combat space fully visible to support readability in hectic moments and reduce camera friction.
+- **Destructible cover with visible states.** Highlight damage states through crumbling sprites or palette shifts so the battlefield feels alive and responsive.
+- **Readable physics exaggeration.** Amplify jump arcs, knockback trails, and projectile effects with bold silhouettes and motion streaks to clarify combat flow.
+- **Diegetic hit feedback.** Favor screen shake, color flashes, and knockback cues over UI overlays to communicate impact without clutter.
+
+## Upgrade Draft Experience
+- **Celebratory card reveal.** When presenting upgrades, dim the background, zoom toward the selection, and animate card entrances to emphasize the moment.
+- **Card motif across UI.** Reuse card-shaped panels and rounded frames in menus, victory screens, and tooltips to reinforce the upgrade identity.
+- **Tooltip clarity by rarity.** Surface concise stats upfront while reserving detailed behavior notes for hover or rarer items to keep choices snappy.
+- **Synergy tags and highlights.** Add small badge graphics (e.g., "Bounce", "Explosive") on upgrade cards to visually hint at combos without verbose text.
+
+## Visual Identity
+- **Bold, flat color palettes.** Employ high-contrast color blocking with thick outlines on characters and UI to maintain readability and support rapid skinning.
+- **Dynamic backgrounds.** Layer simple gradient backdrops with subtle animated elements (particles, parallax shapes) to keep minimalist scenes energetic.
+- **Consistent typography.** Pair the flat aesthetic with clean, geometric fonts on cards and menus for cohesion.
+
+## Feedback & Audio Integration
+- **Chunky SFX visualization.** Tie distinct sound cues to matching visual bursts (e.g., waveform flashes, vibration trails) so players associate mechanics quickly.
+- **Rhythmic UI pulses.** Sync ambient beats with gentle UI pulses or particle bursts to enhance tempo without overwhelming gameplay focus.
+
+Implementing these ideas can help Noodl capture the readable chaos and celebratory moments that give *ROUNDS* its visual appeal while maintaining the game's unique identity.


### PR DESCRIPTION
## Summary
- capture actionable visual presentation ideas from rounds_lessons.md
- document arena, upgrade draft, and identity cues that could translate to Noodl

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df0ba937e0832fbbfb5596f7b11a1a