### PR TITLE
Remove chromatic fruit pickup celebration

### DIFF
--- a/upgrades.lua
+++ b/upgrades.lua
@@ -642,23 +642,6 @@ local pool = {
                     if Saws and Saws.stall then
                         Saws:stall(0.5)
                     end
-                    celebrateUpgrade(getUpgradeString("chromatic_pantry", "celebration"), data, {
-                        color = {0.98, 0.72, 0.94, 1},
-                        particleCount = 14,
-                        particleSpeed = 100,
-                        particleLife = 0.4,
-                        textOffset = 48,
-                        textScale = 1.08,
-                        visual = {
-                            badge = "spark",
-                            outerRadius = 52,
-                            innerRadius = 16,
-                            ringCount = 3,
-                            life = 0.7,
-                            glowAlpha = 0.3,
-                            haloAlpha = 0.2,
-                        },
-                    })
                 end
 
                 if current then


### PR DESCRIPTION
## Summary
- remove the Chromatic Pantry celebration visuals that appeared on fruit pickups

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0a895f488832fae85ec0c14e8866f