### PR TITLE
Draw lasers above saws

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -483,8 +483,8 @@ local function drawPlayfieldLayers(self, stateOverride)
     Fruit:draw()
     Rocks:draw()
     Conveyors:draw()
-    Lasers:draw()
     Saws:draw()
+    Lasers:draw()
     Arena:drawExit()
 
     if renderState == "descending" then


### PR DESCRIPTION
## Summary
- render saws before lasers so beams appear above the blades

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dffecbfb2c832fa186a3271eda43ec