### PR TITLE
Draw heart outlines beneath fill

### DIFF
--- a/ui.lua
+++ b/ui.lua
@@ -130,18 +130,19 @@ local function drawHeartShape(x, y, size)
     local quarter = size * 0.25
     local radius = size * 0.32
 
-    love.graphics.circle("fill", x - quarter, y - quarter, radius, 16)
-    love.graphics.circle("fill", x + quarter, y - quarter, radius, 16)
-    love.graphics.polygon("fill", x - half, y - quarter, x, y + half, x + half, y - quarter)
-
     local r, g, b, a = love.graphics.getColor()
+
     love.graphics.setColor(0, 0, 0, a)
     love.graphics.setLineWidth(3)
     love.graphics.circle("line", x - quarter, y - quarter, radius, 16)
     love.graphics.circle("line", x + quarter, y - quarter, radius, 16)
     love.graphics.polygon("line", x - half, y - quarter, x, y + half, x + half, y - quarter)
     love.graphics.setLineWidth(1)
+
     love.graphics.setColor(r, g, b, a)
+    love.graphics.circle("fill", x - quarter, y - quarter, radius, 16)
+    love.graphics.circle("fill", x + quarter, y - quarter, radius, 16)
+    love.graphics.polygon("fill", x - half, y - quarter, x, y + half, x + half, y - quarter)
 end
 
 -- Button states


### PR DESCRIPTION
## Summary
- render the heart outline as a background layer before drawing the fill

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1d69b44a8832f8883f1649f7d1a00