### PR TITLE
Refactor snake skin rendering for overlays

### DIFF
--- a/snakedraw.lua
+++ b/snakedraw.lua
@@ -12,6 +12,7 @@ local FRUIT_BULGE_SCALE = 1.25
 -- Canvas for single-pass shadow
 local snakeCanvas = nil
 local snakeOverlayCanvas = nil
+local snakeMaskCanvas = nil
 
 local overlayShaderSources = {
   stripes = [[
@@ -22,13 +23,14 @@ local overlayShaderSources = {
     extern float intensity;
     extern vec4 colorA;
     extern vec4 colorB;
+    extern vec4 bodyColor;
 
     vec4 effect(vec4 color, Image tex, vec2 texture_coords, vec2 screen_coords)
     {
-      vec4 base = Texel(tex, texture_coords);
-      float mask = base.a;
+      vec4 maskSample = Texel(tex, texture_coords);
+      float mask = maskSample.a;
       if (mask <= 0.0) {
-        return base * color;
+        return vec4(0.0);
       }
 
       vec2 uv = texture_coords - vec2(0.5);
@@ -37,8 +39,9 @@ local overlayShaderSources = {
       float stripe = sin((uv.x * c + uv.y * s) * frequency + time * speed) * 0.5 + 0.5;
       float blend = clamp(stripe * intensity, 0.0, 1.0);
       vec3 mixCol = mix(colorA.rgb, colorB.rgb, stripe);
-      vec3 result = mix(base.rgb, mixCol, blend);
-      return vec4(result, base.a) * color;
+      vec3 result = mix(bodyColor.rgb, mixCol, blend);
+      float alpha = mask * bodyColor.a;
+      return vec4(result, alpha) * color;
     }
   ]],
   holo = [[
@@ -48,13 +51,14 @@ local overlayShaderSources = {
     extern vec4 colorA;
     extern vec4 colorB;
     extern vec4 colorC;
+    extern vec4 bodyColor;
 
     vec4 effect(vec4 color, Image tex, vec2 texture_coords, vec2 screen_coords)
     {
-      vec4 base = Texel(tex, texture_coords);
-      float mask = base.a;
+      vec4 maskSample = Texel(tex, texture_coords);
+      float mask = maskSample.a;
       if (mask <= 0.0) {
-        return base * color;
+        return vec4(0.0);
       }
 
       vec2 uv = texture_coords - vec2(0.5);
@@ -68,8 +72,9 @@ local overlayShaderSources = {
       layer += shimmer * 0.12 * colorC.rgb;
 
       float blend = clamp(intensity, 0.0, 1.0);
-      vec3 result = mix(base.rgb, layer, blend);
-      return vec4(result, base.a) * color;
+      vec3 result = mix(bodyColor.rgb, layer, blend);
+      float alpha = mask * bodyColor.a;
+      return vec4(result, alpha) * color;
     }
   ]],
 }
@@ -115,8 +120,8 @@ local function resolveColor(color, fallback)
   return {1, 1, 1, 1}
 end
 
-local function applyOverlay(canvas, config)
-  if not (canvas and config and config.type) then
+local function applyOverlay(maskCanvas, bodyColor, config)
+  if not (maskCanvas and config and config.type) then
     return false
   end
 
@@ -134,11 +139,13 @@ local function applyOverlay(canvas, config)
   local primary = resolveColor(colors.primary or colors.color or SnakeCosmetics:getBodyColor())
   local secondary = resolveColor(colors.secondary or SnakeCosmetics:getGlowColor())
   local tertiary = resolveColor(colors.tertiary or secondary)
+  local baseColor = resolveColor(bodyColor or SnakeCosmetics:getBodyColor())
 
   shader:send("time", time)
   shader:send("intensity", config.intensity or 0.5)
   shader:send("colorA", primary)
   shader:send("colorB", secondary)
+  shader:send("bodyColor", baseColor)
 
   if config.type == "stripes" then
     shader:send("frequency", config.frequency or 18)
@@ -153,7 +160,7 @@ local function applyOverlay(canvas, config)
   love.graphics.setShader(shader)
   love.graphics.setBlendMode(config.blendMode or "alpha")
   love.graphics.setColor(1, 1, 1, config.opacity or 1)
-  love.graphics.draw(canvas, 0, 0)
+  love.graphics.draw(maskCanvas, 0, 0)
   love.graphics.pop()
 
   return true
@@ -202,6 +209,21 @@ local function drawCapsuleTrail(trail, radius)
       love.graphics.circle("fill", x, y, radius)
     end
   end
+end
+
+local function ensureCanvas(canvas, width, height, msaa)
+  if canvas and canvas:getWidth() == width and canvas:getHeight() == height then
+    local currentMsaa = canvas.getMSAA and canvas:getMSAA() or 0
+    local targetMsaa = (msaa and msaa > 0) and msaa or 0
+    if currentMsaa ~= targetMsaa then
+      local settings = targetMsaa > 0 and {msaa = targetMsaa} or nil
+      return love.graphics.newCanvas(width, height, settings)
+    end
+    return canvas
+  end
+
+  local settings = (msaa and msaa > 0) and {msaa = msaa} or nil
+  return love.graphics.newCanvas(width, height, settings)
 end
 
 local function applySkinGlow(trail, head, radius, config)
@@ -274,17 +296,28 @@ local function renderSnakeToCanvas(trail, head, half, thickness)
   local outlineColor = SnakeCosmetics:getOutlineColor()
   local bodyR, bodyG, bodyB, bodyA = bodyColor[1] or 0, bodyColor[2] or 0, bodyColor[3] or 0, bodyColor[4] or 1
   local outlineR, outlineG, outlineB, outlineA = outlineColor[1] or 0, outlineColor[2] or 0, outlineColor[3] or 0, outlineColor[4] or 1
-  -- OUTLINE
-  love.graphics.setColor(outlineR, outlineG, outlineB, outlineA)
-  drawCapsuleTrail(trail, half + OUTLINE_SIZE * 0.5)
   local bulgeRadius = half * FRUIT_BULGE_SCALE
-  drawFruitBulges(trail, head, bulgeRadius + OUTLINE_SIZE * 0.5)
 
-  -- BODY
-  love.graphics.setColor(bodyR, bodyG, bodyB, bodyA)
+  -- build body mask for overlays and clean fills
+  love.graphics.setCanvas(snakeMaskCanvas)
+  love.graphics.clear(0, 0, 0, 0)
+  love.graphics.setColor(1, 1, 1, 1)
   drawCapsuleTrail(trail, half)
   drawFruitBulges(trail, head, bulgeRadius)
 
+  -- composite final base snake
+  love.graphics.setCanvas(snakeCanvas)
+  love.graphics.clear(0, 0, 0, 0)
+  love.graphics.setColor(outlineR, outlineG, outlineB, outlineA)
+  drawCapsuleTrail(trail, half + OUTLINE_SIZE * 0.5)
+  drawFruitBulges(trail, head, bulgeRadius + OUTLINE_SIZE * 0.5)
+
+  love.graphics.setColor(bodyR, bodyG, bodyB, bodyA)
+  love.graphics.draw(snakeMaskCanvas, 0, 0)
+
+  love.graphics.setCanvas()
+
+  return bodyColor
 end
 
 drawSoftGlow = function(x, y, radius, r, g, b, a)
@@ -692,41 +725,37 @@ local function drawSnake(trail, segmentCount, SEGMENT_SIZE, popTimer, getHead, s
   end
 
   if trailCount > 0 then
-    -- render into a canvas once
+    -- render into canvases once
     local ww, hh = love.graphics.getDimensions()
     if not snakeCanvas or snakeCanvas:getWidth() ~= ww or snakeCanvas:getHeight() ~= hh then
       snakeCanvas = love.graphics.newCanvas(ww, hh, {msaa = 8})
     end
 
-    love.graphics.setCanvas(snakeCanvas)
-    love.graphics.clear(0,0,0,0)
-    renderSnakeToCanvas(trail, head, half, thickness)
-    love.graphics.setCanvas()
+    local canvasMsaa = snakeCanvas and snakeCanvas.getMSAA and snakeCanvas:getMSAA() or 0
+    snakeMaskCanvas = ensureCanvas(snakeMaskCanvas, ww, hh, canvasMsaa)
+
+    if overlayEffect then
+      snakeOverlayCanvas = ensureCanvas(snakeOverlayCanvas, ww, hh, canvasMsaa)
+    end
+
+    local bodyColor = renderSnakeToCanvas(trail, head, half, thickness)
 
     -- single-pass drop shadow
     love.graphics.setColor(0,0,0,0.25)
     love.graphics.draw(snakeCanvas, SHADOW_OFFSET, SHADOW_OFFSET)
 
-    -- snake
+    -- snake base
+    love.graphics.setColor(1,1,1,1)
     local drewOverlay = false
-    if overlayEffect then
-      if not snakeOverlayCanvas or snakeOverlayCanvas:getWidth() ~= ww or snakeOverlayCanvas:getHeight() ~= hh then
-        local msaa = snakeCanvas and snakeCanvas.getMSAA and snakeCanvas:getMSAA() or 0
-        snakeOverlayCanvas = love.graphics.newCanvas(ww, hh, msaa > 0 and {msaa = msaa} or nil)
-      elseif snakeOverlayCanvas.getMSAA and snakeCanvas and snakeCanvas.getMSAA and snakeOverlayCanvas:getMSAA() ~= snakeCanvas:getMSAA() then
-        local msaa = snakeCanvas:getMSAA()
-        snakeOverlayCanvas = love.graphics.newCanvas(ww, hh, msaa > 0 and {msaa = msaa} or nil)
-      end
-
+    if overlayEffect and snakeOverlayCanvas then
       love.graphics.setCanvas(snakeOverlayCanvas)
       love.graphics.clear(0, 0, 0, 0)
       love.graphics.setColor(1,1,1,1)
       love.graphics.draw(snakeCanvas, 0, 0)
-      drewOverlay = applyOverlay(snakeCanvas, overlayEffect)
+      drewOverlay = applyOverlay(snakeMaskCanvas, bodyColor, overlayEffect)
       love.graphics.setCanvas()
     end
 
-    love.graphics.setColor(1,1,1,1)
     if drewOverlay then
       love.graphics.draw(snakeOverlayCanvas, 0, 0)
     else


### PR DESCRIPTION
## Summary
- build a dedicated mask canvas for the snake body and reuse it for both base fills and overlay effects
- update overlay shaders and rendering flow so body color is composited cleanly before layering effects
- add canvas management helpers to keep overlay canvases synchronized with the main snake canvas size and MSAA settings

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68df4f0a6be0832fb524bbaf29c454a8