### PR TITLE
Add new daily fun challenges

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -55,6 +55,12 @@ local english = {
                     progress = "Emergency saves: ${current}/${goal}",
                     complete = "Shield mastery! ${current} clutch saves.",
                 },
+                shield_triad = {
+                    title = "Shield Triad",
+                    description = "Pull off all three shield maneuvers in a single run.",
+                    progress = "Shield feats: ${current}/${goal}",
+                    complete = "Shield trifecta! ${current} maneuvers mastered.",
+                },
                 marathon = {
                     title = "Serpentine Marathon",
                     description = "Slither ${goal} tiles in a single run.",
@@ -84,6 +90,11 @@ local english = {
                     progress = "Run survival: ${current}/${goal}",
                     complete = "Endurance expert! Survived ${current} minutes.",
                 },
+                floor_tourist = {
+                    title = "Floor Tourist",
+                    description = "Spend ${goal} minutes exploring floors in a single run.",
+                    progress = "Floor time: ${current}/${goal}",
+                },
                 streak_pusher = {
                     title = "Streak Pusher",
                     description = "Collect ${goal} fruit without turning in a single run.",
@@ -93,6 +104,12 @@ local english = {
                 floor_conqueror = {
                     title = "Floor Conqueror",
                     description = "Clear ${goal} floors in a single run.",
+                },
+                depth_delver = {
+                    title = "Depth Delver",
+                    description = "Reach floor ${goal} in a single run.",
+                    progress = "Deepest floor: ${current}/${goal}",
+                    complete = "Depth conquered! Reached floor ${current}.",
                 },
                 apple_hoarder = {
                     title = "Apple Hoarder",

--- a/funchallenges.lua
+++ b/funchallenges.lua
@@ -356,6 +356,29 @@ FunChallenges.challenges = {
         xpReward = 80,
     },
     {
+        id = "shield_triad",
+        titleKey = "menu.fun_daily.shield_triad.title",
+        descriptionKey = "menu.fun_daily.shield_triad.description",
+        goal = 3,
+        progressKey = "menu.fun_daily.shield_triad.progress",
+        completeKey = "menu.fun_daily.shield_triad.complete",
+        getValue = function(self, context)
+            local statsSource = context and context.sessionStats
+            if statsSource and type(statsSource.get) == "function" then
+                local wall = statsSource:get("runShieldWallBounces") or 0
+                local rock = statsSource:get("runShieldRockBreaks") or 0
+                local saw = statsSource:get("runShieldSawParries") or 0
+                return (wall > 0 and 1 or 0) + (rock > 0 and 1 or 0) + (saw > 0 and 1 or 0)
+            end
+
+            local wall = SessionStats and SessionStats.get and SessionStats:get("runShieldWallBounces") or 0
+            local rock = SessionStats and SessionStats.get and SessionStats:get("runShieldRockBreaks") or 0
+            local saw = SessionStats and SessionStats.get and SessionStats:get("runShieldSawParries") or 0
+            return (wall > 0 and 1 or 0) + (rock > 0 and 1 or 0) + (saw > 0 and 1 or 0)
+        end,
+        xpReward = 85,
+    },
+    {
         id = "serpentine_marathon",
         titleKey = "menu.fun_daily.marathon.title",
         descriptionKey = "menu.fun_daily.marathon.description",
@@ -423,6 +446,33 @@ FunChallenges.challenges = {
         xpReward = 90,
     },
     {
+        id = "floor_tourist",
+        titleKey = "menu.fun_daily.floor_tourist.title",
+        descriptionKey = "menu.fun_daily.floor_tourist.description",
+        sessionStat = "totalFloorTime",
+        goal = 720,
+        progressKey = "menu.fun_daily.floor_tourist.progress",
+        progressReplacements = function(self, current, goal)
+            local function formatSeconds(seconds)
+                seconds = math.max(0, math.floor(seconds or 0))
+                local minutes = math.floor(seconds / 60)
+                local secs = seconds % 60
+                return string.format("%d:%02d", minutes, secs)
+            end
+
+            return {
+                current = formatSeconds(current),
+                goal = formatSeconds(goal),
+            }
+        end,
+        descriptionReplacements = function(self, current, goal)
+            return {
+                goal = math.floor((goal or 0) / 60),
+            }
+        end,
+        xpReward = 85,
+    },
+    {
         id = "streak_pusher",
         titleKey = "menu.fun_daily.streak_pusher.title",
         descriptionKey = "menu.fun_daily.streak_pusher.description",
@@ -439,6 +489,22 @@ FunChallenges.challenges = {
         sessionStat = "floorsCleared",
         goal = 10,
         xpReward = 100,
+    },
+    {
+        id = "depth_delver",
+        titleKey = "menu.fun_daily.depth_delver.title",
+        descriptionKey = "menu.fun_daily.depth_delver.description",
+        sessionStat = "deepestFloorReached",
+        goal = 12,
+        progressKey = "menu.fun_daily.depth_delver.progress",
+        completeKey = "menu.fun_daily.depth_delver.complete",
+        progressReplacements = function(self, current, goal)
+            return {
+                current = math.max(1, math.floor(current or 1)),
+                goal = goal or 0,
+            }
+        end,
+        xpReward = 110,
     },
     {
         id = "apple_hoarder",


### PR DESCRIPTION
## Summary
- add three new daily fun challenges for shield variety, floor exploration time, and depth pushing
- include localized strings for the new daily challenges

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df69462940832f8d70efbbc58b1bec