### PR TITLE
Handle missing round line join

### DIFF
--- a/snake.lua
+++ b/snake.lua
@@ -530,7 +530,13 @@ local function debugDrawCollisionSpace(trailData, headX, headY)
 
         if #coords >= 4 then
             love.graphics.setLineCap("round")
-            love.graphics.setLineJoin("round")
+            local setLineJoin = love.graphics.setLineJoin
+            if setLineJoin then
+                local ok = pcall(setLineJoin, "round")
+                if not ok then
+                    setLineJoin("bevel")
+                end
+            end
 
             love.graphics.setColor(1, 0, 0, 0.12)
             love.graphics.setLineWidth(SEGMENT_SIZE)

--- a/snakedraw.lua
+++ b/snakedraw.lua
@@ -186,7 +186,10 @@ local function drawCapsuleTrail(trail, radius)
   local previousJoin = love.graphics.getLineJoin and love.graphics.getLineJoin()
   love.graphics.setLineWidth(radius * 2)
   if love.graphics.setLineJoin then
-    love.graphics.setLineJoin("round")
+    local ok = pcall(love.graphics.setLineJoin, "round")
+    if not ok then
+      love.graphics.setLineJoin("bevel")
+    end
   end
 
   local segmentPoints = {}
@@ -216,7 +219,10 @@ local function drawCapsuleTrail(trail, radius)
 
   love.graphics.setLineWidth(previousWidth)
   if previousJoin and love.graphics.setLineJoin then
-    love.graphics.setLineJoin(previousJoin)
+    local ok = pcall(love.graphics.setLineJoin, previousJoin)
+    if not ok then
+      love.graphics.setLineJoin("bevel")
+    end
   end
 end
 


### PR DESCRIPTION
## Summary
- guard snake trail rendering against Love versions that lack the "round" line join option
- fall back to a bevel join when setting or restoring the line join fails

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df5b6e8694832f8e2db2e63b0e83d4