### PR TITLE
Remove unused floating text fadeStart field

### DIFF
--- a/floatingtext.lua
+++ b/floatingtext.lua
@@ -221,7 +221,6 @@ function FloatingText:add(text, x, y, color, duration, riseSpeed, font, options)
         popDuration = popDuration,
         wobbleMagnitude = wobbleMagnitude,
         wobbleFrequency = wobbleFrequency,
-        fadeStart = clamp(fadeStart, 0, 0.99),
         fadeStartTime = fadeStartTime,
         fadeDuration = fadeDuration,
         drift = drift,


### PR DESCRIPTION
## Summary
- remove the unused `fadeStart` property from floating text entries to avoid dead code

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0bf7b6118832f87053a44358b3b25