### PR TITLE
Hide cursor while playing

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -265,6 +265,10 @@ function Game:enter()
     UI.clearButtons()
     self:load()
 
+    if love.mouse and love.mouse.setVisible then
+        love.mouse.setVisible(false)
+    end
+
     Audio:playMusic("game")
     SessionStats:reset()
     PlayerStats:add("sessionsPlayed", 1)
@@ -278,6 +282,10 @@ end
 
 function Game:leave()
     callMode(self, "leave")
+
+    if love.mouse and love.mouse.setVisible then
+        love.mouse.setVisible(true)
+    end
 
     if Snake and Snake.resetModifiers then
         Snake:resetModifiers()


### PR DESCRIPTION
## Summary
- hide the system cursor when entering the gameplay state
- restore the cursor visibility when leaving gameplay

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dff0740de0832f9cff54a729d842be