### PR TITLE
Adjust saw blade collision radius

### DIFF
--- a/saws.lua
+++ b/saws.lua
@@ -9,7 +9,7 @@ local slots = {}
 local nextSlotId = 0
 
 local SAW_RADIUS = 24
-local COLLISION_RADIUS_MULT = 0.88 -- keep the visual size but ease up on collision tightness
+local COLLISION_RADIUS_MULT = 0.82 -- keep the visual size but ease up on collision tightness
 local SAW_TEETH = 12
 local HUB_HOLE_RADIUS = 4
 local HUB_HIGHLIGHT_PADDING = 3


### PR DESCRIPTION
## Summary
- reduce the saw collision radius multiplier to ease blade hit detection

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df2e31e014832fb6abd37793419421