### PR TITLE
Add localized death quips for laser hazard

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -314,6 +314,12 @@ local english = {
                     "A molten wake isn't a good place to swim.",
                     "The floor decided to exhale… loudly.",
                 },
+                laser = {
+                    "You got carved up by a laser sweep.",
+                    "Note to self: don't stand in the light show.",
+                    "The beam didn't come to dance.",
+                    "Snake tried to limbo under a laser and failed.",
+                },
                 unknown = {
                     "Mysterious demise...",
                     "The void has claimed you.",


### PR DESCRIPTION
## Summary
- add English localization lines for laser-specific death messages so laser kills show flavorful text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e07ee9bb74832f9138910a112308e2