### PR TITLE
Forward mouse movement events to App

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -12,6 +12,7 @@ local handlers = {
     draw = "draw",
     mousepressed = "mousepressed",
     mousereleased = "mousereleased",
+    mousemoved = "mousemoved",
     wheelmoved = "wheelmoved",
     keypressed = "keypressed",
     joystickpressed = "joystickpressed",


### PR DESCRIPTION
## Summary
- forward `love.mousemoved` events through `main.lua`
- allow InputMode to detect mouse usage during gameplay so the cursor can be hidden when appropriate

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e030f8a108832fb463c48f320f5a17