### PR TITLE
Fix developer assist floating text head lookup

### DIFF
--- a/snake.lua
+++ b/snake.lua
@@ -37,7 +37,10 @@ local function announceDeveloperAssistChange(enabled)
     end
 
     local message = enabled and "DEV ASSIST ENABLED" or "DEV ASSIST DISABLED"
-    local hx, hy = Snake:getHead and Snake:getHead()
+    local hx, hy
+    if Snake.getHead then
+        hx, hy = Snake:getHead()
+    end
     if not (hx and hy) then
         hx = (screenW or 0) * 0.5
         hy = (screenH or 0) * 0.45


### PR DESCRIPTION
## Summary
- ensure the developer assist floating text only calls `Snake:getHead()` when the method exists
- avoid syntax errors when developer assist toggles without a snake head available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e152da8e5c832f850cd0bfd3b0fa6d