### PR TITLE
Fix heart polygon seam

### DIFF
--- a/ui.lua
+++ b/ui.lua
@@ -142,7 +142,7 @@ local function getHeartBasePoints()
     local minX, maxX = math.huge, -math.huge
     local minY, maxY = math.huge, -math.huge
 
-    for i = 0, segments do
+    for i = 0, segments - 1 do
         local t = (i / segments) * (2 * math.pi)
         local sinT = math.sin(t)
         local cosT = math.cos(t)


### PR DESCRIPTION
## Summary
- avoid generating a duplicate closing vertex when sampling the parametric heart shape
- prevent the visible seam that appeared at the bottom of the heart outline

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e22e0553c0832fbe969e8b92fdc263