### PR TITLE
Add cosmetics tab to progression screen

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -165,7 +165,17 @@ local english = {
             status_locked = "Unlocks in ${xp} XP",
             tabs = {
                 experience = "Experience",
+                cosmetics = "Cosmetics",
                 stats = "Lifetime Stats",
+            },
+            cosmetics = {
+                header = "Snake Skins",
+                locked_label = "Locked",
+                locked_level = "Reach level ${level} to unlock.",
+                locked_achievement = "Unlock achievement: ${name}.",
+                locked_generic = "Discover this skin by progressing further.",
+                equip_hint = "Click or press Enter to equip.",
+                equipped = "Equipped",
             },
             stats_header = "Lifetime Stats",
             stats_empty = "Keep playing to build your legacy!",


### PR DESCRIPTION
## Summary
- add a cosmetics tab to the progression screen that lists snake skins with previews and status messaging
- hook the progression screen into the snake cosmetics system so players can equip unlocked skins directly from the new tab
- add English localization strings for the cosmetics tab UI

## Testing
- No tests were run (Lua tooling is unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68df162d7594832f8a1c07594321cc94