### PR TITLE
Remove unused reverse controls code and data

### DIFF
--- a/audio.lua
+++ b/audio.lua
@@ -69,24 +69,6 @@ function Audio:load()
     self:applyVolumes()
 end
 
-Audio.soundDesignNotes = {
-    death = "Short, heavy failure sting with a crunchy impact to sell the snake's demise.",
-    exit_spawn = "Gentle magical chime that signals the exit portal appearing nearby.",
-    exit_enter = "Deep whoosh or portal suction to reinforce diving into the exit.",
-    floor_advance = "Upbeat arpeggio or rising tone to celebrate clearing a floor.",
-    floor_intro = "Soft swell or drum hit that sets the tone for the new floor intro card.",
-    shop_open = "Friendly bell or door chime that implies entering the shop.",
-    shop_focus = "Gentle flourish as the cursor glides over a relic choice.",
-    shop_card_deal = "Light card slide as the relic options are dealt onto the table.",
-    shop_card_select = "Subtle flip as you commit to a relic pick.",
-    shop_purchase = "Burst of coins confirming an upgrade purchase.",
-    goal_reached = "Triumphant swell to celebrate filling the fruit goal.",
-    wall_portal = "Gentle shimmer hinting at slipping through the arena wall.",
-    shield_wall = "Firm magical rebound when a shield saves you from the arena edge.",
-    shield_rock = "Crunchy crack as the shield pulverizes a rock.",
-    shield_saw = "Arcane whoosh to sell deflecting a spinning saw.",
-}
-
 function Audio:applyVolumes()
     for _, track in pairs(self.musicTracks) do
         track:setVolume(Settings.muteMusic and 0 or Settings.musicVolume)

--- a/particles.lua
+++ b/particles.lua
@@ -125,12 +125,4 @@ function Particles:reset()
     self.list = {}
 end
 
-function Particles:isEmpty()
-    return #self.list == 0
-end
-
-function Particles:count()
-    return #self.list
-end
-
 return Particles

--- a/snake.lua
+++ b/snake.lua
@@ -22,7 +22,6 @@ local pendingDir = { x = 1, y = 0 }
 local trail = {}
 local descendingHole = nil
 local segmentCount = 1
-local reverseControls = false
 local popTimer = 0
 local isDead = false
 local fruitsSinceLastTurn = 0
@@ -748,11 +747,9 @@ function Snake:load(w, h)
     direction = { x = 1, y = 0 }
     pendingDir = { x = 1, y = 0 }
     segmentCount = 1
-    reverseControls = false
     popTimer = 0
     moveProgress = 0
     isDead = false
-    self.reverseState = false
     self.shieldFlashTimer = 0
     self.hazardGraceTimer = 0
     trail = buildInitialTrail()
@@ -765,13 +762,9 @@ local function getUpgradesModule()
     return package.loaded["upgrades"]
 end
 
-function Snake:setReverseControls(state)
-    reverseControls = state
-end
-
 function Snake:setDirection(name)
     if not isDead then
-        pendingDir = SnakeUtils.calculateDirection(direction, name, reverseControls)
+        pendingDir = SnakeUtils.calculateDirection(direction, name)
     end
 end
 

--- a/snakeutils.lua
+++ b/snakeutils.lua
@@ -209,9 +209,8 @@ function SnakeUtils.aabb(ax, ay, asize, bx, by, bsize)
 end
 
 -- handle input direction
-function SnakeUtils.calculateDirection(current, input, reverse)
+function SnakeUtils.calculateDirection(current, input)
     local nd = SnakeUtils.directions[input]
-    if reverse and nd then nd = { x = -nd.x, y = -nd.y } end
     if nd and not (nd.x == -current.x and nd.y == -current.y) then
         return nd
     end


### PR DESCRIPTION
## Summary
- delete the unused `Audio.soundDesignNotes` reference data
- remove the dormant reverse-controls plumbing from the snake input helpers
- drop unused particle list query helpers

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68e19f7f5ae8832f84bd74e0595db93b