### PR TITLE
Make lasers trim the snake tail when blocked

### DIFF
--- a/movement.lua
+++ b/movement.lua
@@ -446,6 +446,10 @@ local function handleLaserCollision(headX, headY)
                 Snake:onShieldConsumed(headX, headY, "laser")
         end
 
+        if Snake.chopTailByLaser then
+                Snake:chopTailByLaser()
+        end
+
         if shielded then
                 recordShieldEvent("laser")
         end

--- a/snake.lua
+++ b/snake.lua
@@ -1586,7 +1586,7 @@ function Snake:loseSegments(count, options)
 
     if (not options) or options.spawnParticles ~= false then
         local burstColor = {1, 0.8, 0.4, 1}
-        if options and options.cause == "saw" then
+        if options and (options.cause == "saw" or options.cause == "laser") then
             burstColor = {1, 0.6, 0.3, 1}
         end
 
@@ -1609,7 +1609,7 @@ function Snake:loseSegments(count, options)
     return trimmed
 end
 
-function Snake:chopTailBySaw()
+local function chopTailByHazard(cause)
     local available = math.max(0, (segmentCount or 1) - 1)
     if available <= 0 then
         return 0
@@ -1618,7 +1618,15 @@ function Snake:chopTailBySaw()
     local loss = math.floor(math.max(1, available * 0.2))
     loss = math.min(loss, available)
 
-    return self:loseSegments(loss, { cause = "saw" })
+    return Snake:loseSegments(loss, { cause = cause })
+end
+
+function Snake:chopTailBySaw()
+    return chopTailByHazard("saw")
+end
+
+function Snake:chopTailByLaser()
+    return chopTailByHazard("laser")
 end
 
 local function isSawActive(saw)


### PR DESCRIPTION
## Summary
- allow lasers to trim the snake's tail after a shielded collision so they behave like saws
- refactor tail trimming into a shared hazard helper and reuse it for saws and lasers
- treat laser-induced tail cuts like saw hits when selecting the particle burst color

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e00b4d75fc832f83ada1a3dadc673a