### PR TITLE
Add Chromatic Pantry and Sparkstep Relay upgrades

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -442,6 +442,11 @@ local english = {
                 description = "Fruit at combo 4 or higher grant +2 bonus score and stall saws for 0.8s.",
                 combo_bonus = "Twilight Parade +2",
             },
+            chromatic_pantry = {
+                name = "Chromatic Pantry",
+                description = "Collecting a different fruit than last time grants +1 bonus score and stalls saws for 0.5s.",
+                celebration = "Chromatic Bonus",
+            },
             lucky_bite = {
                 name = "Lucky Bite",
                 description = "Each fruit grants +1 bonus score.",
@@ -566,6 +571,11 @@ local english = {
                 name = "Thunder Dash",
                 description = "Press Space (or A/Right Shoulder on a controller) to dash forward, smashing through rocks while briefly speeding up.",
                 activation_text = "Thunder Dash!",
+            },
+            sparkstep_relay = {
+                name = "Sparkstep Relay",
+                description = "Dashing shatters the nearest rock and stalls saws for 0.6s.",
+                activation_text = "Sparkstep!",
             },
             temporal_anchor = {
                 name = "Temporal Anchor",

--- a/upgrades.lua
+++ b/upgrades.lua
@@ -552,6 +552,54 @@ local pool = {
         },
     }),
     register({
+        id = "chromatic_pantry",
+        nameKey = "upgrades.chromatic_pantry.name",
+        descKey = "upgrades.chromatic_pantry.description",
+        rarity = "uncommon",
+        tags = {"economy", "defense"},
+        onAcquire = function(state)
+            state.counters.chromaticPantryLastFruit = nil
+        end,
+        handlers = {
+            fruitCollected = function(data, state)
+                if not data then return end
+
+                local last = state.counters.chromaticPantryLastFruit
+                local current = data.name or (data.fruitType and data.fruitType.id)
+
+                if current and last and current ~= last then
+                    if Score.addBonus then
+                        Score:addBonus(1)
+                    end
+                    if Saws and Saws.stall then
+                        Saws:stall(0.5)
+                    end
+                    celebrateUpgrade(getUpgradeString("chromatic_pantry", "celebration"), data, {
+                        color = {0.98, 0.72, 0.94, 1},
+                        particleCount = 14,
+                        particleSpeed = 100,
+                        particleLife = 0.4,
+                        textOffset = 48,
+                        textScale = 1.08,
+                        visual = {
+                            badge = "spark",
+                            outerRadius = 52,
+                            innerRadius = 16,
+                            ringCount = 3,
+                            life = 0.7,
+                            glowAlpha = 0.3,
+                            haloAlpha = 0.2,
+                        },
+                    })
+                end
+
+                if current then
+                    state.counters.chromaticPantryLastFruit = current
+                end
+            end,
+        },
+    }),
+    register({
         id = "lucky_bite",
         nameKey = "upgrades.lucky_bite.name",
         descKey = "upgrades.lucky_bite.description",
@@ -1179,6 +1227,42 @@ local pool = {
                 end)
             end
         end,
+    }),
+    register({
+        id = "sparkstep_relay",
+        nameKey = "upgrades.sparkstep_relay.name",
+        descKey = "upgrades.sparkstep_relay.description",
+        rarity = "rare",
+        requiresTags = {"mobility"},
+        tags = {"mobility", "defense"},
+        handlers = {
+            dashActivated = function(data)
+                local fx, fy = getEventPosition(data)
+                if Rocks and Rocks.shatterNearest then
+                    Rocks:shatterNearest(fx or 0, fy or 0, 1)
+                end
+                if Saws and Saws.stall then
+                    Saws:stall(0.6)
+                end
+                celebrateUpgrade(getUpgradeString("sparkstep_relay", "activation_text"), data, {
+                    color = {1.0, 0.78, 0.36, 1},
+                    particleCount = 20,
+                    particleSpeed = 150,
+                    particleLife = 0.36,
+                    textOffset = 56,
+                    textScale = 1.16,
+                    visual = {
+                        badge = "bolt",
+                        outerRadius = 54,
+                        innerRadius = 18,
+                        ringCount = 3,
+                        life = 0.6,
+                        glowAlpha = 0.32,
+                        haloAlpha = 0.22,
+                    },
+                })
+            end,
+        },
     }),
     register({
         id = "temporal_anchor",


### PR DESCRIPTION
## Summary
- add the Chromatic Pantry economy/defense upgrade that rewards alternating fruit types with saw stalls and bonus score
- introduce the Sparkstep Relay mobility upgrade that lets dashes shatter nearby rocks while stalling saws
- provide English localization strings for the new cards

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df7362dd08832fb41f340734be66c0