### PR TITLE
Remove unused helpers from UI module

### DIFF
--- a/ui.lua
+++ b/ui.lua
@@ -488,23 +488,6 @@ function UI:mousereleased(x, y, button)
     end
 end
 
--- Score pulse logic
-function UI:reset()
-    scorePulse = 1.0
-    pulseTimer = 0
-    self.combo.count = 0
-    self.combo.timer = 0
-    self.combo.duration = 0
-    self.combo.pop = 0
-    self.floorModifiers = {}
-    self.shields.count = 0
-    self.shields.display = 0
-    self.shields.popTimer = 0
-    self.shields.shakeTimer = 0
-    self.shields.flashTimer = 0
-    self.shields.lastDirection = 0
-end
-
 function UI:triggerScorePulse()
     scorePulse = 1.2
     pulseTimer = 0
@@ -531,10 +514,6 @@ function UI:adjustFruitGoal(delta)
             table.remove(self.fruitSockets)
         end
     end
-end
-
-function UI:getFruitGoal(required)
-    return self.fruitRequired
 end
 
 function UI:setFloorModifiers(modifiers)
@@ -941,10 +920,6 @@ function UI:setCombo(count, timer, duration)
             combo.pop = 0
         end
     end
-end
-
-function UI:getCrashShields()
-    return (self.shields and self.shields.count) or 0
 end
 
 function UI:setCrashShields(count, opts)


### PR DESCRIPTION
## Summary
- remove the unused `UI:reset`, `UI:getFruitGoal`, and `UI:getCrashShields` helpers from the UI module

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0b9469568832f9947da6871cd3879