### PR TITLE
Remove unused shader helper and UI variable

### DIFF
--- a/shaders.lua
+++ b/shaders.lua
@@ -39,12 +39,6 @@ local function sendColor(shader, name, color)
     end
 end
 
-local function sendVec2(shader, name, value)
-    if shaderHasUniform(shader, name) then
-        shader:send(name, value)
-    end
-end
-
 local function sendFloat(shader, name, value)
     if shaderHasUniform(shader, name) then
         shader:send(name, value)

--- a/ui.lua
+++ b/ui.lua
@@ -1639,7 +1639,6 @@ function UI:drawFruitSockets()
     local required  = tostring(self.fruitRequired)
     UI.setFont("button")
     local font = love.graphics.getFont()
-    local textHeight = font:getHeight()
     local padding = 12
     local textY = panelY + panelH + padding
     local shadowColor = Theme.shadowColor or {0, 0, 0, 0.5}


### PR DESCRIPTION
## Summary
- delete the unused `sendVec2` helper in the shader module
- remove an unused font height variable from the UI fruit socket rendering

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e169cb3298832f8a49d2e7d10a4a19