### PR TITLE
Add healing feedback during floor intro

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -340,6 +340,8 @@ local english = {
             },
             floor_intro = {
                 prompt = "Press any key to descend",
+                heal_section_title = "Floor Rest",
+                heal_note = "Recovered ${amount} health.",
             },
         },
         gamemodes = {


### PR DESCRIPTION
## Summary
- add a reusable `Game:restoreHealth` helper and trigger healing when a floor begins using the configured heal amount
- surface the heal in the floor transition panel so players know they were patched up
- add localization strings for the new transition messaging

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e20a8a0f14832f8009e4baed4ec47c