### PR TITLE
Reset adrenaline surge boost at floor start

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -1071,6 +1071,11 @@ function Game:setupFloor(floorNum)
 
     Upgrades:applyPersistentEffects(true)
 
+    if Snake.adrenaline then
+        Snake.adrenaline.active = false
+        Snake.adrenaline.timer = 0
+    end
+
     FloorSetup.finalizeContext(traitContext, spawnPlan)
     Upgrades:notify("floorStart", { floor = floorNum, context = traitContext })
 


### PR DESCRIPTION
## Summary
- reset the snake's adrenaline state when a new floor is prepared to avoid carrying speed boosts between floors

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e0695f6d64832fb861272748569047