### PR TITLE
Ensure completed achievements display full progress bars

### DIFF
--- a/achievements.lua
+++ b/achievements.lua
@@ -646,10 +646,15 @@ function Achievements:getProgressLabel(def)
 end
 
 function Achievements:getProgressRatio(def)
+    if def.unlocked then
+        return 1
+    end
+
     if def.goal and def.goal > 0 then
         return math.min(1, (def.progress or 0) / def.goal)
     end
-    return def.unlocked and 1 or 0
+
+    return 0
 end
 
 function Achievements:getDefinition(id)


### PR DESCRIPTION
## Summary
- ensure achievements marked as unlocked always report full progress ratios
- keep progress bars visually full for completed achievements with tracked goals

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dffb223df8832f94ecf4460e43071e