### PR TITLE
Adjust heart outline joins to remove central seam

### DIFF
--- a/ui.lua
+++ b/ui.lua
@@ -283,9 +283,23 @@ local function drawHeartShape(x, y, size)
     love.graphics.setStencilTest()
 
     love.graphics.setColor(0, 0, 0, a)
+
+    local previousLineJoin = love.graphics.getLineJoin and love.graphics.getLineJoin() or nil
+    if love.graphics.setLineJoin then
+        love.graphics.setLineJoin("bevel")
+    end
+
     love.graphics.setLineWidth(3)
     love.graphics.polygon("line", heartVertexBuffer)
     love.graphics.setLineWidth(1)
+
+    if love.graphics.setLineJoin then
+        if previousLineJoin ~= nil then
+            love.graphics.setLineJoin(previousLineJoin)
+        else
+            love.graphics.setLineJoin("miter")
+        end
+    end
 
     love.graphics.setColor(r, g, b, a)
 end


### PR DESCRIPTION
## Summary
- ensure heart outlines use a bevel join to avoid drawing a seam through the center
- restore the previous line join (or default) after rendering each heart to keep global state intact

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2a0e43a2c832f9727f1a546f31c55