### PR TITLE
Remove unused helpers from game module

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -399,25 +399,6 @@ function Game:load()
     })
 end
 
-function Game:reset()
-    GameUtils:prepareGame(self.screenWidth, self.screenHeight)
-    Face:set("idle")
-    self.state = "playing"
-    self.floor = 1
-    self.runTimer = 0
-    self.floorTimer = 0
-
-    self.mouseCursorState = nil
-
-    if self.transition then
-        self.transition:reset()
-    end
-
-    if self.input then
-        self.input:resetAxes()
-    end
-end
-
 function Game:enter()
     UI.clearButtons()
     self:load()
@@ -469,14 +450,6 @@ end
 function Game:startFloorTransition(advance, skipFade)
     Snake:finishDescending()
     self.transition:startFloorTransition(advance, skipFade)
-end
-
-function Game:startFloorIntro(duration, extra)
-    self.transition:startFloorIntro(duration, extra)
-end
-
-function Game:startFadeIn(duration)
-    self.transition:startFadeIn(duration)
 end
 
 function Game:updateDescending(dt)


### PR DESCRIPTION
## Summary
- remove unused Game:reset, Game:startFloorIntro, and Game:startFadeIn helpers to simplify the game module

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0bc5211f4832fbf637fd597fbf030