### PR TITLE
Increase floor intro prompt font size

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -789,7 +789,7 @@ local function drawTransitionFloorIntro(self, timer, duration, data)
         if promptAlpha > 0 then
             local promptText = Localization:get("game.floor_intro.prompt")
             if promptText and promptText ~= "" then
-                local promptFont = UI.fonts.body
+                local promptFont = UI.fonts.prompt or UI.fonts.body
                 love.graphics.setFont(promptFont)
                 local y = self.screenHeight - promptFont:getHeight() * 2.2
                 local shadow = Theme.shadowColor or { 0, 0, 0, 0.5 }

--- a/ui.lua
+++ b/ui.lua
@@ -154,6 +154,7 @@ UI.fonts = {
     heading      = love.graphics.newFont("Assets/Fonts/Comfortaa-SemiBold.ttf", 28),
     button       = love.graphics.newFont("Assets/Fonts/Comfortaa-SemiBold.ttf", 24),
     body         = love.graphics.newFont("Assets/Fonts/Comfortaa-SemiBold.ttf", 16),
+    prompt       = love.graphics.newFont("Assets/Fonts/Comfortaa-SemiBold.ttf", 20),
     caption      = love.graphics.newFont("Assets/Fonts/Comfortaa-SemiBold.ttf", 14),
     small        = love.graphics.newFont("Assets/Fonts/Comfortaa-SemiBold.ttf", 12),
     timer        = love.graphics.newFont("Assets/Fonts/Comfortaa-Bold.ttf", 42),


### PR DESCRIPTION
## Summary
- add a dedicated UI font for floor prompts with a larger size
- apply the new font to the "Press any key to descend" floor intro message

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e02cedbee0832fb76aa13ebd19e28a