### PR TITLE
Fix overlay shader intensity to cover snake corners

### DIFF
--- a/snakedraw.lua
+++ b/snakedraw.lua
@@ -34,7 +34,7 @@ local overlayShaderSources = {
       float c = cos(angle);
       float s = sin(angle);
       float stripe = sin((uv.x * c + uv.y * s) * frequency + time * speed) * 0.5 + 0.5;
-      float blend = clamp(stripe * intensity * mask, 0.0, 1.0);
+      float blend = clamp(stripe * intensity, 0.0, 1.0);
       vec3 mixCol = mix(colorA.rgb, colorB.rgb, stripe);
       vec3 result = mix(base.rgb, mixCol, blend);
       return vec4(result, base.a) * color;
@@ -66,7 +66,7 @@ local overlayShaderSources = {
       layer = mix(layer, colorC.rgb, clamp(radial * 0.5 + 0.5, 0.0, 1.0) * 0.6);
       layer += shimmer * 0.12 * colorC.rgb;
 
-      float blend = clamp(intensity * mask, 0.0, 1.0);
+      float blend = clamp(intensity, 0.0, 1.0);
       vec3 result = mix(base.rgb, layer, blend);
       return vec4(result, base.a) * color;
     }


### PR DESCRIPTION
## Summary
- update overlay shaders to keep full intensity regardless of alpha mask so corner plugs match the body tint

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df3c43fd50832fab8239159a15e162