### PR TITLE
Add achievement for collecting 10 total dragonfruit

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -685,6 +685,10 @@ local english = {
                 title = "Dragon Hunter",
                 description = "Collect the legendary Dragonfruit",
             },
+            dragonfruitDevotee = {
+                title = "Dragonfruit Devotee",
+                description = "Collect 10 total dragonfruit",
+            },
             dragonComboFusion = {
                 title = "Dragon Combo Fusion",
                 description = "Eat a dragonfruit and reach an 8-fruit combo in the same run.",

--- a/achievement_definitions.lua
+++ b/achievement_definitions.lua
@@ -469,6 +469,17 @@ local definitions = {
         categoryOrder = 3,
         order = 10,
     },
+    {
+        id = "dragonfruitDevotee",
+        titleKey = "achievements_definitions.dragonfruitDevotee.title",
+        descriptionKey = "achievements_definitions.dragonfruitDevotee.description",
+        icon = "Apple",
+        goal = 10,
+        stat = "totalDragonfruitEaten",
+        category = "collection",
+        categoryOrder = 3,
+        order = 20,
+    },
 }
 
 return definitions


### PR DESCRIPTION
## Summary
- add the dragonfruit devotee achievement that tracks collecting 10 total dragonfruit
- localize the new achievement in English

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e00c7c33ec832fb3e748a15a780cd0