### PR TITLE
Adjust Verdant Garden arena border color

### DIFF
--- a/floors.lua
+++ b/floors.lua
@@ -29,7 +29,7 @@ local Floors = {
                 palette = {
                         bgColor     = {0.24, 0.32, 0.24, 1}, -- brighter forest green backdrop
                         arenaBG     = {0.46, 0.66, 0.39, 1}, -- still bright, grassy playfield
-                        arenaBorder = {0.55, 0.75, 0.4, 1},  -- leafy, slightly lighter edge
+                        arenaBorder = {0.52, 0.38, 0.24, 1},  -- warm soil rim to break up the greens
                         snake       = {0.12, 0.9, 0.48, 1},  -- vivid spring green snake
                         rock        = {0.74, 0.59, 0.38, 1}, -- sun-baked sandstone, pops from grass
                 },


### PR DESCRIPTION
## Summary
- warm up the Verdant Garden arena border with an earthy soil tone to offset the dominant greens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df15b73258832f8bf5a35f1b8e3e8d