### PR TITLE
Increase arena border thickness

### DIFF
--- a/arena.lua
+++ b/arena.lua
@@ -220,7 +220,7 @@ function Arena:drawBorder()
     local ax, ay, aw, ah = self:getBounds()
 
     -- Match snake style
-    local thickness    = 20       -- border thickness
+    local thickness    = 22       -- border thickness
     local outlineSize  = 6        -- black outline thickness
     local shadowOffset = 3
     local radius       = thickness / 2


### PR DESCRIPTION
## Summary
- increase the arena border thickness by 2 pixels while keeping the playfield area unchanged

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e09af41240832fa730543378d39127