### PR TITLE
Ensure SnakeActor follows straight paths

### DIFF
--- a/shop.lua
+++ b/shop.lua
@@ -133,9 +133,6 @@ function Shop:start(currentFloor)
     self.snakeActor = SnakeActor:new({
         segmentCount = 18,
         speed = 115,
-        wiggleAmplitude = 14,
-        wiggleFrequency = 1.25,
-        wiggleStride = 0.85,
         radiusX = 260,
         radiusY = 110,
         defaultPathPoints = 36,

--- a/snakeactor.lua
+++ b/snakeactor.lua
@@ -43,9 +43,9 @@ end
 local DEFAULTS = {
     segmentCount = 14,
     speed = 110,
-    wiggleAmplitude = SEGMENT_SIZE * 0.18,
-    wiggleFrequency = 1.45,
-    wiggleStride = 0.85,
+    wiggleAmplitude = 0,
+    wiggleFrequency = 0,
+    wiggleStride = 0,
     loop = true,
     defaultPathPoints = 28,
 }
@@ -307,12 +307,9 @@ function SnakeActor:new(options)
 
     actor.segmentCount = math.max(1, math.floor(options.segmentCount or options.length or DEFAULTS.segmentCount))
     actor.speed = options.speed or DEFAULTS.speed
-    actor.wiggleAmplitude = options.wiggleAmplitude
-    if actor.wiggleAmplitude == nil then
-        actor.wiggleAmplitude = DEFAULTS.wiggleAmplitude
-    end
-    actor.wiggleFrequency = options.wiggleFrequency or DEFAULTS.wiggleFrequency
-    actor.wiggleStride = options.wiggleStride or DEFAULTS.wiggleStride
+    actor.wiggleAmplitude = 0
+    actor.wiggleFrequency = 0
+    actor.wiggleStride = 0
     actor.drawFace = options.drawFace ~= false
     actor.popTimer = options.popTimer or 0
     actor.shieldCount = options.shieldCount or 0
@@ -425,15 +422,9 @@ function SnakeActor:setSpeed(speed)
 end
 
 function SnakeActor:setWiggle(amplitude, frequency, stride)
-    if amplitude ~= nil then
-        self.wiggleAmplitude = amplitude
-    end
-    if frequency ~= nil then
-        self.wiggleFrequency = frequency
-    end
-    if stride ~= nil then
-        self.wiggleStride = stride
-    end
+    self.wiggleAmplitude = 0
+    self.wiggleFrequency = 0
+    self.wiggleStride = 0
 end
 
 function SnakeActor:getHead()

--- a/transitionmanager.lua
+++ b/transitionmanager.lua
@@ -156,9 +156,6 @@ function TransitionManager:startFloorIntro(duration, extra)
     local snake = SnakeActor:new({
         segmentCount = 20,
         speed = 140,
-        wiggleAmplitude = 16,
-        wiggleFrequency = 1.3,
-        wiggleStride = 0.9,
         path = path,
         loop = true,
         offsetX = anchorX,


### PR DESCRIPTION
## Summary
- remove the menu and shop snake wiggle configuration so the actor moves strictly along its path
- force SnakeActor to disable wiggle motion regardless of provided options, ensuring orthogonal movement only

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68e07bcb5378832f96fd8c8619c153e1