### PR TITLE
Remove snake actor from shop and floor intro

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -770,30 +770,6 @@ local function drawTransitionFloorIntro(self, timer, duration, data)
         return alpha * outroAlpha
     end
 
-    local snake = data.transitionSnake
-    if snake then
-        local anchorX = self.screenWidth * 0.5
-        local anchorY = self.screenHeight * 0.58
-        if data.transitionSnakeAnchorX ~= anchorX or data.transitionSnakeAnchorY ~= anchorY then
-            snake:setOffset(anchorX, anchorY)
-            data.transitionSnakeAnchorX = anchorX
-            data.transitionSnakeAnchorY = anchorY
-        end
-
-        local introEase = easeOutBack(clamp01((timer - 0.05) / 0.7))
-        local snakeScale = 0.92 + 0.08 * introEase
-        local outroScale = 0.96 + 0.04 * outroAlpha
-        snakeScale = snakeScale * outroScale
-        local verticalDrift = math.sin(timer * 0.8) * 6 * outroAlpha
-
-        love.graphics.push()
-        love.graphics.translate(anchorX, anchorY + verticalDrift)
-        love.graphics.scale(snakeScale, snakeScale)
-        love.graphics.translate(-anchorX, -anchorY)
-        snake:draw()
-        love.graphics.pop()
-    end
-
     local nameAlpha = fadeAlpha(0.0, 0.45)
     local titleParams
     if nameAlpha > 0 then

--- a/shop.lua
+++ b/shop.lua
@@ -4,7 +4,6 @@ local Audio = require("audio")
 local MetaProgression = require("metaprogression")
 local Theme = require("theme")
 local Shaders = require("shaders")
-local SnakeActor = require("snakeactor")
 
 local Shop = {}
 
@@ -130,15 +129,6 @@ function Shop:start(currentFloor)
     self.inputMode = nil
     self.time = 0
     configureBackgroundEffect()
-    self.snakeActor = SnakeActor:new({
-        segmentCount = 18,
-        speed = 115,
-        radiusX = 260,
-        radiusY = 110,
-        defaultPathPoints = 36,
-    })
-    self.snakeActorAnchorX = nil
-    self.snakeActorAnchorY = nil
     self:refreshCards()
 end
 
@@ -272,9 +262,6 @@ end
 
 function Shop:update(dt)
     if not dt then return end
-    if self.snakeActor then
-        self.snakeActor:update(dt)
-    end
     self.time = (self.time or 0) + dt
     if not self.cardStates then return end
 
@@ -740,23 +727,6 @@ function Shop:draw(screenW, screenH)
     drawBackground(screenW, screenH)
     love.graphics.setFont(UI.fonts.title)
     love.graphics.printf("Choose an Upgrade", 0, screenH * 0.15, screenW, "center")
-
-    local snake = self.snakeActor
-    if snake then
-        local anchorX = screenW * 0.5
-        local anchorY = screenH * 0.68
-        if self.snakeActorAnchorX ~= anchorX or self.snakeActorAnchorY ~= anchorY then
-            snake:setOffset(anchorX, anchorY)
-            self.snakeActorAnchorX = anchorX
-            self.snakeActorAnchorY = anchorY
-        end
-
-        local bobOffset = math.sin((self.time or 0) * 0.8) * 6
-        love.graphics.push()
-        love.graphics.translate(0, bobOffset)
-        snake:draw()
-        love.graphics.pop()
-    end
 
     if self.shopkeeperLine then
         love.graphics.setFont(UI.fonts.body)

--- a/transitionmanager.lua
+++ b/transitionmanager.lua
@@ -3,7 +3,6 @@ local Floors = require("floors")
 local SessionStats = require("sessionstats")
 local PlayerStats = require("playerstats")
 local Shop = require("shop")
-local SnakeActor = require("snakeactor")
 
 local TransitionManager = {}
 TransitionManager.__index = TransitionManager
@@ -138,33 +137,6 @@ function TransitionManager:startFloorIntro(duration, extra)
     self:startPhase("floorintro", introDuration)
     Audio:playSound("floor_intro")
 
-    local width = (self.game and self.game.screenWidth) or (love.graphics and love.graphics.getWidth and love.graphics.getWidth()) or 0
-    local height = (self.game and self.game.screenHeight) or (love.graphics and love.graphics.getHeight and love.graphics.getHeight()) or 0
-    local anchorX = width * 0.5
-    local anchorY = height * 0.58
-    local path = {
-        { -280, -130 },
-        { -160, -210 },
-        { 0, -235 },
-        { 160, -210 },
-        { 280, -130 },
-        { 220, 40 },
-        { 0, 140 },
-        { -220, 40 },
-    }
-
-    local snake = SnakeActor:new({
-        segmentCount = 20,
-        speed = 140,
-        path = path,
-        loop = true,
-        offsetX = anchorX,
-        offsetY = anchorY,
-    })
-
-    data.transitionSnake = snake
-    data.transitionSnakeAnchorX = anchorX
-    data.transitionSnakeAnchorY = anchorY
 end
 
 function TransitionManager:startFadeIn(duration)
@@ -239,10 +211,6 @@ function TransitionManager:update(dt)
     end
 
     if phase == "floorintro" then
-        local snake = self.data.transitionSnake
-        if snake then
-            snake:update(dt)
-        end
         if self.timer >= self.duration then
             local data = self.data
 
@@ -289,10 +257,6 @@ function TransitionManager:completeFloorIntro()
     local data = self.data
     local resumePhase = data.transitionResumePhase or "fadein"
     local fadeDuration = data.transitionResumeFadeDuration
-
-    data.transitionSnake = nil
-    data.transitionSnakeAnchorX = nil
-    data.transitionSnakeAnchorY = nil
 
     data.transitionIntroConfirmed = nil
     data.transitionIntroReady = nil


### PR DESCRIPTION
## Summary
- remove the snake actor from the shop screen and associated update/draw logic
- stop spawning a snake actor during floor intro transitions and strip the related rendering

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0b4a2885c832f9d51fcfbfdd82693