### PR TITLE
Add Mirrored Scales upgrade that reflects lasers

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -483,6 +483,11 @@ local english = {
                 description = "Breaking a crash shield grants +3 bonus score and stalls saws for 1s.",
                 activation_text = "Mirrored Rebound",
             },
+            mirrored_scales = {
+                name = "Mirrored Scales",
+                description = "Blocking a laser makes it fire back the other way after a quick recharge and grants +2 bonus score (+1 per additional copy).",
+                activation_text = "Laser Ricochet",
+            },
             resonant_shell = {
                 name = "Resonant Shell",
                 description = "Gain +0.35s saw stall duration for each Defense upgrade you own.",

--- a/movement.lua
+++ b/movement.lua
@@ -423,7 +423,7 @@ local function handleLaserCollision(headX, headY)
                 return "dead", "laser"
         end
 
-        Lasers:onShieldedHit(laserHit)
+        Lasers:onShieldedHit(laserHit, headX, headY)
 
         Particles:spawnBurst(headX, headY, {
                 count = 10,

--- a/upgrades.lua
+++ b/upgrades.lua
@@ -49,6 +49,51 @@ local function stoneSkinShieldHandler(data, state)
     Rocks:shatterNearest(fx or 0, fy or 0, 1)
 end
 
+local function mirroredScalesChargeFactor(stacks)
+    stacks = stacks or 1
+    local factor = 0.45 - 0.08 * (stacks - 1)
+    if factor < 0.2 then
+        factor = 0.2
+    end
+    return factor
+end
+
+local function mirroredScalesLaserHandler(data, state)
+    if not (state and data) then return end
+
+    local stacks = (state.takenSet and state.takenSet.mirrored_scales) or 0
+    if stacks <= 0 then return end
+
+    local beam = data.beam
+    if beam and Lasers and Lasers.reflectBeam then
+        Lasers:reflectBeam(beam, { chargeFactor = mirroredScalesChargeFactor(stacks) })
+    end
+
+    if Score.addBonus then
+        local bonus = 2 + math.max(0, stacks - 1)
+        Score:addBonus(bonus)
+    end
+
+    celebrateUpgrade(getUpgradeString("mirrored_scales", "activation_text"), data, {
+        color = {0.72, 0.92, 1, 1},
+        textOffset = 56,
+        textScale = 1.18,
+        particleCount = 18 + stacks * 2,
+        particleSpeed = 150,
+        particleLife = 0.48,
+        visual = {
+            badge = "shield",
+            outerRadius = 64,
+            innerRadius = 20,
+            ringCount = 3,
+            ringSpacing = 12,
+            life = 0.72,
+            glowAlpha = 0.34,
+            haloAlpha = 0.24,
+        },
+    })
+end
+
 local function newRunState()
     return {
         takenOrder = {},
@@ -830,6 +875,22 @@ local pool = {
                 })
             end,
         },
+    }),
+    register({
+        id = "mirrored_scales",
+        nameKey = "upgrades.mirrored_scales.name",
+        descKey = "upgrades.mirrored_scales.description",
+        rarity = "rare",
+        tags = {"defense", "economy"},
+        onAcquire = function(state)
+            if not state.counters then
+                state.counters = {}
+            end
+            if not state.counters.mirroredScalesHandler then
+                state.counters.mirroredScalesHandler = true
+                Upgrades:addEventHandler("laserShielded", mirroredScalesLaserHandler)
+            end
+        end,
     }),
     register({
         id = "resonant_shell",


### PR DESCRIPTION
## Summary
- add the Mirrored Scales upgrade that flips shielded laser beams, awards bonus score, and celebrates the ricochet
- expose a laserShielded event plus a reflection helper so upgrades can interact with blocked beams
- update English localization with Mirrored Scales strings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e0b590f7b8832f81c172150fd5b81d