### PR TITLE
Make lasers sever snake tail like saws

### DIFF
--- a/movement.lua
+++ b/movement.lua
@@ -447,6 +447,12 @@ local function handleLaserCollision(headX, headY)
                 Snake:onShieldConsumed(headX, headY, "laser")
         end
 
+        if Snake.chopTailByHazard then
+                Snake:chopTailByHazard("laser")
+        elseif Snake.chopTailBySaw then
+                Snake:chopTailBySaw()
+        end
+
         if shielded then
                 recordShieldEvent("laser")
         end

--- a/snake.lua
+++ b/snake.lua
@@ -1609,16 +1609,27 @@ function Snake:loseSegments(count, options)
     return trimmed
 end
 
-function Snake:chopTailBySaw()
+local function chopTailLossAmount()
     local available = math.max(0, (segmentCount or 1) - 1)
     if available <= 0 then
         return 0
     end
 
     local loss = math.floor(math.max(1, available * 0.2))
-    loss = math.min(loss, available)
+    return math.min(loss, available)
+end
 
-    return self:loseSegments(loss, { cause = "saw" })
+function Snake:chopTailByHazard(cause)
+    local loss = chopTailLossAmount()
+    if loss <= 0 then
+        return 0
+    end
+
+    return self:loseSegments(loss, { cause = cause or "saw" })
+end
+
+function Snake:chopTailBySaw()
+    return self:chopTailByHazard("saw")
 end
 
 local function isSawActive(saw)


### PR DESCRIPTION
## Summary
- make shielded laser collisions sever the snake's tail just like saws do
- refactor tail severing logic into a shared helper so other hazards can reuse it

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e04ac130d0832f9366cdf9d0b12dd2