### PR TITLE
Flash rocks red when causing player death

### DIFF
--- a/movement.lua
+++ b/movement.lua
@@ -317,6 +317,7 @@ local function handleRockCollision(headX, headY)
                                 end
                         else
                                 if not Snake:consumeCrashShield() then
+                                        Rocks:triggerHitFlash(rock)
                                         return "dead", "rock"
                                 end
 


### PR DESCRIPTION
## Summary
- add a hit flash timer to rocks so they can briefly tint red
- trigger the flash when a rock kills the player and fade it out over time
- update rock rendering to use the temporary flash color and matching highlight

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e04932c404832fa31d0b63e0a123a0