### PR TITLE
Use Love RNG for safe spawns

### DIFF
--- a/snakeutils.lua
+++ b/snakeutils.lua
@@ -239,9 +239,12 @@ function SnakeUtils.getSafeSpawn(trail, fruit, rocks, safeZone)
     local rockList = (rocks and rocks.getAll and rocks:getAll()) or {}
     local safeCells = safeZone or {}
 
+    -- Use Love's RNG so fruit/rock spawning shares the game's seeded randomness.
+    local random = (love and love.math and love.math.random) or math.random
+
     for _ = 1, maxAttempts do
-        local col = math.random(1, cols)
-        local row = math.random(1, rows)
+        local col = random(1, cols)
+        local row = random(1, rows)
         local cx, cy = Arena:getCenterOfTile(col, row)
 
         local blocked = false


### PR DESCRIPTION
## Summary
- ensure safe spawn selection uses Love's RNG so fruit and rock spawns respect the game's seed
- fall back to Lua's math.random only when Love's RNG is not available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0d854b824832fab64420f8741eb63