### PR TITLE
Enhance Mushroom Grotto shader colors

### DIFF
--- a/shaders.lua
+++ b/shaders.lua
@@ -661,6 +661,8 @@ registerEffect({
             float waveMix = clamp(petalWave * 0.5 + 0.5, 0.0, 1.0) * (0.18 + 0.28 * intensity);
 
             vec3 base = mix(baseColor.rgb, softColor.rgb, clamp(0.45 + intensity * 0.25 + centered.y * 0.2, 0.0, 1.0));
+            vec3 fungalGlow = mix(accentColor.rgb, sporeColor.rgb, 0.55);
+            base = mix(base, fungalGlow, 0.18 + 0.22 * intensity);
             vec3 accent = mix(base, accentColor.rgb, 0.65);
             vec3 glow = mix(accentColor.rgb, glowColor.rgb, 0.58);
             vec3 spores = mix(glowColor.rgb, sporeColor.rgb, 0.6);
@@ -689,11 +691,12 @@ registerEffect({
             float vignette = 1.0 - smoothstep(innerEdge, outerEdge, dist + breathing * 0.08 * intensity);
 
             float ambientPulse = sin(time * 0.22 + centered.y * 3.0) * 0.5 + 0.5;
-            vec3 tintedBase = mix(baseColor.rgb, softColor.rgb, 0.35 + ambientPulse * 0.2);
-            tintedBase = mix(tintedBase, sporeColor.rgb, 0.18 + 0.22 * ambientPulse);
-            tintedBase = mix(tintedBase, accentColor.rgb, 0.08 + 0.08 * intensity);
+            vec3 tintedBase = mix(baseColor.rgb, softColor.rgb, 0.25 + ambientPulse * 0.2);
+            tintedBase = mix(tintedBase, sporeColor.rgb, 0.28 + 0.25 * ambientPulse + 0.15 * intensity);
+            tintedBase = mix(tintedBase, accentColor.rgb, 0.22 + 0.18 * intensity);
+            tintedBase = mix(tintedBase, glowColor.rgb, 0.14 + 0.22 * ambientPulse);
 
-            float finalMix = clamp(vignette * 0.78 + 0.22, 0.0, 1.0);
+            float finalMix = clamp(vignette * (0.82 + 0.08 * intensity) + 0.16, 0.0, 1.0);
             vec3 finalColor = mix(tintedBase, colorBlend, finalMix);
 
             return vec4(finalColor, baseColor.a) * color;


### PR DESCRIPTION
## Summary
- infuse the Mushroom Grotto background shader with a fungal glow blend for richer hues
- retune base and pulse mixes to lean into accent, spore, and glow colors instead of bright whites
- adjust final vignette weighting so the arena keeps the deeper saturation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1c3c1d934832f80f1137bb0c3912f