### PR TITLE
Align saw tail collision detection with head logic

### DIFF
--- a/saws.lua
+++ b/saws.lua
@@ -149,6 +149,18 @@ local function overlapsCollisionCell(saw, x, y, w, h)
     return false
 end
 
+local function isCollisionCandidate(saw, x, y, w, h)
+    if not (saw and x and y and w and h) then
+        return false
+    end
+
+    if (saw.sinkProgress or 0) > 0 or (saw.sinkTarget or 0) > 0 then
+        return false
+    end
+
+    return overlapsCollisionCell(saw, x, y, w, h)
+end
+
 local function getMoveSpeed()
     return MOVE_SPEED * (Saws.speedMult or 1)
 end
@@ -637,9 +649,13 @@ function Saws:onFruitCollected()
     end
 end
 
+function Saws:isCollisionCandidate(saw, x, y, w, h)
+    return isCollisionCandidate(saw, x, y, w, h)
+end
+
 function Saws:checkCollision(x, y, w, h)
     for _, saw in ipairs(self:getAll()) do
-        if not ((saw.sinkProgress or 0) > 0 or (saw.sinkTarget or 0) > 0) and overlapsCollisionCell(saw, x, y, w, h) then
+        if isCollisionCandidate(saw, x, y, w, h) then
             local px, py = getSawCollisionCenter(saw)
 
             -- Circle vs AABB

--- a/snake.lua
+++ b/snake.lua
@@ -1809,6 +1809,7 @@ function Snake:checkSawBodyCollision()
         if isSawActive(saw) then
             local sx, sy = getSawCenterPosition(saw)
             if sx and sy then
+                local sawRadius = (saw.collisionRadius or saw.radius or 0)
                 local travelled = 0
                 local prevX, prevY = headX, headY
 
@@ -1820,11 +1821,18 @@ function Snake:checkSawBodyCollision()
                         local dx = cx - prevX
                         local dy = cy - prevY
                         local segLen = math.sqrt(dx * dx + dy * dy)
-                        if segLen > 1e-6 then
+                        local minX = math.min(prevX, cx) - bodyRadius
+                        local minY = math.min(prevY, cy) - bodyRadius
+                        local maxX = math.max(prevX, cx) + bodyRadius
+                        local maxY = math.max(prevY, cy) + bodyRadius
+                        local width = maxX - minX
+                        local height = maxY - minY
+
+                        if segLen > 1e-6 and (not (Saws and Saws.isCollisionCandidate) or Saws:isCollisionCandidate(saw, minX, minY, width, height)) then
                             local closestX, closestY, distSq, t = closestPointOnSegment(sx, sy, prevX, prevY, cx, cy)
                             local along = travelled + segLen * (t or 0)
                             if along > guardDistance then
-                                local combined = (saw.radius or 0) + bodyRadius
+                                local combined = sawRadius + bodyRadius
                                 if distSq <= combined * combined then
                                     local handled = self:handleSawBodyCut({
                                         index = index,
@@ -1838,6 +1846,7 @@ function Snake:checkSawBodyCollision()
                                 end
                             end
                         end
+
                         travelled = travelled + segLen
                         prevX, prevY = cx, cy
                     end


### PR DESCRIPTION
## Summary
- add a reusable saw collision candidate helper so other systems can share head-hit gating logic
- update snake body saw collision checks to respect track coverage and the adjusted collision radius

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68df6f822f64832f8b033cc6c7f58eda