### PR TITLE
Increase arena border thickness

### DIFF
--- a/arena.lua
+++ b/arena.lua
@@ -220,7 +220,7 @@ function Arena:drawBorder()
     local ax, ay, aw, ah = self:getBounds()
 
     -- Match snake style
-    local thickness    = 18       -- border thickness
+    local thickness    = 20       -- border thickness
     local outlineSize  = 6        -- black outline thickness
     local shadowOffset = 3
     local radius       = thickness / 2


### PR DESCRIPTION
## Summary
- increase the arena border thickness so the outline appears 2px larger without shifting inward

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e07a53cb48832fa77d13844459e3fc