### PR TITLE
Show mouse cursor when navigating the shop with a mouse

### DIFF
--- a/transitionmanager.lua
+++ b/transitionmanager.lua
@@ -100,6 +100,10 @@ function TransitionManager:openShop()
 end
 
 function TransitionManager:startFloorIntro(duration, extra)
+    if self.phase == "shop" and Shop.onClosed then
+        Shop:onClosed()
+    end
+
     extra = shallowCopy(extra)
     if not extra.transitionResumePhase then
         extra.transitionResumePhase = "fadein"


### PR DESCRIPTION
## Summary
- track the active input mode in the shop so the mouse cursor becomes visible when interacting with mouse input
- hide the cursor again when switching back to keyboard/gamepad controls or closing the shop

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dff2ea2bf8832fb377abb6ca8a8acb