### PR TITLE
Add 3px black outline to health hearts

### DIFF
--- a/ui.lua
+++ b/ui.lua
@@ -134,11 +134,14 @@ local function drawHeartShape(x, y, size)
     love.graphics.circle("fill", x + quarter, y - quarter, radius, 16)
     love.graphics.polygon("fill", x - half, y - quarter, x, y + half, x + half, y - quarter)
 
-    love.graphics.setLineWidth(2)
+    local r, g, b, a = love.graphics.getColor()
+    love.graphics.setColor(0, 0, 0, a)
+    love.graphics.setLineWidth(3)
     love.graphics.circle("line", x - quarter, y - quarter, radius, 16)
     love.graphics.circle("line", x + quarter, y - quarter, radius, 16)
     love.graphics.polygon("line", x - half, y - quarter, x, y + half, x + half, y - quarter)
     love.graphics.setLineWidth(1)
+    love.graphics.setColor(r, g, b, a)
 end
 
 -- Button states


### PR DESCRIPTION
## Summary
- update the heart drawing helper to render a 3px black outline around the health icons
- preserve the existing fill color while restoring it after outlining

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1d129c9c8832fb82111b2f1781687