### PR TITLE
Remove unused segment count argument from snake rendering

### DIFF
--- a/achievementsmenu.lua
+++ b/achievementsmenu.lua
@@ -240,7 +240,7 @@ local function drawThumbSnake(trackX, trackY, trackWidth, trackHeight, thumbY, t
     local scissorH = trackHeight + outlinePad * 2
     love.graphics.setScissor(scissorX, scissorY, scissorW, scissorH)
 
-    drawSnake(trail, #trail, segmentSize, nil, nil, nil, nil, nil)
+    drawSnake(trail, segmentSize, nil, nil, nil, nil, nil)
 
     local head = trail[#trail]
     if head then

--- a/drawword.lua
+++ b/drawword.lua
@@ -55,7 +55,7 @@ local function drawWord(word, ox, oy, cellSize, spacing)
 
       -- The menu draws the face manually so it sits at the end of the word.
       -- Disable the built-in face rendering here to avoid double faces.
-      drawSnake(letterTrail, #letterTrail, cellSize, nil, nil, nil, nil, nil, false)
+      drawSnake(letterTrail, cellSize, nil, nil, nil, nil, nil, false)
 
       for _, p in ipairs(letterTrail) do table.insert(fullTrail, p) end
 

--- a/snake.lua
+++ b/snake.lua
@@ -1003,7 +1003,7 @@ function Snake:drawClipped(hx, hy, hr)
 
     local shouldDrawFace = descendingHole == nil
 
-    DrawSnake(renderTrail, segmentCount, SEGMENT_SIZE, popTimer, function()
+    DrawSnake(renderTrail, SEGMENT_SIZE, popTimer, function()
         if headX and headY and clipRadius > 0 then
             local dx = headX - hx
             local dy = headY - hy
@@ -1919,14 +1919,14 @@ function Snake:draw()
                         return headSeg.drawX or headSeg.x, headSeg.drawY or headSeg.y
                     end
 
-                    DrawSnake(trailData, piece.segmentCount or #trailData, SEGMENT_SIZE, 0, getPieceHead, 0, 0, nil, false)
+                    DrawSnake(trailData, SEGMENT_SIZE, 0, getPieceHead, 0, 0, nil, false)
                 end
             end
         end
 
         local shouldDrawFace = descendingHole == nil
 
-        DrawSnake(trail, segmentCount, SEGMENT_SIZE, popTimer, function()
+        DrawSnake(trail, SEGMENT_SIZE, popTimer, function()
             return self:getHead()
         end, self.crashShields or 0, self.shieldFlashTimer or 0, upgradeVisuals, shouldDrawFace)
 

--- a/snakeactor.lua
+++ b/snakeactor.lua
@@ -514,7 +514,6 @@ function SnakeActor:draw()
 
     DrawSnake(
         self.trail,
-        self.segmentCount,
         self.segmentSize,
         self.popTimer,
         getHead,

--- a/snakedraw.lua
+++ b/snakedraw.lua
@@ -678,7 +678,7 @@ local function drawDashChargeHalo(trail, hx, hy, SEGMENT_SIZE, data)
   love.graphics.pop()
 end
 
-local function drawSnake(trail, segmentCount, SEGMENT_SIZE, popTimer, getHead, shieldCount, shieldFlashTimer, upgradeVisuals, drawFace)
+local function drawSnake(trail, SEGMENT_SIZE, popTimer, getHead, shieldCount, shieldFlashTimer, upgradeVisuals, drawFace)
   if not trail or #trail == 0 then return end
 
   local thickness = SEGMENT_SIZE * 0.8


### PR DESCRIPTION
## Summary
- remove the unused segmentCount parameter from the snakedraw module
- update all callers to use the streamlined drawSnake signature

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0b83ac720832fba59a3a0887dac17