### PR TITLE
Add dart traps to arenas

### DIFF
--- a/darts.lua
+++ b/darts.lua
@@ -1,0 +1,574 @@
+local Theme = require("theme")
+local Arena = require("arena")
+local SnakeUtils = require("snakeutils")
+local Rocks = require("rocks")
+local Audio = require("audio")
+local Particles = require("particles")
+
+local Darts = {}
+
+local launchers = {}
+
+local DEFAULT_TELEGRAPH_DURATION = 0.85
+local DEFAULT_COOLDOWN_MIN = 3.4
+local DEFAULT_COOLDOWN_MAX = 5.0
+local DEFAULT_FIRE_SPEED = 460
+local DEFAULT_DART_LENGTH = 32
+local DART_THICKNESS = 8
+local HOLE_RADIUS = 10
+local TELEGRAPH_PULSE_SPEED = 6.4
+local IMPACT_RING_LIFE = 0.32
+
+local function getTime()
+    if love and love.timer and love.timer.getTime then
+        return love.timer.getTime()
+    end
+
+    return 0
+end
+
+local function clamp01(value)
+    if value < 0 then
+        return 0
+    elseif value > 1 then
+        return 1
+    end
+    return value
+end
+
+local function getLauncherColors()
+    local body = Theme.laserBaseColor or {0.18, 0.19, 0.24, 0.95}
+    local accent = Theme.laserColor or {1, 0.32, 0.26, 1}
+    return body, accent
+end
+
+local function getArenaLimits(dir, facing)
+    local ax, ay, aw, ah = Arena:getBounds()
+    local inset = (Arena.tileSize or 24) * 0.5
+    local left = ax + inset
+    local right = ax + aw - inset
+    local top = ay + inset
+    local bottom = ay + ah - inset
+
+    if dir == "horizontal" then
+        if facing >= 0 then
+            return left, right - 4
+        else
+            return right, left + 4
+        end
+    else
+        if facing >= 0 then
+            return top, bottom - 4
+        else
+            return bottom, top + 4
+        end
+    end
+end
+
+local function getHolePosition(dir, facing, x, y)
+    local tileSize = Arena.tileSize or 24
+    local offset = tileSize * 0.5 + 6
+    if dir == "horizontal" then
+        return x - facing * offset, y
+    else
+        return x, y - facing * offset
+    end
+end
+
+local function updateImpact(launcher, dt)
+    local impact = launcher and launcher.impact
+    if not impact then
+        return
+    end
+
+    impact.timer = impact.timer - dt
+    if impact.timer <= 0 then
+        launcher.impact = nil
+    end
+end
+
+local function scheduleCooldown(launcher)
+    local minCooldown = launcher.cooldownMin or DEFAULT_COOLDOWN_MIN
+    local maxCooldown = launcher.cooldownMax or DEFAULT_COOLDOWN_MAX
+    if maxCooldown < minCooldown then
+        maxCooldown = minCooldown
+    end
+
+    local roll = love.math.random()
+    launcher.cooldownTimer = minCooldown + (maxCooldown - minCooldown) * roll
+    launcher.state = "cooldown"
+    launcher.telegraphProgress = 0
+end
+
+local function spawnImpactFX(x, y, dirX, dirY)
+    local _, accent = getLauncherColors()
+    local normalX = dirX or 0
+    local normalY = dirY or 0
+
+    Particles:spawnBurst(x, y, {
+        count = love.math.random(4, 6),
+        speed = 110,
+        speedVariance = 40,
+        life = 0.32,
+        size = 3.2,
+        color = {accent[1], accent[2], accent[3], 1},
+        spread = math.pi * 0.6,
+        angle = math.atan2(normalY, normalX),
+        angleJitter = math.pi * 0.25,
+        drag = 2.6,
+        gravity = 160,
+        scaleMin = 0.48,
+        scaleVariance = 0.4,
+        fadeTo = 0,
+    })
+
+    Particles:spawnBurst(x, y, {
+        count = love.math.random(4, 6),
+        speed = 60,
+        speedVariance = 28,
+        life = 0.38,
+        size = 2.0,
+        color = {1, 0.92, 0.72, 0.6},
+        spread = math.pi * 2,
+        angleJitter = math.pi,
+        drag = 3.4,
+        gravity = 0,
+        scaleMin = 0.32,
+        scaleVariance = 0.4,
+        fadeTo = 0,
+    })
+end
+
+local function triggerImpact(launcher, hitX, hitY)
+    if not launcher then
+        return
+    end
+
+    local projectile = launcher.projectile
+    if projectile then
+        launcher.impact = {
+            x = hitX or projectile.tipX,
+            y = hitY or projectile.tipY,
+            dirX = projectile.dirX,
+            dirY = projectile.dirY,
+            timer = IMPACT_RING_LIFE,
+            life = IMPACT_RING_LIFE,
+        }
+    end
+
+    spawnImpactFX(hitX or launcher.x, hitY or launcher.y, launcher.dirX, launcher.dirY)
+    Audio:playSound("shield_saw")
+    launcher.projectile = nil
+    scheduleCooldown(launcher)
+end
+
+local function getRockCollision(projectile, newTipX, newTipY)
+    local rocks = Rocks:getAll()
+    if not (rocks and #rocks > 0) then
+        return nil
+    end
+
+    local bestDistance
+    local hit
+    local dirX, dirY = projectile.dirX, projectile.dirY
+    local prevX, prevY = projectile.tipX, projectile.tipY
+
+    for _, rock in ipairs(rocks) do
+        local width = rock.w or 24
+        local height = rock.h or 24
+        local offsetY = rock.offsetY or 0
+        local scaleX = rock.scaleX or 1
+        local scaleY = rock.scaleY or 1
+
+        local halfW = (width * scaleX) * 0.5
+        local halfH = (height * scaleY) * 0.5
+        local left = (rock.x or 0) - halfW
+        local right = left + width * scaleX
+        local top = (rock.y or 0) + offsetY - halfH
+        local bottom = top + height * scaleY
+
+        if dirX ~= 0 then
+            local y = newTipY
+            if y >= top and y <= bottom then
+                if dirX > 0 then
+                    if prevX <= left and newTipX >= left then
+                        local distance = left - projectile.originX
+                        if not bestDistance or distance < bestDistance then
+                            bestDistance = distance
+                            hit = { x = left, y = y }
+                        end
+                    end
+                else
+                    if prevX >= right and newTipX <= right then
+                        local distance = projectile.originX - right
+                        if not bestDistance or distance < bestDistance then
+                            bestDistance = distance
+                            hit = { x = right, y = y }
+                        end
+                    end
+                end
+            end
+        else
+            local x = newTipX
+            if x >= left and x <= right then
+                if dirY > 0 then
+                    if prevY <= top and newTipY >= top then
+                        local distance = top - projectile.originY
+                        if not bestDistance or distance < bestDistance then
+                            bestDistance = distance
+                            hit = { x = x, y = top }
+                        end
+                    end
+                else
+                    if prevY >= bottom and newTipY <= bottom then
+                        local distance = projectile.originY - bottom
+                        if not bestDistance or distance < bestDistance then
+                            bestDistance = distance
+                            hit = { x = x, y = bottom }
+                        end
+                    end
+                end
+            end
+        end
+    end
+
+    return hit
+end
+
+local function updateProjectile(launcher, dt)
+    local projectile = launcher.projectile
+    if not projectile then
+        return
+    end
+
+    local speed = projectile.speed or DEFAULT_FIRE_SPEED
+    local dirX, dirY = projectile.dirX, projectile.dirY
+    local travel = speed * dt
+
+    projectile.prevTipX = projectile.tipX
+    projectile.prevTipY = projectile.tipY
+
+    local newTipX = projectile.tipX + dirX * travel
+    local newTipY = projectile.tipY + dirY * travel
+
+    if dirX ~= 0 then
+        if (dirX > 0 and newTipX > projectile.limit) or (dirX < 0 and newTipX < projectile.limit) then
+            newTipX = projectile.limit
+        end
+    else
+        if (dirY > 0 and newTipY > projectile.limit) or (dirY < 0 and newTipY < projectile.limit) then
+            newTipY = projectile.limit
+        end
+    end
+
+    local collision = getRockCollision(projectile, newTipX, newTipY)
+    if collision then
+        newTipX = collision.x
+        newTipY = collision.y
+    end
+
+    projectile.tipX = newTipX
+    projectile.tipY = newTipY
+    projectile.baseX = newTipX - dirX * projectile.length
+    projectile.baseY = newTipY - dirY * projectile.length
+
+    if (dirX ~= 0 and newTipX == projectile.limit) or (dirY ~= 0 and newTipY == projectile.limit) or collision then
+        triggerImpact(launcher, newTipX, newTipY)
+    end
+end
+
+local function advanceLauncher(launcher, dt)
+    if launcher.state == "cooldown" then
+        launcher.cooldownTimer = (launcher.cooldownTimer or 0) - dt
+        if launcher.cooldownTimer <= 0 then
+            launcher.telegraphTimer = launcher.telegraphDuration or DEFAULT_TELEGRAPH_DURATION
+            launcher.state = "telegraph"
+            launcher.cooldownTimer = nil
+        end
+    elseif launcher.state == "telegraph" then
+        launcher.telegraphTimer = (launcher.telegraphTimer or 0) - dt
+        local duration = launcher.telegraphDuration or DEFAULT_TELEGRAPH_DURATION
+        local progress = 1 - (launcher.telegraphTimer or 0) / duration
+        launcher.telegraphProgress = clamp01(progress)
+
+        if launcher.telegraphTimer <= 0 then
+            launcher.projectile = {
+                tipX = launcher.startX,
+                tipY = launcher.startY,
+                prevTipX = launcher.startX,
+                prevTipY = launcher.startY,
+                baseX = launcher.startX - launcher.dirX * launcher.dartLength,
+                baseY = launcher.startY - launcher.dirY * launcher.dartLength,
+                dirX = launcher.dirX,
+                dirY = launcher.dirY,
+                speed = launcher.fireSpeed or DEFAULT_FIRE_SPEED,
+                length = launcher.dartLength,
+                limit = launcher.travelLimit,
+                originX = launcher.startX,
+                originY = launcher.startY,
+            }
+            launcher.state = "firing"
+            launcher.telegraphProgress = 1
+            Audio:playSound("laser_fire")
+        end
+    elseif launcher.state == "firing" then
+        updateProjectile(launcher, dt)
+    end
+
+    updateImpact(launcher, dt)
+end
+
+function Darts:reset()
+    for _, launcher in ipairs(launchers) do
+        if launcher.col and launcher.row then
+            SnakeUtils.setOccupied(launcher.col, launcher.row, false)
+        end
+    end
+
+    launchers = {}
+end
+
+function Darts:spawn(x, y, dir, options)
+    dir = dir or "horizontal"
+    options = options or {}
+
+    local col, row = Arena:getTileFromWorld(x, y)
+    local facing = options.facing
+    if facing == nil then
+        if dir == "horizontal" then
+            facing = (col <= math.floor((Arena.cols or 1) / 2)) and 1 or -1
+        else
+            facing = (row <= math.floor((Arena.rows or 1) / 2)) and 1 or -1
+        end
+    end
+
+    facing = (facing >= 0) and 1 or -1
+    local dirX = (dir == "horizontal") and facing or 0
+    local dirY = (dir == "vertical") and facing or 0
+    local _, travelLimit = getArenaLimits(dir, facing)
+
+    local tileSize = Arena.tileSize or 24
+    local startX = x + dirX * (tileSize * 0.5 - 6)
+    local startY = y + dirY * (tileSize * 0.5 - 6)
+
+    local launcher = {
+        x = x,
+        y = y,
+        col = col,
+        row = row,
+        dir = dir,
+        facing = facing,
+        dirX = dirX,
+        dirY = dirY,
+        startX = startX,
+        startY = startY,
+        travelLimit = travelLimit,
+        telegraphDuration = options.telegraphDuration or DEFAULT_TELEGRAPH_DURATION,
+        fireSpeed = options.fireSpeed or DEFAULT_FIRE_SPEED,
+        dartLength = options.dartLength or DEFAULT_DART_LENGTH,
+        cooldownMin = options.cooldownMin or DEFAULT_COOLDOWN_MIN,
+        cooldownMax = options.cooldownMax or DEFAULT_COOLDOWN_MAX,
+        state = "cooldown",
+        telegraphProgress = 0,
+        randomOffset = love.math.random() * math.pi * 2,
+    }
+
+    launcher.travelLimit = travelLimit
+
+    launcher.holeX, launcher.holeY = getHolePosition(dir, facing, x, y)
+
+    SnakeUtils.setOccupied(col, row, true)
+    scheduleCooldown(launcher)
+
+    launchers[#launchers + 1] = launcher
+    return launcher
+end
+
+function Darts:update(dt)
+    if dt <= 0 then
+        return
+    end
+
+    for _, launcher in ipairs(launchers) do
+        advanceLauncher(launcher, dt)
+    end
+end
+
+local function drawTelegraph(launcher, bodyColor, accentColor)
+    local progress = launcher.telegraphProgress or 0
+    if progress <= 0 then
+        return
+    end
+
+    local pulse = 0.35 + 0.25 * math.sin((getTime() + launcher.randomOffset) * TELEGRAPH_PULSE_SPEED)
+    local glowAlpha = clamp01(progress * 0.9 + pulse * 0.35)
+
+    love.graphics.setColor(accentColor[1], accentColor[2], accentColor[3], glowAlpha)
+
+    if launcher.dir == "horizontal" then
+        local dir = launcher.dirX >= 0 and 1 or -1
+        local tipX = launcher.startX - dir * (1 - progress) * 8
+        local startX = tipX - dir * 8
+        local endX = tipX + dir * 4
+        local rectX = math.min(startX, endX)
+        local rectW = math.abs(endX - startX)
+        love.graphics.rectangle("fill", rectX, launcher.y - DART_THICKNESS * 0.5, rectW, DART_THICKNESS)
+    else
+        local dir = launcher.dirY >= 0 and 1 or -1
+        local tipY = launcher.startY - dir * (1 - progress) * 8
+        local startY = tipY - dir * 8
+        local endY = tipY + dir * 4
+        local rectY = math.min(startY, endY)
+        local rectH = math.abs(endY - startY)
+        love.graphics.rectangle("fill", launcher.x - DART_THICKNESS * 0.5, rectY, DART_THICKNESS, rectH)
+    end
+
+    love.graphics.setColor(1, 1, 1, glowAlpha * 0.6)
+    love.graphics.circle("fill", launcher.holeX, launcher.holeY, HOLE_RADIUS * clamp01(progress * 0.8))
+end
+
+local function drawProjectile(launcher, accentColor)
+    local projectile = launcher.projectile
+    if not projectile then
+        return
+    end
+
+    local dirX, dirY = projectile.dirX, projectile.dirY
+    love.graphics.setColor(accentColor)
+
+    if dirX ~= 0 then
+        local left = math.min(projectile.baseX, projectile.tipX)
+        local width = math.abs(projectile.tipX - projectile.baseX)
+        love.graphics.rectangle("fill", left, projectile.tipY - DART_THICKNESS * 0.5, width, DART_THICKNESS)
+
+        local tipWidth = 10
+        local tipHeight = DART_THICKNESS * 0.75
+        if dirX > 0 then
+            love.graphics.polygon("fill",
+                projectile.tipX + 2, projectile.tipY,
+                projectile.tipX - tipWidth, projectile.tipY - tipHeight,
+                projectile.tipX - tipWidth, projectile.tipY + tipHeight
+            )
+        else
+            love.graphics.polygon("fill",
+                projectile.tipX - 2, projectile.tipY,
+                projectile.tipX + tipWidth, projectile.tipY - tipHeight,
+                projectile.tipX + tipWidth, projectile.tipY + tipHeight
+            )
+        end
+    else
+        local top = math.min(projectile.baseY, projectile.tipY)
+        local height = math.abs(projectile.tipY - projectile.baseY)
+        love.graphics.rectangle("fill", projectile.tipX - DART_THICKNESS * 0.5, top, DART_THICKNESS, height)
+
+        local tipWidth = DART_THICKNESS * 0.75
+        local tipHeight = 10
+        if dirY > 0 then
+            love.graphics.polygon("fill",
+                projectile.tipX, projectile.tipY + 2,
+                projectile.tipX - tipWidth, projectile.tipY - tipHeight,
+                projectile.tipX + tipWidth, projectile.tipY - tipHeight
+            )
+        else
+            love.graphics.polygon("fill",
+                projectile.tipX, projectile.tipY - 2,
+                projectile.tipX - tipWidth, projectile.tipY + tipHeight,
+                projectile.tipX + tipWidth, projectile.tipY + tipHeight
+            )
+        end
+    end
+end
+
+local function drawHole(launcher, bodyColor)
+    love.graphics.setColor(bodyColor)
+    love.graphics.circle("fill", launcher.holeX, launcher.holeY, HOLE_RADIUS)
+
+    love.graphics.setColor(0, 0, 0, 0.75)
+    love.graphics.setLineWidth(3)
+    love.graphics.circle("line", launcher.holeX, launcher.holeY, HOLE_RADIUS)
+    love.graphics.setLineWidth(1)
+end
+
+local function drawImpact(launcher, accentColor)
+    local impact = launcher.impact
+    if not impact then
+        return
+    end
+
+    local progress = clamp01(impact.timer / (impact.life or IMPACT_RING_LIFE))
+    local radius = 6 + (1 - progress) * 12
+    love.graphics.setColor(accentColor[1], accentColor[2], accentColor[3], progress * 0.6)
+    love.graphics.setLineWidth(2)
+    love.graphics.circle("line", impact.x, impact.y, radius)
+    love.graphics.setLineWidth(1)
+end
+
+function Darts:draw()
+    local bodyColor, accentColor = getLauncherColors()
+
+    for _, launcher in ipairs(launchers) do
+        drawHole(launcher, bodyColor)
+        drawTelegraph(launcher, bodyColor, accentColor)
+        drawProjectile(launcher, accentColor)
+        drawImpact(launcher, accentColor)
+    end
+
+    love.graphics.setColor(1, 1, 1, 1)
+end
+
+local function overlapsProjectile(launcher, x, y, w, h)
+    local projectile = launcher.projectile
+    if not projectile then
+        return false
+    end
+
+    local margin = DART_THICKNESS * 0.5
+    if projectile.dirX ~= 0 then
+        local prevBase = projectile.prevTipX - projectile.dirX * projectile.length
+        local left = math.min(projectile.baseX, projectile.tipX, projectile.prevTipX, prevBase) - margin
+        local right = math.max(projectile.baseX, projectile.tipX, projectile.prevTipX, prevBase) + margin
+        local top = projectile.tipY - margin
+        local bottom = projectile.tipY + margin
+
+        return x < right and x + w > left and y < bottom and y + h > top
+    else
+        local prevBase = projectile.prevTipY - projectile.dirY * projectile.length
+        local top = math.min(projectile.baseY, projectile.tipY, projectile.prevTipY, prevBase) - margin
+        local bottom = math.max(projectile.baseY, projectile.tipY, projectile.prevTipY, prevBase) + margin
+        local left = projectile.tipX - margin
+        local right = projectile.tipX + margin
+
+        return x < right and x + w > left and y < bottom and y + h > top
+    end
+end
+
+function Darts:checkCollision(x, y, w, h)
+    for _, launcher in ipairs(launchers) do
+        if launcher.state == "firing" and overlapsProjectile(launcher, x, y, w, h) then
+            return {
+                launcher = launcher,
+                dirX = launcher.dirX,
+                dirY = launcher.dirY,
+                x = launcher.projectile and launcher.projectile.tipX,
+                y = launcher.projectile and launcher.projectile.tipY,
+            }
+        end
+    end
+
+    return nil
+end
+
+function Darts:onShieldedHit(hit, hitX, hitY)
+    if not hit then
+        return
+    end
+
+    local launcher = hit.launcher
+    if not launcher then
+        return
+    end
+
+    triggerImpact(launcher, hitX or hit.x, hitY or hit.y)
+end
+
+return Darts

--- a/floorplan.lua
+++ b/floorplan.lua
@@ -4,12 +4,23 @@ local FloorPlan = {}
 
 local FINAL_FLOOR = #Floors
 local BASE_LASER_CAP = 3
+local BASE_DART_CAP = 4
 
 local function getLaserCap(floorIndex)
     floorIndex = floorIndex or 1
 
     if FINAL_FLOOR > 0 and floorIndex < FINAL_FLOOR then
         return BASE_LASER_CAP
+    end
+
+    return nil
+end
+
+local function getDartCap(floorIndex)
+    floorIndex = floorIndex or 1
+
+    if FINAL_FLOOR > 0 and floorIndex < FINAL_FLOOR then
+        return BASE_DART_CAP
     end
 
     return nil
@@ -26,12 +37,24 @@ local function applyLaserCap(context)
     end
 end
 
+local function applyDartCap(context)
+    if not context then
+        return
+    end
+
+    local cap = getDartCap(context.floor)
+    if cap and context.dartCount ~= nil then
+        context.dartCount = math.min(cap, context.dartCount)
+    end
+end
+
 local BASELINE_PLAN = {
     [1] = {
         fruitGoal = 6,
         rocks = 4,
         saws = 1,
         laserCount = 0,
+        dartCount = 0,
         rockSpawnChance = 0.24,
         sawSpeedMult = 1.08,
         sawSpinMult = 1.0,
@@ -42,6 +65,7 @@ local BASELINE_PLAN = {
         rocks = 5,
         saws = 1,
         laserCount = 0,
+        dartCount = 0,
         rockSpawnChance = 0.26,
         sawSpeedMult = 1.14,
         sawSpinMult = 1.06,
@@ -52,6 +76,7 @@ local BASELINE_PLAN = {
         rocks = 6,
         saws = 2,
         laserCount = 0,
+        dartCount = 0,
         rockSpawnChance = 0.28,
         sawSpeedMult = 1.2,
         sawSpinMult = 1.12,
@@ -62,6 +87,7 @@ local BASELINE_PLAN = {
         rocks = 7,
         saws = 2,
         laserCount = 0,
+        dartCount = 0,
         rockSpawnChance = 0.3,
         sawSpeedMult = 1.26,
         sawSpinMult = 1.18,
@@ -72,6 +98,7 @@ local BASELINE_PLAN = {
         rocks = 8,
         saws = 3,
         laserCount = 0,
+        dartCount = 0,
         rockSpawnChance = 0.33,
         sawSpeedMult = 1.32,
         sawSpinMult = 1.24,
@@ -82,6 +109,7 @@ local BASELINE_PLAN = {
         rocks = 9,
         saws = 3,
         laserCount = 1,
+        dartCount = 0,
         rockSpawnChance = 0.36,
         sawSpeedMult = 1.38,
         sawSpinMult = 1.3,
@@ -92,6 +120,7 @@ local BASELINE_PLAN = {
         rocks = 10,
         saws = 4,
         laserCount = 1,
+        dartCount = 0,
         rockSpawnChance = 0.39,
         sawSpeedMult = 1.44,
         sawSpinMult = 1.36,
@@ -102,6 +131,7 @@ local BASELINE_PLAN = {
         rocks = 11,
         saws = 4,
         laserCount = 1,
+        dartCount = 1,
         rockSpawnChance = 0.42,
         sawSpeedMult = 1.5,
         sawSpinMult = 1.42,
@@ -112,6 +142,7 @@ local BASELINE_PLAN = {
         rocks = 12,
         saws = 4,
         laserCount = 2,
+        dartCount = 1,
         rockSpawnChance = 0.45,
         sawSpeedMult = 1.56,
         sawSpinMult = 1.48,
@@ -122,6 +153,7 @@ local BASELINE_PLAN = {
         rocks = 13,
         saws = 5,
         laserCount = 2,
+        dartCount = 1,
         rockSpawnChance = 0.48,
         sawSpeedMult = 1.62,
         sawSpinMult = 1.54,
@@ -132,6 +164,7 @@ local BASELINE_PLAN = {
         rocks = 14,
         saws = 5,
         laserCount = 2,
+        dartCount = 2,
         rockSpawnChance = 0.5,
         sawSpeedMult = 1.68,
         sawSpinMult = 1.6,
@@ -142,6 +175,7 @@ local BASELINE_PLAN = {
         rocks = 15,
         saws = 6,
         laserCount = 2,
+        dartCount = 2,
         rockSpawnChance = 0.52,
         sawSpeedMult = 1.74,
         sawSpinMult = 1.66,
@@ -152,6 +186,7 @@ local BASELINE_PLAN = {
         rocks = 16,
         saws = 6,
         laserCount = 3,
+        dartCount = 2,
         rockSpawnChance = 0.54,
         sawSpeedMult = 1.8,
         sawSpinMult = 1.72,
@@ -162,6 +197,7 @@ local BASELINE_PLAN = {
         rocks = 17,
         saws = 7,
         laserCount = 3,
+        dartCount = 3,
         rockSpawnChance = 0.56,
         sawSpeedMult = 1.84,
         sawSpinMult = 1.76,
@@ -172,6 +208,7 @@ local BASELINE_PLAN = {
         rocks = 19,
         saws = 7,
         laserCount = 3,
+        dartCount = 3,
         rockSpawnChance = 0.58,
         sawSpeedMult = 1.88,
         sawSpinMult = 1.8,
@@ -198,6 +235,7 @@ function FloorPlan.buildBaselineFloorContext(floorNum)
             context[key] = value
         end
         applyLaserCap(context)
+        applyDartCap(context)
         return context
     end
 
@@ -215,7 +253,9 @@ function FloorPlan.buildBaselineFloorContext(floorNum)
     context.rocks = math.max(0, math.min(40, (lastPlan.rocks or 19) + extraFloors))
     context.saws = math.max(1, math.min(8, (lastPlan.saws or 7) + math.floor(extraFloors / 3)))
     context.laserCount = math.max(0, math.min(6, (lastPlan.laserCount or 3) + math.floor(extraFloors / 5)))
+    context.dartCount = math.max(0, math.min(6, (lastPlan.dartCount or 3) + math.floor(extraFloors / 6)))
     applyLaserCap(context)
+    applyDartCap(context)
     context.rockSpawnChance = math.min(0.68, (lastPlan.rockSpawnChance or 0.58) + extraFloors * 0.015)
     context.sawSpeedMult = math.min(1.95, (lastPlan.sawSpeedMult or 1.88) + extraFloors * 0.03)
     context.sawSpinMult = math.min(1.88, (lastPlan.sawSpinMult or 1.8) + extraFloors * 0.025)
@@ -225,5 +265,6 @@ function FloorPlan.buildBaselineFloorContext(floorNum)
 end
 
 FloorPlan.getLaserCap = getLaserCap
+FloorPlan.getDartCap = getDartCap
 
 return FloorPlan

--- a/floortraits.lua
+++ b/floortraits.lua
@@ -201,6 +201,11 @@ function FloorTraits:apply(list, context)
         local maxLasers = cap or 6
         ctx.laserCount = math.max(0, math.min(maxLasers, math.floor(ctx.laserCount + 0.5)))
     end
+    if ctx.dartCount ~= nil then
+        local cap = FloorPlan.getDartCap and FloorPlan.getDartCap(ctx.floor)
+        local maxDarts = cap or 6
+        ctx.dartCount = math.max(0, math.min(maxDarts, math.floor(ctx.dartCount + 0.5)))
+    end
     if ctx.fruitGoal then
         ctx.fruitGoal = math.max(1, math.floor(ctx.fruitGoal + 0.5))
     end

--- a/game.lua
+++ b/game.lua
@@ -26,6 +26,7 @@ local GameModes = require("gamemodes")
 local GameUtils = require("gameutils")
 local Saws = require("saws")
 local Lasers = require("lasers")
+local Darts = require("darts")
 local Death = require("death")
 local Floors = require("floors")
 local Shop = require("shop")
@@ -54,6 +55,7 @@ local ENTITY_UPDATE_ORDER = {
     Fruit,
     Rocks,
     Lasers,
+    Darts,
     Saws,
     Arena,
     Particles,
@@ -567,8 +569,9 @@ local function drawPlayfieldLayers(self, stateOverride)
 
     Fruit:draw()
     Rocks:draw()
-    Saws:draw()
     Lasers:draw()
+    Darts:draw()
+    Saws:draw()
     Arena:drawExit()
 
     if renderState == "descending" then


### PR DESCRIPTION
## Summary
- add a dedicated dart trap module that telegraphs, fires, and reacts to collisions
- integrate dart launchers into floor setup, baseline plans, and runtime hazard handling
- extend movement logic and rendering so darts interact with shields and the arena like other traps

## Testing
- `luac -p darts.lua floorplan.lua floorsetup.lua floortraits.lua game.lua movement.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e1bb636e38832fb74a627110334e11