### PR TITLE
Brighten Echoing Caverns palette and shader

### DIFF
--- a/floors.lua
+++ b/floors.lua
@@ -46,11 +46,11 @@ local Floors = {
         name = "Echoing Caverns",
         flavor = "Echoes promise sweeter bites deeper in. Noodl slithers on, belly rumbling.",
         palette = {
-            bgColor    = {0.12, 0.14, 0.18, 1}, -- bluish depth
-            arenaBG    = {0.18, 0.19, 0.23, 1}, -- softened slate
-            arenaBorder= {0.2, 0.28, 0.42, 1},  -- cool blue edge
-            snake      = {0.6, 0.65, 0.7, 1},   -- pale stone
-            rock       = {0.38, 0.43, 0.52, 1}, -- cool steel-blue highlights
+            bgColor    = {0.09, 0.11, 0.2, 1},   -- deeper indigo backdrop
+            arenaBG    = {0.14, 0.18, 0.3, 1},   -- cooler slate with teal tint
+            arenaBorder= {0.38, 0.36, 0.68, 1},  -- luminous violet-blue edge
+            snake      = {0.32, 0.78, 0.92, 1},  -- crisp glacial teal body
+            rock       = {0.28, 0.46, 0.66, 1},  -- saturated steel-blue highlights
         },
         backgroundEffect = {
             type = "softCavern",

--- a/shaders.lua
+++ b/shaders.lua
@@ -306,16 +306,20 @@ registerEffect({
             float ceiling = smoothstep(0.1, 0.7, uv.y + sin((uv.x * 3.5) + time * 0.18) * 0.04);
             float mist = smoothstep(0.0, 1.0, uv.y * 1.1);
             float shimmer = sin((uv.x * 6.0 - uv.y * 1.2) + time * 0.32) * 0.5 + 0.5;
+            float colorPulse = sin((uv.x + uv.y) * 4.6 + time * 0.45) * 0.5 + 0.5;
 
             vec3 base = mix(baseColor.rgb, fogColor.rgb, ceiling * 0.58 + mist * 0.42);
-            float highlight = clamp((shimmer * 0.34 + 0.12) * intensity, 0.0, 1.0);
-            vec3 col = mix(base, glintColor.rgb, highlight * 0.58);
+            float highlight = clamp((shimmer * 0.38 + 0.16) * intensity, 0.0, 1.0);
+            vec3 col = mix(base, glintColor.rgb, highlight * 0.62);
 
-            float ambient = clamp(0.16 + intensity * 0.28, 0.0, 0.45);
-            col = mix(col, mix(fogColor.rgb, glintColor.rgb, 0.25), ambient);
+            vec3 accent = mix(glintColor.rgb, fogColor.rgb, 0.28);
+            col = mix(col, accent, colorPulse * 0.22 * intensity);
+
+            float ambient = clamp(0.18 + intensity * 0.32, 0.0, 0.48);
+            col = mix(col, mix(fogColor.rgb, glintColor.rgb, 0.22), ambient);
 
             float depth = smoothstep(0.0, 0.4, uv.y);
-            col = mix(col, baseColor.rgb, depth * 0.08);
+            col = mix(col, baseColor.rgb, depth * 0.06);
 
             return vec4(col, baseColor.a) * color;
         }


### PR DESCRIPTION
## Summary
- enrich the Echoing Caverns floor palette with deeper indigos and vibrant teal highlights
- add extra shimmer and color pulses to the soft cavern background shader for a livelier backdrop

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1c3409a2c832f9c8a8d8767916ab2