### PR TITLE
Streamline state registration and drop unused gamestate helpers

### DIFF
--- a/app.lua
+++ b/app.lua
@@ -16,24 +16,22 @@ local InputMode = require("inputmode")
 
 local App = {
     stateModules = {
-        menu = "menu",
-        modeselect = "modeselect",
-        game = "game",
-        gameover = "gameover",
-        achievementsmenu = "achievementsmenu",
-        metaprogression = "metaprogressionscreen",
-        settings = "settingsscreen",
+        menu = require("menu"),
+        modeselect = require("modeselect"),
+        game = require("game"),
+        gameover = require("gameover"),
+        achievementsmenu = require("achievementsmenu"),
+        metaprogression = require("metaprogressionscreen"),
+        settings = require("settingsscreen"),
     }
 }
 
 function App:registerStates()
-    for key in pairs(GameState.states) do
-        GameState.states[key] = nil
+    local states = {}
+    for stateName, module in pairs(self.stateModules) do
+        states[stateName] = module
     end
-
-    for stateName, modulePath in pairs(self.stateModules) do
-        GameState.states[stateName] = require(modulePath)
-    end
+    GameState.states = states
 end
 
 function App:loadSubsystems()

--- a/gamestate.lua
+++ b/gamestate.lua
@@ -178,10 +178,6 @@ local function callCurrentState(self, methodName, ...)
     end
 end
 
-local function shouldBlockDuringTransition(eventName)
-    return transitionBlockedEvents[eventName]
-end
-
 function GameState:switch(stateName, data)
     if self.transitioning then
         self.queuedState = stateName
@@ -412,47 +408,8 @@ function GameState:draw()
     end
 end
 
-function GameState:getTransitionContext()
-    if not self.transitionContext then
-        local fromName, toName
-        if self.transitionDirection == 1 then
-            fromName = self.current
-            toName = self.next
-        else
-            fromName = self.transitionFrom
-            toName = self.current
-        end
-
-        updateTransitionContext(self, {
-            transitioning = self.transitioning,
-            direction = self.transitionDirection,
-            progress = self.transitioning and self.transitionTime or 1,
-            duration = self.transitionDuration,
-            time = self.transitioning and (self.transitionTime * self.transitionDuration) or 0,
-            from = fromName,
-            to = toName,
-        })
-    end
-
-    return self.transitionContext
-end
-
-function GameState:isTransitioning()
-    return self.transitioning == true
-end
-
-function GameState:getTransitionProgress()
-    local context = self:getTransitionContext()
-    return context and context.progress or 1
-end
-
-function GameState:getTransitionAlpha()
-    local context = self:getTransitionContext()
-    return context and context.alpha or 0
-end
-
 function GameState:dispatch(eventName, ...)
-    if self.transitioning and shouldBlockDuringTransition(eventName) then
+    if self.transitioning and transitionBlockedEvents[eventName] then
         return
     end
 


### PR DESCRIPTION
## Summary
- require each state module up front and replace the state registry in one assignment
- remove unused transition helper methods from the game state dispatcher

## Testing
- not run (Lua runtime not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e044444d4c832fbd5d5811956d02ed