### PR TITLE
Disable dart and laser hazards

### DIFF
--- a/darts.lua
+++ b/darts.lua
@@ -7,7 +7,13 @@ local Particles = require("particles")
 
 local Darts = {}
 
+local DARTS_ENABLED = false
+
 local launchers = {}
+
+function Darts:isEnabled()
+    return DARTS_ENABLED
+end
 
 local DEFAULT_TELEGRAPH_DURATION = 1.15
 local DEFAULT_COOLDOWN_MIN = 4.0
@@ -334,9 +340,17 @@ function Darts:reset()
     end
 
     launchers = {}
+
+    if not DARTS_ENABLED then
+        return
+    end
 end
 
 function Darts:spawn(x, y, dir, options)
+    if not DARTS_ENABLED then
+        return
+    end
+
     dir = dir or "horizontal"
     options = options or {}
 
@@ -393,6 +407,10 @@ function Darts:spawn(x, y, dir, options)
 end
 
 function Darts:update(dt)
+    if not DARTS_ENABLED then
+        return
+    end
+
     if dt <= 0 then
         return
     end
@@ -570,6 +588,10 @@ local function drawImpact(launcher, accentColor)
 end
 
 function Darts:draw()
+    if not DARTS_ENABLED then
+        return
+    end
+
     local bodyColor, accentColor = getLauncherColors()
 
     for _, launcher in ipairs(launchers) do
@@ -609,6 +631,10 @@ local function overlapsProjectile(launcher, x, y, w, h)
 end
 
 function Darts:checkCollision(x, y, w, h)
+    if not DARTS_ENABLED then
+        return nil
+    end
+
     for _, launcher in ipairs(launchers) do
         if launcher.state == "firing" and overlapsProjectile(launcher, x, y, w, h) then
             return {
@@ -625,6 +651,10 @@ function Darts:checkCollision(x, y, w, h)
 end
 
 function Darts:onShieldedHit(hit, hitX, hitY)
+    if not DARTS_ENABLED then
+        return
+    end
+
     if not hit then
         return
     end

--- a/lasers.lua
+++ b/lasers.lua
@@ -6,7 +6,13 @@ local Audio = require("audio")
 
 local Lasers = {}
 
+local LASERS_ENABLED = false
+
 local emitters = {}
+
+function Lasers:isEnabled()
+    return LASERS_ENABLED
+end
 
 Lasers.fireDurationMult = 1
 Lasers.fireDurationFlat = 0
@@ -305,6 +311,10 @@ local function computeBeamTarget(beam)
 end
 
 function Lasers:reflectBeam(beam, options)
+    if not LASERS_ENABLED then
+        return nil
+    end
+
     if not beam then
         return nil
     end
@@ -344,9 +354,17 @@ function Lasers:reset()
         releaseOccupancy(beam)
     end
     emitters = {}
+
+    if not LASERS_ENABLED then
+        return
+    end
 end
 
 function Lasers:spawn(x, y, dir, options)
+    if not LASERS_ENABLED then
+        return
+    end
+
     dir = dir or "horizontal"
     options = options or {}
 
@@ -393,6 +411,10 @@ function Lasers:spawn(x, y, dir, options)
 end
 
 function Lasers:update(dt)
+    if not LASERS_ENABLED then
+        return
+    end
+
     if dt <= 0 then
         return
     end
@@ -486,6 +508,10 @@ function Lasers:update(dt)
 end
 
 function Lasers:onShieldedHit(beam, hitX, hitY)
+    if not LASERS_ENABLED then
+        return
+    end
+
     if not beam then
         return
     end
@@ -530,12 +556,20 @@ local function baseBounds(beam)
 end
 
 function Lasers:applyTimingModifiers()
+    if not LASERS_ENABLED then
+        return
+    end
+
     for _, beam in ipairs(emitters) do
         recalcBeamTiming(beam, false)
     end
 end
 
 function Lasers:checkCollision(x, y, w, h)
+    if not LASERS_ENABLED then
+        return nil
+    end
+
     if not (x and y and w and h) then
         return nil
     end
@@ -831,6 +865,10 @@ local function drawEmitterBase(beam)
 end
 
 function Lasers:draw()
+    if not LASERS_ENABLED then
+        return
+    end
+
     if #emitters == 0 then
         return
     end


### PR DESCRIPTION
## Summary
- add module level feature flags that keep dart and laser hazards inactive
- short-circuit spawn, update, draw, and collision handling when hazards are disabled

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2082f3e20832f966b67d0b5115971