### PR TITLE
Refactor hazard occupancy helpers

### DIFF
--- a/floorsetup.lua
+++ b/floorsetup.lua
@@ -122,7 +122,7 @@ local function trySpawnHorizontalSaw(halfTiles, bladeRadius)
 
     if SnakeUtils.sawTrackIsFree(fx, fy, "horizontal") then
         Saws:spawn(fx, fy, bladeRadius, 8, "horizontal")
-        SnakeUtils.occupySawTrack(fx, fy, "horizontal", bladeRadius, TRACK_LENGTH)
+        SnakeUtils.occupySawTrack(fx, fy, "horizontal")
         return true
     end
 
@@ -137,7 +137,7 @@ local function trySpawnVerticalSaw(halfTiles, bladeRadius)
 
     if SnakeUtils.sawTrackIsFree(fx, fy, "vertical") then
         Saws:spawn(fx, fy, bladeRadius, 8, "vertical", side)
-        SnakeUtils.occupySawTrack(fx, fy, "vertical", bladeRadius, TRACK_LENGTH, side)
+        SnakeUtils.occupySawTrack(fx, fy, "vertical")
         return true
     end
 


### PR DESCRIPTION
## Summary
- centralize cell normalization and occupancy helpers in `snakeutils.lua`
- reuse the shared helpers for hazard track checks to reduce duplication
- simplify saw occupancy calls in `floorsetup.lua` now that unused parameters are gone

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e039219e18832f9f5ccb2bafcb8e3d