### PR TITLE
Polish fruit socket UI animations

### DIFF
--- a/easing.lua
+++ b/easing.lua
@@ -38,6 +38,13 @@ function Easing.easeOutBack(t)
     return 1 + c3 * math.pow(t - 1, 3) + c1 * math.pow(t - 1, 2)
 end
 
+function Easing.easeInBack(t)
+    local c1 = 1.70158
+    local c3 = c1 + 1
+
+    return c3 * math.pow(t, 3) - c1 * math.pow(t, 2)
+end
+
 function Easing.easedProgress(timer, duration)
     if not duration or duration <= 0 then
         return 1


### PR DESCRIPTION
## Summary
- add an ease-in-back helper so fruit sockets can use a matching pop-out curve
- rework fruit socket bookkeeping to support staged pop-in, pop-out, and celebratory bounces
- refresh the fruit socket rendering with eased scaling, glow effects, and panel flashes when the goal is met

## Testing
- `luac -p ui.lua` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dffbf6eb58832f8d524293bfe790a3