### PR TITLE
Play laser firing sound effect

### DIFF
--- a/lasers.lua
+++ b/lasers.lua
@@ -2,6 +2,7 @@ local Theme = require("theme")
 local Arena = require("arena")
 local SnakeUtils = require("snakeutils")
 local Rocks = require("rocks")
+local Audio = require("audio")
 
 local Lasers = {}
 
@@ -378,6 +379,7 @@ function Lasers:update(dt)
                 beam.chargeTimer = nil
                 beam.flashTimer = math.max(beam.flashTimer or 0, 0.75)
                 beam.burnAlpha = 0.92
+                Audio:playSound("laser_fire")
             end
         elseif beam.state == "firing" then
             beam.fireTimer = (beam.fireTimer or beam.fireDuration) - dt


### PR DESCRIPTION
## Summary
- require the audio module in the laser system
- trigger the laser_fire sound whenever a laser transitions into its firing state

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0ac53ede8832f95d011ae32cef5e0