### PR TITLE
Refine health system flow and critical moments

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -342,6 +342,10 @@ local english = {
                 prompt = "Press any key to descend",
                 heal_section_title = "Floor Rest",
                 heal_note = "Recovered ${amount} health.",
+                shield_note = "Forged ${amount} crash shield(s).",
+            },
+            health = {
+                critical_surge = "Second Wind!",
             },
         },
         gamemodes = {

--- a/healthsystem.lua
+++ b/healthsystem.lua
@@ -1,0 +1,122 @@
+local HealthSystem = {}
+HealthSystem.__index = HealthSystem
+
+local function clampToInt(value)
+    if value == nil then
+        return 0
+    end
+
+    return math.max(0, math.floor((value or 0) + 0.0001))
+end
+
+function HealthSystem.new(maxHealth)
+    local instance = setmetatable({}, HealthSystem)
+    instance.criticalThreshold = 1
+    instance:reset(maxHealth)
+    return instance
+end
+
+function HealthSystem:reset(maxHealth)
+    if maxHealth ~= nil then
+        self.max = clampToInt(maxHealth)
+        if self.max <= 0 then
+            self.max = 1
+        end
+    else
+        self.max = self.max and clampToInt(self.max) or 1
+    end
+
+    self.current = clampToInt(self.max or 1)
+    self.damageTaken = 0
+    self.totalHealed = 0
+
+    return self.current
+end
+
+function HealthSystem:setMax(maxHealth)
+    self.max = clampToInt(maxHealth)
+    if self.max <= 0 then
+        self.max = 1
+    end
+
+    if self.current == nil then
+        self.current = self.max
+    else
+        self.current = math.min(self.current, self.max)
+    end
+
+    return self.current
+end
+
+function HealthSystem:setCurrent(value)
+    value = clampToInt(value)
+    if self.max then
+        value = math.min(value, self.max)
+    end
+
+    self.current = value
+    return self.current
+end
+
+function HealthSystem:getCurrent()
+    return self.current or 0
+end
+
+function HealthSystem:getMax()
+    return self.max or 0
+end
+
+function HealthSystem:damage(amount)
+    local damage = clampToInt(amount)
+    if damage <= 0 then
+        return 0, self.current or 0, (self.current or 0) > 0
+    end
+
+    local previous = self.current or 0
+    local updated = math.max(0, previous - damage)
+    self.current = updated
+    local applied = previous - updated
+    self.damageTaken = (self.damageTaken or 0) + applied
+
+    return applied, updated, updated > 0
+end
+
+function HealthSystem:heal(amount)
+    local heal = clampToInt(amount)
+    if heal <= 0 then
+        return 0, 0
+    end
+
+    local previous = self.current or 0
+    local cap = self.max
+    local updated
+
+    if cap and cap > 0 then
+        updated = math.min(cap, previous + heal)
+    else
+        updated = previous + heal
+    end
+
+    self.current = updated
+    local restored = math.max(0, updated - previous)
+    local overflow = heal - restored
+    if overflow < 0 then
+        overflow = 0
+    end
+
+    self.totalHealed = (self.totalHealed or 0) + restored
+
+    return restored, overflow
+end
+
+function HealthSystem:isCritical()
+    local threshold = self.criticalThreshold or 1
+    local current = self.current or 0
+    if threshold <= 0 then
+        return current <= 0
+    end
+
+    return current > 0 and current <= threshold
+end
+
+return HealthSystem

--- a/upgrades.lua
+++ b/upgrades.lua
@@ -43,13 +43,20 @@ local function adjustMaxHealth(delta)
     end
 
     local game = getGameInstance()
-    if not (game and game.maxHealth ~= nil) then
+    if not game then
+        return false
+    end
+
+    if game.adjustMaxHealth then
+        return game:adjustMaxHealth(delta, { immediate = true })
+    end
+
+    if game.maxHealth == nil then
         return false
     end
 
     local newMax = math.max(1, (game.maxHealth or 0) + delta)
     game.maxHealth = newMax
-
     if game.health == nil then
         game.health = newMax
     else


### PR DESCRIPTION
## Summary
- centralize run health logic in a dedicated HealthSystem and use it throughout game flow
- introduce critical health surges, overflow floor rest shield conversion, and floor replay resets through the new system
- refresh UI hearts, localization, and upgrade hooks to reflect the new health experience

## Testing
- not run (lua CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e21f0ace08832fbfa40eb4cec29251