### PR TITLE
Add forgiving health system

### DIFF
--- a/gamemodes.lua
+++ b/gamemodes.lua
@@ -31,6 +31,7 @@ GameModes.available = {
         unlocked = true,
         unlockCondition = nil,
         unlockDescription = nil,
+        maxHealth = 3,
 
         load = function(game)
             game.timer = nil
@@ -50,6 +51,7 @@ GameModes.available = {
             value = 25,
         },
         unlockDescriptionKey = "gamemodes.hardcore.unlock_description",
+        maxHealth = 1,
 
         load = function(game)
             if game.Effects and game.Effects.shake then
@@ -71,6 +73,7 @@ GameModes.available = {
             value = 50,
         },
         unlockDescriptionKey = "gamemodes.timed.unlock_description",
+        maxHealth = 3,
 
         load = function(game)
             game.timer = game.mode.timeLimit
@@ -108,6 +111,7 @@ GameModes.available = {
         timeLimit = nil,
         unlocked = true,
         daily = true,
+        maxHealth = 3,
 
         load = function(game)
             game.effects = GameModes:getDailyModifiers()


### PR DESCRIPTION
## Summary
- add a mode-configurable health pool for each run and manage it from the core game loop
- convert hazard collisions to deal damage with recovery context instead of ending the run immediately
- surface the player's remaining hearts on the HUD with shake/flash feedback when taking damage

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e1cbd80998832f962f23ac6569a7c8