### PR TITLE
Clarify Stone Skin upgrade description includes lasers

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -382,7 +382,7 @@ local english = {
             },
             stone_skin = {
                 name = "Stone Skin",
-                description = "Gain a crash shield that shatters rocks and shrugs off a saw clip.",
+                description = "Gain a crash shield that shatters rocks and shrugs off a saw or laser clip.",
                 shield_text = "Stone Skin!",
             },
             aegis_recycler = {


### PR DESCRIPTION
## Summary
- update the Stone Skin upgrade card description to note it protects against saws and lasers

## Testing
- not run (text-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e005658c04832fb54cc55f17894f3d