### PR TITLE
Fix line join compatibility for snake rendering

### DIFF
--- a/snake.lua
+++ b/snake.lua
@@ -530,21 +530,43 @@ local function debugDrawCollisionSpace(trailData, headX, headY)
 
         if #coords >= 4 then
             love.graphics.setLineCap("round")
+            local getLineJoin = love.graphics.getLineJoin
             local setLineJoin = love.graphics.setLineJoin
+            local previousJoin = getLineJoin and getLineJoin() or nil
             if setLineJoin then
-                local ok = pcall(setLineJoin, "round")
+                local ok = pcall(setLineJoin, "bevel")
                 if not ok then
-                    setLineJoin("bevel")
+                    pcall(setLineJoin, "miter")
                 end
             end
 
             love.graphics.setColor(1, 0, 0, 0.12)
             love.graphics.setLineWidth(SEGMENT_SIZE)
             love.graphics.line(unpack(coords))
+            local radius = SEGMENT_SIZE / 2
+            for i = 1, #coords, 2 do
+                local cx, cy = coords[i], coords[i + 1]
+                if cx and cy then
+                    love.graphics.circle("fill", cx, cy, radius)
+                end
+            end
 
             love.graphics.setColor(1, 0, 0, 0.45)
             love.graphics.setLineWidth(2)
             love.graphics.line(unpack(coords))
+            for i = 1, #coords, 2 do
+                local cx, cy = coords[i], coords[i + 1]
+                if cx and cy then
+                    love.graphics.circle("line", cx, cy, radius)
+                end
+            end
+
+            if previousJoin and setLineJoin then
+                local ok = pcall(setLineJoin, previousJoin)
+                if not ok then
+                    pcall(setLineJoin, "bevel")
+                end
+            end
         end
     end
 

--- a/snakedraw.lua
+++ b/snakedraw.lua
@@ -183,12 +183,15 @@ local function drawCapsuleTrail(trail, radius)
   end
 
   local previousWidth = love.graphics.getLineWidth()
-  local previousJoin = love.graphics.getLineJoin and love.graphics.getLineJoin()
+  local getLineJoin = love.graphics.getLineJoin
+  local previousJoin = getLineJoin and getLineJoin()
   love.graphics.setLineWidth(radius * 2)
-  if love.graphics.setLineJoin then
-    local ok = pcall(love.graphics.setLineJoin, "round")
+
+  local setLineJoin = love.graphics.setLineJoin
+  if setLineJoin then
+    local ok = pcall(setLineJoin, "bevel")
     if not ok then
-      love.graphics.setLineJoin("bevel")
+      pcall(setLineJoin, "miter")
     end
   end
 
@@ -197,6 +200,12 @@ local function drawCapsuleTrail(trail, radius)
     local count = #segmentPoints
     if count >= 4 then
       love.graphics.line(unpack(segmentPoints))
+      for i = 1, count, 2 do
+        local px, py = segmentPoints[i], segmentPoints[i + 1]
+        if px and py then
+          love.graphics.circle("fill", px, py, radius)
+        end
+      end
     elseif count == 2 then
       love.graphics.circle("fill", segmentPoints[1], segmentPoints[2], radius)
     end
@@ -218,10 +227,10 @@ local function drawCapsuleTrail(trail, radius)
   flush()
 
   love.graphics.setLineWidth(previousWidth)
-  if previousJoin and love.graphics.setLineJoin then
-    local ok = pcall(love.graphics.setLineJoin, previousJoin)
+  if previousJoin and setLineJoin then
+    local ok = pcall(setLineJoin, previousJoin)
     if not ok then
-      love.graphics.setLineJoin("bevel")
+      pcall(setLineJoin, "bevel")
     end
   end
 end


### PR DESCRIPTION
## Summary
- avoid using the unsupported `round` line join when rendering the snake trail
- add manual corner caps so the bevel join keeps the rounded appearance
- update the collision debug rendering to match the new join handling

## Testing
- not run (LÖVE runtime unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68df5f389340832f93bcab4f2bd85775