### PR TITLE
Increase floor intro prompt font size

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -789,7 +789,7 @@ local function drawTransitionFloorIntro(self, timer, duration, data)
         if promptAlpha > 0 then
             local promptText = Localization:get("game.floor_intro.prompt")
             if promptText and promptText ~= "" then
-                local promptFont = UI.fonts.body
+                local promptFont = UI.fonts.prompt or UI.fonts.body
                 love.graphics.setFont(promptFont)
                 local y = self.screenHeight - promptFont:getHeight() * 2.2
                 local shadow = Theme.shadowColor or { 0, 0, 0, 0.5 }

--- a/ui.lua
+++ b/ui.lua
@@ -153,6 +153,7 @@ UI.fonts = {
     subtitle     = love.graphics.newFont("Assets/Fonts/Comfortaa-SemiBold.ttf", 32),
     heading      = love.graphics.newFont("Assets/Fonts/Comfortaa-SemiBold.ttf", 28),
     button       = love.graphics.newFont("Assets/Fonts/Comfortaa-SemiBold.ttf", 24),
+    prompt       = love.graphics.newFont("Assets/Fonts/Comfortaa-SemiBold.ttf", 20),
     body         = love.graphics.newFont("Assets/Fonts/Comfortaa-SemiBold.ttf", 16),
     caption      = love.graphics.newFont("Assets/Fonts/Comfortaa-SemiBold.ttf", 14),
     small        = love.graphics.newFont("Assets/Fonts/Comfortaa-SemiBold.ttf", 12),


### PR DESCRIPTION
## Summary
- add a dedicated prompt font to the UI font collection
- use the prompt font for the floor intro prompt to make it slightly larger

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e00496fe7c832f9f2d84b5e4c25221