### PR TITLE
Handle mouse cursor visibility based on active input method

### DIFF
--- a/app.lua
+++ b/app.lua
@@ -12,6 +12,7 @@ local UI = require("ui")
 local Localization = require("localization")
 local Theme = require("theme")
 local SnakeCosmetics = require("snakecosmetics")
+local InputMode = require("inputmode")
 
 local App = {
     stateModules = {
@@ -138,18 +139,27 @@ function App:draw()
 end
 
 function App:mousepressed(x, y, button)
+    InputMode:noteMouse()
     return self:forwardEvent("mousepressed", x, y, button)
 end
 
 function App:mousereleased(x, y, button)
+    InputMode:noteMouse()
     return self:forwardEvent("mousereleased", x, y, button)
 end
 
+function App:mousemoved(x, y, dx, dy, istouch)
+    InputMode:noteMouse()
+    return self:forwardEvent("mousemoved", x, y, dx, dy, istouch)
+end
+
 function App:wheelmoved(dx, dy)
+    InputMode:noteMouse()
     return self:forwardEvent("wheelmoved", dx, dy)
 end
 
 function App:keypressed(key)
+    InputMode:noteKeyboard()
     if key == "printscreen" then
         local time = os.date("%Y-%m-%d_%H-%M-%S")
         love.graphics.captureScreenshot("screenshot_" .. time .. ".png")
@@ -159,6 +169,7 @@ function App:keypressed(key)
 end
 
 function App:joystickpressed(joystick, button)
+    InputMode:noteGamepad()
     return self:forwardEvent("joystickpressed", joystick, button)
 end
 
@@ -167,10 +178,12 @@ function App:joystickreleased(joystick, button)
 end
 
 function App:joystickaxis(joystick, axis, value)
+    InputMode:noteGamepadAxis(value)
     return self:forwardEvent("joystickaxis", joystick, axis, value)
 end
 
 function App:gamepadpressed(joystick, button)
+    InputMode:noteGamepad()
     return self:forwardEvent("gamepadpressed", joystick, button)
 end
 
@@ -179,6 +192,7 @@ function App:gamepadreleased(joystick, button)
 end
 
 function App:gamepadaxis(joystick, axis, value)
+    InputMode:noteGamepadAxis(value)
     return self:forwardEvent("gamepadaxis", joystick, axis, value)
 end
 

--- a/inputmode.lua
+++ b/inputmode.lua
@@ -1,0 +1,50 @@
+local InputMode = {
+    lastDevice = nil,
+}
+
+local function isMouseSupported()
+    if not love or not love.mouse then
+        return false
+    end
+
+    local supported = true
+    if love.mouse.isCursorSupported then
+        supported = love.mouse.isCursorSupported()
+    end
+
+    if supported == nil then
+        supported = true
+    end
+
+    return supported and love.mouse.setVisible ~= nil
+end
+
+function InputMode:isMouseSupported()
+    return isMouseSupported()
+end
+
+function InputMode:noteMouse()
+    if isMouseSupported() then
+        self.lastDevice = "mouse"
+    end
+end
+
+function InputMode:noteKeyboard()
+    self.lastDevice = "keyboard"
+end
+
+function InputMode:noteGamepad()
+    self.lastDevice = "gamepad"
+end
+
+function InputMode:noteGamepadAxis(value)
+    if math.abs(value or 0) > 0.25 then
+        self:noteGamepad()
+    end
+end
+
+function InputMode:isMouseActive()
+    return self.lastDevice == "mouse" and isMouseSupported()
+end
+
+return InputMode


### PR DESCRIPTION
## Summary
- add an input mode tracker so we know when a mouse is the active device
- manage cursor visibility during gameplay and shop transitions only when the mouse is in use

## Testing
- ⚠️ `luac -p game.lua app.lua inputmode.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dff4aa53e0832f8c6731cf0e97ca71