### PR TITLE
Hide snake face when descending into exit

### DIFF
--- a/snake.lua
+++ b/snake.lua
@@ -1042,6 +1042,8 @@ function Snake:drawClipped(hx, hy, hr)
         love.graphics.setStencilTest("equal", 0)
     end
 
+    local shouldDrawFace = descendingHole == nil
+
     DrawSnake(renderTrail, segmentCount, SEGMENT_SIZE, popTimer, function()
         if headX and headY and clipRadius > 0 then
             local dx = headX - hx
@@ -1051,7 +1053,7 @@ function Snake:drawClipped(hx, hy, hr)
             end
         end
         return headX, headY
-    end, self.crashShields or 0, self.shieldFlashTimer or 0, upgradeVisuals)
+    end, self.crashShields or 0, self.shieldFlashTimer or 0, upgradeVisuals, shouldDrawFace)
 
     debugDrawCollisionSpace(trail, headX, headY)
 
@@ -1963,9 +1965,11 @@ function Snake:draw()
             end
         end
 
+        local shouldDrawFace = descendingHole == nil
+
         DrawSnake(trail, segmentCount, SEGMENT_SIZE, popTimer, function()
             return self:getHead()
-        end, self.crashShields or 0, self.shieldFlashTimer or 0, upgradeVisuals)
+        end, self.crashShields or 0, self.shieldFlashTimer or 0, upgradeVisuals, shouldDrawFace)
 
         local headX, headY = self:getHead()
         debugDrawCollisionSpace(trail, headX, headY)


### PR DESCRIPTION
## Summary
- stop rendering the snake face while the snake is descending into the exit hole so the transition reads as diving underground

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e054c876e0832f8e382bb41db2d4e5