### PR TITLE
Improve upgrade rarity distribution and legendary pity

### DIFF
--- a/upgradehelpers.lua
+++ b/upgradehelpers.lua
@@ -13,27 +13,27 @@ end
 
 UpgradeHelpers.rarities = {
     common = {
-        weight = 60,
+        weight = 46,
         labelKey = "upgrades.rarities.common",
         color = {0.75, 0.82, 0.88, 1},
     },
     uncommon = {
-        weight = 32,
+        weight = 30,
         labelKey = "upgrades.rarities.uncommon",
         color = {0.55, 0.78, 0.58, 1},
     },
     rare = {
-        weight = 10,
+        weight = 16,
         labelKey = "upgrades.rarities.rare",
         color = {0.54, 0.72, 0.96, 1},
     },
     epic = {
-        weight = 2.8,
+        weight = 5.2,
         labelKey = "upgrades.rarities.epic",
         color = {0.76, 0.56, 0.88, 1},
     },
     legendary = {
-        weight = 0.5,
+        weight = 1.4,
         labelKey = "upgrades.rarities.legendary",
         color = {1, 0.66, 0.32, 1},
     },


### PR DESCRIPTION
## Summary
- retune rarity weights and pity multipliers so rare and above upgrades surface more often
- add a legendary pity counter that guarantees a legendary card after repeated dry spells once unlocked

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e2ac74c914832fb8d6724763378686