### PR TITLE
Add tempo turbine, mirror mantle, and verdant bonds shop cards

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -471,6 +471,11 @@ local english = {
                 name = "Echo Aegis",
                 description = "Crash shields unleash a shockwave that stalls saws.",
             },
+            mirror_mantle = {
+                name = "Mirror Mantle",
+                description = "Breaking a crash shield grants +3 bonus score and stalls saws for 1s.",
+                activation_text = "Mirrored Rebound",
+            },
             resonant_shell = {
                 name = "Resonant Shell",
                 description = "Gain +0.35s saw stall duration for each Defense upgrade you own.",
@@ -492,6 +497,11 @@ local english = {
                 name = "Aurora Band",
                 description = "Combo window increases by 0.35s.",
             },
+            tempo_turbine = {
+                name = "Tempo Turbine",
+                description = "Combos of 2+ fruits build charge; every third combo fruit stalls saws for 0.7s and grants +2 bonus score.",
+                activation_text = "Turbine Surge",
+            },
             caravan_contract = {
                 name = "Caravan Contract",
                 description = "Shops offer +1 card. Each floor spawns an extra rock.",
@@ -504,6 +514,11 @@ local english = {
                 name = "Mercantile Echo",
                 description = "The first time you acquire an upgrade with a new tag, gain +0.15s saw stall and +1 bonus score.",
                 activation_text = "Echo Dividend",
+            },
+            verdant_bonds = {
+                name = "Verdant Bonds",
+                description = "Buying an Economy upgrade grants crash shields equal to Verdant Bonds stacks.",
+                activation_text = "Verdant Growth",
             },
             fresh_supplies = {
                 name = "Fresh Supplies",

--- a/upgrades.lua
+++ b/upgrades.lua
@@ -814,6 +814,40 @@ local pool = {
         },
     }),
     register({
+        id = "mirror_mantle",
+        nameKey = "upgrades.mirror_mantle.name",
+        descKey = "upgrades.mirror_mantle.description",
+        rarity = "rare",
+        tags = {"defense", "combo"},
+        handlers = {
+            shieldConsumed = function(data)
+                if Score.addBonus then
+                    Score:addBonus(3)
+                end
+                if Saws and Saws.stall then
+                    Saws:stall(1)
+                end
+                celebrateUpgrade(getUpgradeString("mirror_mantle", "activation_text"), data, {
+                    color = {0.82, 0.74, 1, 1},
+                    particleCount = 18,
+                    particleSpeed = 140,
+                    particleLife = 0.5,
+                    textOffset = 50,
+                    textScale = 1.14,
+                    visual = {
+                        badge = "shield",
+                        outerRadius = 60,
+                        innerRadius = 18,
+                        ringCount = 4,
+                        life = 0.7,
+                        glowAlpha = 0.3,
+                        haloAlpha = 0.22,
+                    },
+                })
+            end,
+        },
+    }),
+    register({
         id = "resonant_shell",
         nameKey = "upgrades.resonant_shell.name",
         descKey = "upgrades.resonant_shell.description",
@@ -911,6 +945,58 @@ local pool = {
         onAcquire = function(state)
             state.effects.comboWindowBonus = (state.effects.comboWindowBonus or 0) + 0.35
         end,
+    }),
+    register({
+        id = "tempo_turbine",
+        nameKey = "upgrades.tempo_turbine.name",
+        descKey = "upgrades.tempo_turbine.description",
+        rarity = "uncommon",
+        tags = {"combo", "economy"},
+        onAcquire = function(state)
+            state.counters.tempoTurbineCharge = state.counters.tempoTurbineCharge or 0
+        end,
+        handlers = {
+            fruitCollected = function(data, state)
+                if not data then return end
+
+                local combo = data.combo or 0
+                if combo < 2 then
+                    state.counters.tempoTurbineCharge = 0
+                    return
+                end
+
+                local charge = (state.counters.tempoTurbineCharge or 0) + 1
+                local threshold = 3
+                if charge >= threshold then
+                    charge = 0
+                    if Score.addBonus then
+                        Score:addBonus(2)
+                    end
+                    if Saws and Saws.stall then
+                        Saws:stall(0.7)
+                    end
+                    celebrateUpgrade(getUpgradeString("tempo_turbine", "activation_text"), data, {
+                        color = {0.56, 0.84, 0.98, 1},
+                        particleCount = 16,
+                        particleSpeed = 150,
+                        particleLife = 0.46,
+                        textOffset = 48,
+                        textScale = 1.12,
+                        visual = {
+                            badge = "spark",
+                            outerRadius = 54,
+                            innerRadius = 16,
+                            ringCount = 3,
+                            life = 0.66,
+                            glowAlpha = 0.26,
+                            haloAlpha = 0.18,
+                        },
+                    })
+                end
+
+                state.counters.tempoTurbineCharge = charge
+            end,
+        },
     }),
     register({
         id = "caravan_contract",
@@ -1016,6 +1102,61 @@ local pool = {
                 })
             end,
         },
+    }),
+    register({
+        id = "verdant_bonds",
+        nameKey = "upgrades.verdant_bonds.name",
+        descKey = "upgrades.verdant_bonds.description",
+        rarity = "uncommon",
+        tags = {"economy", "defense"},
+        allowDuplicates = true,
+        maxStacks = 3,
+        onAcquire = function(state)
+            state.counters.verdantBondsShields = (state.counters.verdantBondsShields or 0) + 1
+            if not state.counters.verdantBondsHandlerRegistered then
+                state.counters.verdantBondsHandlerRegistered = true
+                Upgrades:addEventHandler("upgradeAcquired", function(data, runState)
+                    if not runState then return end
+                    if not runState.takenSet or (runState.takenSet.verdant_bonds or 0) <= 0 then return end
+                    if not data or not data.upgrade then return end
+
+                    local upgradeTags = data.upgrade.tags
+                    local hasEconomy = false
+                    if upgradeTags then
+                        for _, tag in ipairs(upgradeTags) do
+                            if tag == "economy" then
+                                hasEconomy = true
+                                break
+                            end
+                        end
+                    end
+
+                    if not hasEconomy then return end
+
+                    local shields = runState.counters.verdantBondsShields or 1
+                    if Snake and Snake.addCrashShields then
+                        Snake:addCrashShields(shields)
+                    end
+                    celebrateUpgrade(getUpgradeString("verdant_bonds", "activation_text"), data, {
+                        color = {0.58, 0.88, 0.64, 1},
+                        particleCount = 14,
+                        particleSpeed = 120,
+                        particleLife = 0.48,
+                        textOffset = 46,
+                        textScale = 1.1,
+                        visual = {
+                            badge = "shield",
+                            outerRadius = 52,
+                            innerRadius = 16,
+                            ringCount = 3,
+                            life = 0.68,
+                            glowAlpha = 0.26,
+                            haloAlpha = 0.18,
+                        },
+                    })
+                end)
+            end
+        end,
     }),
     register({
         id = "fresh_supplies",


### PR DESCRIPTION
## Summary
- add the Tempo Turbine upgrade to reward sustained combos with bonus score and saw stall
- introduce the Mirror Mantle upgrade that turns crash shield breaks into combo-friendly stuns
- create the Verdant Bonds upgrade so economy purchases forge crash shields and add localization for all three cards

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e041579320832fb78f864e7b0e0088