### PR TITLE
Adjust shop rarity odds and add bad luck protection

### DIFF
--- a/upgradehelpers.lua
+++ b/upgradehelpers.lua
@@ -23,17 +23,17 @@ UpgradeHelpers.rarities = {
         color = {0.55, 0.78, 0.58, 1},
     },
     rare = {
-        weight = 8,
+        weight = 10,
         labelKey = "upgrades.rarities.rare",
         color = {0.54, 0.72, 0.96, 1},
     },
     epic = {
-        weight = 2,
+        weight = 2.8,
         labelKey = "upgrades.rarities.epic",
         color = {0.76, 0.56, 0.88, 1},
     },
     legendary = {
-        weight = 0.35,
+        weight = 0.5,
         labelKey = "upgrades.rarities.legendary",
         color = {1, 0.66, 0.32, 1},
     },


### PR DESCRIPTION
## Summary
- increase base rarity weights for rare, epic, and legendary upgrades
- add a shop bad luck counter to boost high-rarity weights when streaking without rare cards
- reset the counter when a shop offers rare or better cards to provide gentle pity protection

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfff85521c832fbf4ffaf28dca1d70