### PR TITLE
Add persistent talent tree selection interface

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -15,6 +15,7 @@ local english = {
             settings = "Settings",
             achievements = "Achievements",
             progression = "Progression",
+            talents = "Talents",
             quit = "Quit",
             version = "v1.0.0",
             title_word = "noodl",
@@ -170,6 +171,15 @@ local english = {
                 description = "Unlock this secret to reveal its details.",
                 progress = "Hidden",
             },
+        },
+        talents = {
+            title = "Talent Forge",
+            subtitle = "Choose one talent per tier to shape your run.",
+            loadout = "Active loadout:",
+            loadout_empty = "Active loadout: balanced.",
+            selected = "Selected",
+            back = "Back to Menu",
+            hint = "Use arrows, mouse, or gamepad to navigate. Enter/A selects, Esc/B returns.",
         },
         metaprogression = {
             title = "Progression",

--- a/app.lua
+++ b/app.lua
@@ -22,6 +22,7 @@ local App = {
         gameover = require("gameover"),
         achievementsmenu = require("achievementsmenu"),
         metaprogression = require("metaprogressionscreen"),
+        talenttree = require("talenttreescreen"),
         settings = require("settingsscreen"),
     }
 }

--- a/menu.lua
+++ b/menu.lua
@@ -234,6 +234,7 @@ function Menu:enter()
         { key = "menu.start_game",   action = "modeselect" },
         { key = "menu.achievements", action = "achievementsmenu" },
         { key = "menu.progression",  action = "metaprogression" },
+        { key = "menu.talents",      action = "talenttree" },
         { key = "menu.settings",     action = "settings" },
         { key = "menu.quit",         action = "quit" },
     }

--- a/talenttree.lua
+++ b/talenttree.lua
@@ -1,0 +1,483 @@
+local Snake = require("snake")
+local Score = require("score")
+local Rocks = require("rocks")
+
+local TalentTree = {}
+
+local SAVE_FILE = "talenttree_state.lua"
+
+local DEFAULT_STATE = {
+    selections = {},
+}
+
+local tiers = {
+    {
+        id = "foundation",
+        name = "Tier I — Foundation",
+        description = "Set your baseline defenses and scoring expectations.",
+        options = {
+            {
+                id = "balanced_protocol",
+                name = "Balanced Protocol",
+                description = "Maintain the classic noodl experience with no modifiers.",
+                bonuses = { "Run behaves exactly as classic" },
+                penalties = {},
+                effects = {},
+                default = true,
+            },
+            {
+                id = "adaptive_plating",
+                name = "Adaptive Plating",
+                description = "Lean into survivability by thickening your hull.",
+                bonuses = { "+1 max health" },
+                penalties = { "Fruit bonus -0.4" },
+                effects = {
+                    maxHealthBonus = 1,
+                    fruitBonus = -0.4,
+                },
+            },
+            {
+                id = "glass_cannon",
+                name = "Glass Cannon",
+                description = "Strip armor for a higher scoring ceiling.",
+                bonuses = { "+1.5 fruit bonus" },
+                penalties = { "-1 max health" },
+                effects = {
+                    maxHealthBonus = -1,
+                    fruitBonus = 1.5,
+                },
+            },
+        },
+    },
+    {
+        id = "mobility",
+        name = "Tier II — Mobility",
+        description = "Tune how aggressively your snake moves across the arena.",
+        options = {
+            {
+                id = "baseline_flow",
+                name = "Baseline Flow",
+                description = "Keep your acceleration curve identical to classic noodl.",
+                bonuses = { "No change to movement" },
+                penalties = {},
+                effects = {},
+                default = true,
+            },
+            {
+                id = "velocity_drive",
+                name = "Velocity Drive",
+                description = "Hit the throttle and weave between hazards.",
+                bonuses = { "Snake speed x1.18" },
+                penalties = { "Rock spawns x1.25" },
+                effects = {
+                    snakeSpeedMultiplier = 1.18,
+                    rockSpawnMultiplier = 1.25,
+                },
+            },
+            {
+                id = "shield_dash",
+                name = "Shield Dash",
+                description = "Start with an extra shield and a slight pace boost.",
+                bonuses = { "+1 crash shield", "Snake speed x1.05" },
+                penalties = { "Fruit bonus -0.2" },
+                effects = {
+                    startingCrashShields = 1,
+                    snakeSpeedMultiplier = 1.05,
+                    fruitBonus = -0.2,
+                },
+            },
+        },
+    },
+    {
+        id = "control",
+        name = "Tier III — Control",
+        description = "Decide how you want hazards and combos to scale.",
+        options = {
+            {
+                id = "stabilizers",
+                name = "Field Stabilizers",
+                description = "Preserve the baseline hazard cadence from classic runs.",
+                bonuses = { "No change to hazard pacing" },
+                penalties = {},
+                effects = {},
+                default = true,
+            },
+            {
+                id = "hazard_training",
+                name = "Hazard Training",
+                description = "Invite more danger to learn faster reactions.",
+                bonuses = { "+1 crash shield" },
+                penalties = { "Rock spawns x1.35" },
+                effects = {
+                    startingCrashShields = 1,
+                    rockSpawnMultiplier = 1.35,
+                },
+            },
+            {
+                id = "precision_combo",
+                name = "Precision Combo",
+                description = "Chase big combo bonuses by tightening execution.",
+                bonuses = { "Combo multiplier x1.35" },
+                penalties = { "Snake speed x0.96" },
+                effects = {
+                    comboMultiplier = 1.35,
+                    snakeSpeedMultiplier = 0.96,
+                },
+            },
+        },
+    },
+    {
+        id = "harvest",
+        name = "Tier IV — Harvest",
+        description = "Shape long-term growth and resource flow.",
+        options = {
+            {
+                id = "balanced_harvest",
+                name = "Balanced Harvest",
+                description = "Maintain the familiar balance between growth and scoring.",
+                bonuses = { "No change to fruit rewards" },
+                penalties = {},
+                effects = {},
+                default = true,
+            },
+            {
+                id = "lean_frame",
+                name = "Lean Frame",
+                description = "Stay trim for sharper dodges at the cost of points.",
+                bonuses = { "Extra growth -1" },
+                penalties = { "Fruit bonus -0.3" },
+                effects = {
+                    extraGrowth = -1,
+                    fruitBonus = -0.3,
+                },
+            },
+            {
+                id = "score_pipeline",
+                name = "Score Pipeline",
+                description = "Sacrifice resilience for explosive scoring runs.",
+                bonuses = { "Combo multiplier x1.45", "Fruit bonus +0.6" },
+                penalties = { "-1 max health" },
+                effects = {
+                    comboMultiplier = 1.45,
+                    fruitBonus = 0.6,
+                    maxHealthBonus = -1,
+                },
+            },
+        },
+    },
+}
+
+local function copyTable(source)
+    if type(source) ~= "table" then
+        return source
+    end
+
+    local result = {}
+    for key, value in pairs(source) do
+        if type(value) == "table" then
+            result[key] = copyTable(value)
+        else
+            result[key] = value
+        end
+    end
+
+    return result
+end
+
+local function findTier(tierId)
+    for _, tier in ipairs(tiers) do
+        if tier.id == tierId then
+            return tier
+        end
+    end
+end
+
+local function findOption(tier, optionId)
+    if not (tier and tier.options) then
+        return nil
+    end
+
+    for _, option in ipairs(tier.options) do
+        if option.id == optionId then
+            return option
+        end
+    end
+end
+
+local function ensureDefaults(state)
+    state.selections = state.selections or {}
+
+    for _, tier in ipairs(tiers) do
+        local selection = state.selections[tier.id]
+        if selection then
+            local option = findOption(tier, selection)
+            if option then
+                goto continue
+            end
+        end
+
+        local fallback
+        for _, option in ipairs(tier.options) do
+            if option.default then
+                fallback = option.id
+                break
+            end
+        end
+
+        if not fallback and tier.options and tier.options[1] then
+            fallback = tier.options[1].id
+        end
+
+        if fallback then
+            state.selections[tier.id] = fallback
+        end
+
+        ::continue::
+    end
+end
+
+function TalentTree:_ensureLoaded()
+    if self._loaded then
+        return
+    end
+
+    local data = copyTable(DEFAULT_STATE)
+
+    if love.filesystem.getInfo(SAVE_FILE) then
+        local ok, chunk = pcall(love.filesystem.load, SAVE_FILE)
+        if ok and chunk then
+            local success, saved = pcall(chunk)
+            if success and type(saved) == "table" then
+                if type(saved.selections) == "table" then
+                    data.selections = copyTable(saved.selections)
+                end
+            end
+        end
+    end
+
+    ensureDefaults(data)
+
+    self.state = data
+    self._loaded = true
+end
+
+local function serialize(value, indent)
+    indent = indent or 0
+    local valueType = type(value)
+
+    if valueType == "number" or valueType == "boolean" then
+        return tostring(value)
+    elseif valueType == "string" then
+        return string.format("%q", value)
+    elseif valueType == "table" then
+        local spacing = string.rep(" ", indent)
+        local lines = { "{\n" }
+        local nextIndent = indent + 4
+        local entryIndent = string.rep(" ", nextIndent)
+        for key, val in pairs(value) do
+            local keyRepr = string.format("[%q]", tostring(key))
+            table.insert(lines, string.format("%s%s = %s,\n", entryIndent, keyRepr, serialize(val, nextIndent)))
+        end
+        table.insert(lines, string.format("%s}", spacing))
+        return table.concat(lines)
+    end
+
+    return "nil"
+end
+
+function TalentTree:_save()
+    self:_ensureLoaded()
+    local payload = {
+        selections = copyTable(self.state.selections or {}),
+    }
+    local serialized = "return " .. serialize(payload, 0) .. "\n"
+    love.filesystem.write(SAVE_FILE, serialized)
+end
+
+function TalentTree:getTiers()
+    return tiers
+end
+
+function TalentTree:getSelections()
+    self:_ensureLoaded()
+    return copyTable(self.state.selections or {})
+end
+
+function TalentTree:getSelection(tierId)
+    self:_ensureLoaded()
+    return (self.state.selections or {})[tierId]
+end
+
+function TalentTree:setSelection(tierId, optionId)
+    if not tierId or not optionId then
+        return false
+    end
+
+    self:_ensureLoaded()
+
+    local tier = findTier(tierId)
+    if not tier then
+        return false
+    end
+
+    local option = findOption(tier, optionId)
+    if not option then
+        return false
+    end
+
+    self.state.selections = self.state.selections or {}
+    if self.state.selections[tierId] == optionId then
+        return true
+    end
+
+    self.state.selections[tierId] = optionId
+    ensureDefaults(self.state)
+    self:_save()
+    return true
+end
+
+local function createEffectAccumulator()
+    return {
+        maxHealthBonus = 0,
+        fruitBonus = 0,
+        snakeSpeedMultiplier = 1,
+        comboMultiplier = 1,
+        startingCrashShields = 0,
+        extraGrowth = 0,
+        rockSpawnMultiplier = 1,
+    }
+end
+
+local function accumulateEffects(accumulator, effects)
+    if type(effects) ~= "table" then
+        return accumulator
+    end
+
+    if effects.maxHealthBonus then
+        accumulator.maxHealthBonus = (accumulator.maxHealthBonus or 0) + effects.maxHealthBonus
+    end
+
+    if effects.fruitBonus then
+        accumulator.fruitBonus = (accumulator.fruitBonus or 0) + effects.fruitBonus
+    end
+
+    if effects.snakeSpeedMultiplier then
+        accumulator.snakeSpeedMultiplier = (accumulator.snakeSpeedMultiplier or 1) * effects.snakeSpeedMultiplier
+    end
+
+    if effects.comboMultiplier then
+        accumulator.comboMultiplier = (accumulator.comboMultiplier or 1) * effects.comboMultiplier
+    end
+
+    if effects.startingCrashShields then
+        accumulator.startingCrashShields = (accumulator.startingCrashShields or 0) + effects.startingCrashShields
+    end
+
+    if effects.extraGrowth then
+        accumulator.extraGrowth = (accumulator.extraGrowth or 0) + effects.extraGrowth
+    end
+
+    if effects.rockSpawnMultiplier then
+        accumulator.rockSpawnMultiplier = (accumulator.rockSpawnMultiplier or 1) * effects.rockSpawnMultiplier
+    end
+
+    return accumulator
+end
+
+function TalentTree:calculateEffects(selections)
+    local accumulator = createEffectAccumulator()
+
+    for _, tier in ipairs(tiers) do
+        local chosen = selections and selections[tier.id]
+        if chosen then
+            local option = findOption(tier, chosen)
+            if option then
+                accumulateEffects(accumulator, option.effects)
+            end
+        end
+    end
+
+    return accumulator
+end
+
+function TalentTree:getAggregatedEffects()
+    self:_ensureLoaded()
+    return self:calculateEffects(self.state.selections)
+end
+
+local function clamp(value, minValue)
+    if value == nil then
+        return minValue
+    end
+
+    if value < minValue then
+        return minValue
+    end
+
+    return value
+end
+
+local function approximatelyEqual(a, b, epsilon)
+    epsilon = epsilon or 1e-3
+    return math.abs((a or 0) - (b or 0)) <= epsilon
+end
+
+function TalentTree:applyRunModifiers(game, effects)
+    effects = effects or self:getAggregatedEffects()
+
+    if not effects then
+        return nil
+    end
+
+    if game then
+        game.talentEffects = copyTable(effects)
+        game.health = game.maxHealth
+        if game.healthSystem and game.healthSystem.setMax then
+            game.healthSystem:setMax(game.maxHealth)
+            if game.healthSystem.setCurrent then
+                game.healthSystem:setCurrent(game.maxHealth)
+            end
+        end
+    end
+
+    if Snake and Snake.addSpeedMultiplier and not approximatelyEqual(effects.snakeSpeedMultiplier, 1) then
+        if effects.snakeSpeedMultiplier > 0 then
+            Snake:addSpeedMultiplier(effects.snakeSpeedMultiplier)
+        end
+    end
+
+    if Snake and effects.startingCrashShields and effects.startingCrashShields ~= 0 and Snake.addCrashShields then
+        Snake:addCrashShields(effects.startingCrashShields)
+    end
+
+    if Snake then
+        local extraGrowth = effects.extraGrowth or 0
+        if extraGrowth ~= 0 then
+            Snake.extraGrowth = (Snake.extraGrowth or 0) + extraGrowth
+        end
+    end
+
+    if Score then
+        local fruitBonus = effects.fruitBonus or 0
+        if fruitBonus ~= 0 and Score.addFruitBonus then
+            Score:addFruitBonus(fruitBonus)
+        end
+
+        if Score.getComboBonusMultiplier and Score.setComboBonusMultiplier and not approximatelyEqual(effects.comboMultiplier, 1) then
+            local current = Score:getComboBonusMultiplier() or 1
+            Score:setComboBonusMultiplier(current * effects.comboMultiplier)
+        end
+    end
+
+    if Rocks and effects.rockSpawnMultiplier and not approximatelyEqual(effects.rockSpawnMultiplier, 1) then
+        local multiplier = effects.rockSpawnMultiplier
+        if multiplier < 0 then
+            multiplier = 0
+        end
+        Rocks.spawnChance = clamp((Rocks.spawnChance or 0.25) * multiplier, 0)
+    end
+
+    return effects
+end
+
+return TalentTree

--- a/talenttreescreen.lua
+++ b/talenttreescreen.lua
@@ -1,0 +1,930 @@
+local Screen = require("screen")
+local Theme = require("theme")
+local UI = require("ui")
+local Localization = require("localization")
+local TalentTree = require("talenttree")
+local Audio = require("audio")
+local Shaders = require("shaders")
+
+local TalentTreeScreen = {
+    transitionDuration = 0.35,
+}
+
+local unpack = table.unpack or unpack
+
+local CARD_WIDTH = 300
+local CARD_HEIGHT = 172
+local CARD_SPACING = 26
+local HEADER_HEIGHT = 60
+local OPTION_FOOTER_SPACING = 36
+local TIER_SPACING = 68
+local PANEL_PADDING = 38
+local PANEL_WIDTH = 1140
+local PANEL_TOP = 136
+local PANEL_BOTTOM_MARGIN = 110
+local CONTENT_TOP_PADDING = 12
+local SCROLL_SPEED = 60
+local DPAD_REPEAT_INITIAL_DELAY = 0.3
+local DPAD_REPEAT_INTERVAL = 0.12
+local ANALOG_DEADZONE = 0.35
+
+local tiers = {}
+local selections = {}
+local buttons = {}
+local focusedIndex = nil
+local hoveredIndex = nil
+local pressedButtonId = nil
+local scrollOffset = 0
+local minScrollOffset = 0
+local viewportHeight = 0
+local contentHeight = 0
+local layout = {
+    panelX = 0,
+    panelY = 0,
+    panelW = 0,
+    panelH = 0,
+    contentX = 0,
+    contentY = 0,
+    contentW = 0,
+}
+
+local heldDpadButton = nil
+local heldDpadAction = nil
+local heldDpadTimer = 0
+local heldDpadInterval = DPAD_REPEAT_INITIAL_DELAY
+local analogAxisDirections = { horizontal = nil, vertical = nil }
+
+local backgroundEffectType = "metaFlux"
+local backgroundEffectCache = {}
+local backgroundEffect = nil
+
+local function configureBackgroundEffect()
+    local effect = Shaders.ensure(backgroundEffectCache, backgroundEffectType)
+    if not effect then
+        backgroundEffect = nil
+        return
+    end
+
+    local defaultBackdrop = select(1, Shaders.getDefaultIntensities(effect))
+    effect.backdropIntensity = defaultBackdrop or effect.backdropIntensity or 0.55
+
+    Shaders.configure(effect, {
+        bgColor = Theme.bgColor,
+        primaryColor = Theme.progressColor,
+        secondaryColor = Theme.accentTextColor,
+    })
+
+    backgroundEffect = effect
+end
+
+local function drawBackground(sw, sh)
+    love.graphics.setColor(Theme.bgColor)
+    love.graphics.rectangle("fill", 0, 0, sw, sh)
+
+    if not backgroundEffect then
+        configureBackgroundEffect()
+    end
+
+    if backgroundEffect then
+        local intensity = backgroundEffect.backdropIntensity or select(1, Shaders.getDefaultIntensities(backgroundEffect))
+        Shaders.draw(backgroundEffect, 0, 0, sw, sh, intensity)
+    end
+
+    love.graphics.setColor(1, 1, 1, 1)
+end
+
+local function resetHeldDpad()
+    heldDpadButton = nil
+    heldDpadAction = nil
+    heldDpadTimer = 0
+    heldDpadInterval = DPAD_REPEAT_INITIAL_DELAY
+end
+
+local function startHeldDpad(button, action)
+    heldDpadButton = button
+    heldDpadAction = action
+    heldDpadTimer = 0
+    heldDpadInterval = DPAD_REPEAT_INITIAL_DELAY
+end
+
+local function stopHeldDpad(button)
+    if heldDpadButton ~= button then
+        return
+    end
+
+    resetHeldDpad()
+end
+
+local function updateHeldDpad(dt)
+    if not heldDpadAction then
+        return
+    end
+
+    heldDpadTimer = heldDpadTimer + dt
+    local interval = heldDpadInterval
+    while heldDpadTimer >= interval do
+        heldDpadTimer = heldDpadTimer - interval
+        heldDpadAction()
+        heldDpadInterval = DPAD_REPEAT_INTERVAL
+        interval = heldDpadInterval
+        if interval <= 0 then
+            break
+        end
+    end
+end
+
+local function updateFocusVisuals()
+    for index, button in ipairs(buttons) do
+        local focused = (focusedIndex == index)
+        button.focused = focused
+        UI.setButtonFocus(button.id, focused)
+    end
+end
+
+local function clampScroll()
+    if scrollOffset < minScrollOffset then
+        scrollOffset = minScrollOffset
+    elseif scrollOffset > 0 then
+        scrollOffset = 0
+    end
+end
+
+local function ensureFocusVisible(button)
+    if not button or button.type ~= "option" then
+        return
+    end
+
+    local padding = 32
+    local top = button.contentY + scrollOffset
+    local bottom = button.contentBottom + scrollOffset
+
+    if top < padding then
+        scrollOffset = math.min(0, scrollOffset + (padding - top))
+    elseif bottom > viewportHeight - padding then
+        scrollOffset = math.max(minScrollOffset, scrollOffset - (bottom - (viewportHeight - padding)))
+    end
+
+    clampScroll()
+end
+
+local function setFocus(index, opts)
+    if not index or not buttons[index] then
+        return
+    end
+
+    focusedIndex = index
+    updateFocusVisuals()
+
+    if not (opts and opts.skipScroll) then
+        ensureFocusVisible(buttons[index])
+    end
+
+    return buttons[index]
+end
+
+local function focusFirstSelectable()
+    if #buttons == 0 then
+        focusedIndex = nil
+        return
+    end
+
+    for index, button in ipairs(buttons) do
+        if button.type ~= "spacer" then
+            return setFocus(index, { skipScroll = true })
+        end
+    end
+
+    setFocus(1, { skipScroll = true })
+end
+
+local function findOptionButton(tierIndex, optionIndex)
+    for index, button in ipairs(buttons) do
+        if button.type == "option" and button.tierIndex == tierIndex and button.optionIndex == optionIndex then
+            return button, index
+        end
+    end
+end
+
+local function moveFocusHorizontal(delta)
+    if not delta or delta == 0 then
+        return
+    end
+
+    local current = buttons[focusedIndex]
+    if not current then
+        return
+    end
+
+    if current.type ~= "option" then
+        return
+    end
+
+    local tier = tiers[current.tierIndex]
+    if not tier then
+        return
+    end
+
+    local count = #tier.options
+    if count <= 1 then
+        return
+    end
+
+    local targetOption = current.optionIndex + delta
+    if targetOption < 1 then
+        targetOption = 1
+    elseif targetOption > count then
+        targetOption = count
+    end
+
+    local _, index = findOptionButton(current.tierIndex, targetOption)
+    if index then
+        setFocus(index)
+    end
+end
+
+local function moveFocusVertical(delta)
+    if not delta or delta == 0 then
+        return
+    end
+
+    local current = buttons[focusedIndex]
+    if not current then
+        return
+    end
+
+    if current.type == "back" then
+        if delta < 0 then
+            local lastTier = #tiers
+            if lastTier > 0 then
+                local targetTier = lastTier
+                local targetOption = selections[tiers[targetTier].id]
+                local tier = tiers[targetTier]
+                local optionIndex = 1
+                if targetOption then
+                    for idx, opt in ipairs(tier.options) do
+                        if opt.id == targetOption then
+                            optionIndex = idx
+                            break
+                        end
+                    end
+                end
+                local _, index = findOptionButton(targetTier, optionIndex)
+                if index then
+                    setFocus(index)
+                end
+            end
+        end
+        return
+    end
+
+    local targetTierIndex = current.tierIndex + delta
+    if targetTierIndex < 1 then
+        return
+    end
+
+    if targetTierIndex > #tiers then
+        for index, button in ipairs(buttons) do
+            if button.type == "back" then
+                setFocus(index)
+                return
+            end
+        end
+        return
+    end
+
+    local tier = tiers[targetTierIndex]
+    if not tier then
+        return
+    end
+
+    local preferredOption = current.optionIndex
+    if tier.options[preferredOption] == nil then
+        preferredOption = math.min(preferredOption, #tier.options)
+        if preferredOption <= 0 then
+            preferredOption = 1
+        end
+    end
+
+    local _, index = findOptionButton(targetTierIndex, preferredOption)
+    if index then
+        setFocus(index)
+    end
+end
+
+local function addScroll(delta)
+    if not delta or delta == 0 then
+        return
+    end
+
+    scrollOffset = scrollOffset + delta
+    clampScroll()
+end
+
+local function rebuildButtons()
+    tiers = TalentTree:getTiers() or {}
+    selections = TalentTree:getSelections() or {}
+    buttons = {}
+
+    for tierIndex, tier in ipairs(tiers) do
+        for optionIndex, option in ipairs(tier.options or {}) do
+            buttons[#buttons + 1] = {
+                id = string.format("talent_option_%s_%s", tier.id, option.id),
+                type = "option",
+                tier = tier,
+                option = option,
+                tierIndex = tierIndex,
+                optionIndex = optionIndex,
+                x = 0,
+                y = 0,
+                w = CARD_WIDTH,
+                h = CARD_HEIGHT,
+                contentY = 0,
+                contentBottom = 0,
+            }
+        end
+    end
+
+    local backLabel = Localization:get("talents.back")
+    if backLabel == "talents.back" then
+        backLabel = Localization:get("common.back_to_menu")
+    end
+
+    buttons[#buttons + 1] = {
+        id = "talent_back",
+        type = "back",
+        label = backLabel,
+        x = 0,
+        y = 0,
+        w = UI.spacing.buttonWidth,
+        h = UI.spacing.buttonHeight,
+    }
+
+    focusFirstSelectable()
+end
+
+local function updateLayout()
+    local sw, sh = Screen:get()
+
+    layout.panelW = math.min(PANEL_WIDTH, sw - 120)
+    layout.panelX = math.floor((sw - layout.panelW) / 2)
+    layout.panelY = PANEL_TOP
+    layout.panelH = math.max(420, sh - PANEL_TOP - PANEL_BOTTOM_MARGIN)
+    layout.contentX = layout.panelX + PANEL_PADDING
+    layout.contentY = layout.panelY + PANEL_PADDING
+    layout.contentW = layout.panelW - PANEL_PADDING * 2
+
+    viewportHeight = math.max(0, layout.panelH - PANEL_PADDING * 2)
+
+    local yCursor = CONTENT_TOP_PADDING
+    for tierIndex, tier in ipairs(tiers) do
+        local optionStart = yCursor + HEADER_HEIGHT
+        local tierHeight = HEADER_HEIGHT + CARD_HEIGHT + OPTION_FOOTER_SPACING
+
+        local optionCount = #tier.options
+        local totalWidth = optionCount * CARD_WIDTH + math.max(0, optionCount - 1) * CARD_SPACING
+        local startX = layout.contentX + math.max(0, (layout.contentW - totalWidth) / 2)
+
+        for optionIndex = 1, optionCount do
+            local button, index = findOptionButton(tierIndex, optionIndex)
+            if button and index then
+                button.w = CARD_WIDTH
+                button.h = CARD_HEIGHT
+                button.contentY = optionStart
+                button.contentBottom = optionStart + CARD_HEIGHT
+                button.x = startX + (optionIndex - 1) * (CARD_WIDTH + CARD_SPACING)
+                button.y = layout.contentY + scrollOffset + optionStart
+                button.visible = button.y + button.h >= layout.contentY and button.y <= layout.contentY + viewportHeight
+                UI.registerButton(button.id, button.x, button.y, button.w, button.h, button.option.name)
+            end
+        end
+
+        yCursor = yCursor + tierHeight + TIER_SPACING
+    end
+
+    if #tiers > 0 then
+        yCursor = yCursor - TIER_SPACING
+    end
+
+    contentHeight = yCursor
+    minScrollOffset = math.min(0, viewportHeight - contentHeight)
+    clampScroll()
+
+    local backButton = buttons[#buttons]
+    if backButton and backButton.type == "back" then
+        backButton.w = math.min(UI.spacing.buttonWidth * 1.4, layout.panelW - PANEL_PADDING * 2)
+        backButton.h = UI.spacing.buttonHeight
+        backButton.x = layout.panelX + (layout.panelW - backButton.w) / 2
+        backButton.y = layout.panelY + layout.panelH - PANEL_PADDING - backButton.h
+        UI.registerButton(backButton.id, backButton.x, backButton.y, backButton.w, backButton.h, backButton.label)
+        UI.setButtonFocus(backButton.id, focusedIndex == #buttons)
+    end
+end
+
+local function getSummaryLines()
+    local effects = TalentTree:calculateEffects(selections)
+    local lines = {}
+
+    if math.abs(effects.maxHealthBonus or 0) > 0.01 then
+        lines[#lines + 1] = string.format("Max health %+g", effects.maxHealthBonus)
+    end
+
+    if math.abs(effects.startingCrashShields or 0) > 0.01 then
+        lines[#lines + 1] = string.format("Crash shields %+g", effects.startingCrashShields)
+    end
+
+    if math.abs((effects.fruitBonus or 0)) > 0.01 then
+        lines[#lines + 1] = string.format("Fruit bonus %+0.1f", effects.fruitBonus)
+    end
+
+    if math.abs((effects.comboMultiplier or 1) - 1) > 0.01 then
+        lines[#lines + 1] = string.format("Combo multiplier x%.2f", effects.comboMultiplier)
+    end
+
+    if math.abs((effects.snakeSpeedMultiplier or 1) - 1) > 0.01 then
+        lines[#lines + 1] = string.format("Snake speed x%.2f", effects.snakeSpeedMultiplier)
+    end
+
+    if math.abs((effects.extraGrowth or 0)) > 0.01 then
+        lines[#lines + 1] = string.format("Extra growth %+0.1f", effects.extraGrowth)
+    end
+
+    if math.abs((effects.rockSpawnMultiplier or 1) - 1) > 0.01 then
+        lines[#lines + 1] = string.format("Rock spawn x%.2f", effects.rockSpawnMultiplier)
+    end
+
+    return lines
+end
+
+local function drawOptionCard(button)
+    local option = button.option
+    local tier = button.tier
+    local selected = selections[tier.id] == option.id
+
+    local fill = UI.colors.panel
+    if selected then
+        fill = { Theme.progressColor[1], Theme.progressColor[2], Theme.progressColor[3], 0.24 }
+    end
+
+    local borderColor = UI.colors.panelBorder
+    if selected then
+        borderColor = Theme.progressColor
+    end
+
+    UI.registerButton(button.id, button.x, button.y, button.w, button.h, option.name)
+
+    UI.drawPanel(button.x, button.y, button.w, button.h, {
+        fill = fill,
+        borderColor = borderColor,
+        focused = button.focused,
+        focusColor = Theme.accentTextColor,
+        shadowOffset = 6,
+    })
+
+    local padding = 18
+    UI.drawLabel(option.name, button.x + padding, button.y + padding - 2, button.w - padding * 2, "left", {
+        fontKey = "heading",
+        color = Theme.textColor,
+    })
+
+    local descY = button.y + padding + UI.fonts.heading:getHeight() - 4
+    UI.drawLabel(option.description or "", button.x + padding, descY, button.w - padding * 2, "left", {
+        fontKey = "body",
+        color = UI.colors.subtleText,
+    })
+
+    local listY = descY + UI.fonts.body:getHeight() + 8
+    local listFont = UI.fonts.small
+
+    if option.bonuses and #option.bonuses > 0 then
+        for _, bonus in ipairs(option.bonuses) do
+            UI.drawLabel("• " .. bonus, button.x + padding, listY, button.w - padding * 2, "left", {
+                fontKey = "body",
+                color = Theme.progressColor,
+            })
+            listY = listY + listFont:getHeight() + 4
+        end
+    end
+
+    if option.penalties and #option.penalties > 0 then
+        for _, penalty in ipairs(option.penalties) do
+            UI.drawLabel("• " .. penalty, button.x + padding, listY, button.w - padding * 2, "left", {
+                fontKey = "body",
+                color = Theme.warningColor,
+            })
+            listY = listY + listFont:getHeight() + 4
+        end
+    end
+
+    if selected then
+        local tagText = Localization:get("talents.selected")
+        if tagText == "talents.selected" then
+            tagText = "Selected"
+        end
+        local tagWidth = UI.fonts.caption:getWidth(tagText) + 16
+        local tagHeight = UI.fonts.caption:getHeight() + 6
+        local tagX = button.x + button.w - tagWidth - padding
+        local tagY = button.y + button.h - tagHeight - padding + 6
+        UI.drawPanel(tagX, tagY, tagWidth, tagHeight, {
+            fill = { Theme.progressColor[1], Theme.progressColor[2], Theme.progressColor[3], 0.4 },
+            borderColor = Theme.progressColor,
+            shadowOffset = 0,
+            radius = 10,
+        })
+        UI.drawLabel(tagText, tagX, tagY + 3, tagWidth, "center", {
+            fontKey = "caption",
+            color = Theme.textColor,
+        })
+    end
+end
+
+local function drawTier(tierIndex, tier)
+    local tierTop = layout.contentY + scrollOffset + CONTENT_TOP_PADDING + (tierIndex - 1) * (HEADER_HEIGHT + CARD_HEIGHT + OPTION_FOOTER_SPACING + TIER_SPACING)
+    local titleY = tierTop
+    local descY = titleY + UI.fonts.heading:getHeight() + 4
+
+    UI.drawLabel(tier.name, layout.contentX, titleY, layout.contentW, "left", {
+        fontKey = "heading",
+        color = Theme.accentTextColor,
+    })
+
+    UI.drawLabel(tier.description or "", layout.contentX, descY, layout.contentW, "left", {
+        fontKey = "body",
+        color = UI.colors.subtleText,
+    })
+
+    for optionIndex = 1, #tier.options do
+        local button = select(1, findOptionButton(tierIndex, optionIndex))
+        if button then
+            button.y = layout.contentY + scrollOffset + button.contentY
+            drawOptionCard(button)
+        end
+    end
+end
+
+local function activateButton(button)
+    if not button then
+        return nil
+    end
+
+    if button.type == "back" then
+        Audio:playSound("click")
+        return { state = "menu" }
+    elseif button.type == "option" then
+        local tierId = button.tier.id
+        if selections[tierId] ~= button.option.id then
+            selections[tierId] = button.option.id
+            TalentTree:setSelection(tierId, button.option.id)
+        end
+        Audio:playSound("click")
+        return nil
+    end
+
+    return nil
+end
+
+function TalentTreeScreen:enter()
+    UI.clearButtons()
+    scrollOffset = 0
+    minScrollOffset = 0
+    viewportHeight = 0
+    contentHeight = 0
+    focusedIndex = nil
+    hoveredIndex = nil
+    pressedButtonId = nil
+    resetHeldDpad()
+    analogAxisDirections.horizontal = nil
+    analogAxisDirections.vertical = nil
+
+    rebuildButtons()
+    updateLayout()
+end
+
+function TalentTreeScreen:leave()
+    resetHeldDpad()
+end
+
+function TalentTreeScreen:update(dt)
+    updateLayout()
+    updateHeldDpad(dt)
+
+    local mx, my = love.mouse.getPosition()
+    hoveredIndex = nil
+
+    for index, button in ipairs(buttons) do
+        if button.type == "option" then
+            button.y = layout.contentY + scrollOffset + button.contentY
+            if UI.isHovered(button.x, button.y, button.w, button.h, mx, my) then
+                hoveredIndex = index
+            end
+        elseif button.type == "back" then
+            if UI.isHovered(button.x, button.y, button.w, button.h, mx, my) then
+                hoveredIndex = index
+            end
+        end
+    end
+
+    if hoveredIndex then
+        setFocus(hoveredIndex)
+    else
+        updateFocusVisuals()
+    end
+end
+
+function TalentTreeScreen:draw()
+    updateLayout()
+
+    local sw, sh = Screen:get()
+    drawBackground(sw, sh)
+
+    UI.drawPanel(layout.panelX, layout.panelY, layout.panelW, layout.panelH, {
+        fill = Theme.panelColor,
+        borderColor = Theme.panelBorder,
+        shadowOffset = 18,
+    })
+
+    local title = Localization:get("talents.title")
+    if title == "talents.title" then
+        title = "Talent Forge"
+    end
+
+    local subtitle = Localization:get("talents.subtitle")
+    if subtitle == "talents.subtitle" then
+        subtitle = "Choose one talent per tier to shape your run."
+    end
+
+    UI.drawLabel(title, 0, layout.panelY - 88, sw, "center", {
+        fontKey = "title",
+        color = Theme.textColor,
+    })
+
+    UI.drawLabel(subtitle, layout.panelX, layout.panelY - 36, layout.panelW, "center", {
+        fontKey = "body",
+        color = UI.colors.subtleText,
+    })
+
+    local summaryLines = getSummaryLines()
+    if #summaryLines > 0 then
+        local summaryY = layout.panelY + 12
+        local summaryX = layout.panelX + PANEL_PADDING
+        UI.drawLabel(Localization:get("talents.loadout") ~= "talents.loadout" and Localization:get("talents.loadout") or "Active loadout:", summaryX, summaryY, layout.panelW - PANEL_PADDING * 2, "left", {
+            fontKey = "prompt",
+            color = Theme.accentTextColor,
+        })
+        summaryY = summaryY + UI.fonts.prompt:getHeight() + 4
+        for _, line in ipairs(summaryLines) do
+            UI.drawLabel("• " .. line, summaryX, summaryY, layout.panelW - PANEL_PADDING * 2, "left", {
+                fontKey = "body",
+                color = Theme.textColor,
+            })
+            summaryY = summaryY + UI.fonts.body:getHeight() + 2
+        end
+    else
+        UI.drawLabel(Localization:get("talents.loadout_empty") ~= "talents.loadout_empty" and Localization:get("talents.loadout_empty") or "Active loadout: balanced.", layout.panelX + PANEL_PADDING, layout.panelY + 12, layout.panelW - PANEL_PADDING * 2, "left", {
+            fontKey = "prompt",
+            color = Theme.accentTextColor,
+        })
+    end
+
+    local viewportX = layout.contentX
+    local viewportY = layout.contentY
+    local viewportW = layout.contentW
+    local viewportH = viewportHeight
+
+    local prevScissor = { love.graphics.getScissor() }
+    if viewportW > 0 and viewportH > 0 then
+        love.graphics.setScissor(viewportX, viewportY, viewportW, viewportH)
+    end
+
+    for tierIndex, tier in ipairs(tiers) do
+        drawTier(tierIndex, tier)
+    end
+
+    if viewportW > 0 and viewportH > 0 then
+        love.graphics.setScissor(unpack(prevScissor))
+    end
+
+    local hint = Localization:get("talents.hint")
+    if hint == "talents.hint" then
+        hint = "Use arrows, mouse, or gamepad to navigate. Enter/A selects, Esc/B returns."
+    end
+
+    UI.drawLabel(hint, layout.panelX, layout.panelY + layout.panelH + 16, layout.panelW, "center", {
+        fontKey = "caption",
+        color = UI.colors.subtleText,
+    })
+
+    local backButton = buttons[#buttons]
+    if backButton and backButton.type == "back" then
+        UI.registerButton(backButton.id, backButton.x, backButton.y, backButton.w, backButton.h, backButton.label)
+        UI.drawButton(backButton.id)
+    end
+end
+
+function TalentTreeScreen:keypressed(key)
+    if key == "escape" then
+        Audio:playSound("click")
+        return { state = "menu" }
+    elseif key == "return" or key == "kpenter" or key == "space" then
+        return activateButton(buttons[focusedIndex])
+    elseif key == "up" then
+        moveFocusVertical(-1)
+    elseif key == "down" then
+        moveFocusVertical(1)
+    elseif key == "left" then
+        moveFocusHorizontal(-1)
+    elseif key == "right" then
+        moveFocusHorizontal(1)
+    elseif key == "pageup" then
+        addScroll(SCROLL_SPEED * 3)
+    elseif key == "pagedown" then
+        addScroll(-SCROLL_SPEED * 3)
+    end
+end
+
+local function handleGamepadButton(button, pressed)
+    if not pressed then
+        stopHeldDpad(button)
+        return
+    end
+
+    if button == "dpup" then
+        startHeldDpad(button, function()
+            moveFocusVertical(-1)
+        end)
+        moveFocusVertical(-1)
+    elseif button == "dpdown" then
+        startHeldDpad(button, function()
+            moveFocusVertical(1)
+        end)
+        moveFocusVertical(1)
+    elseif button == "dpleft" then
+        startHeldDpad(button, function()
+            moveFocusHorizontal(-1)
+        end)
+        moveFocusHorizontal(-1)
+    elseif button == "dpright" then
+        startHeldDpad(button, function()
+            moveFocusHorizontal(1)
+        end)
+        moveFocusHorizontal(1)
+    elseif button == "a" then
+        return activateButton(buttons[focusedIndex])
+    elseif button == "b" then
+        Audio:playSound("click")
+        return { state = "menu" }
+    elseif button == "leftshoulder" then
+        addScroll(SCROLL_SPEED * 2)
+    elseif button == "rightshoulder" then
+        addScroll(-SCROLL_SPEED * 2)
+    end
+
+    return nil
+end
+
+function TalentTreeScreen:gamepadpressed(_, button)
+    return handleGamepadButton(button, true)
+end
+
+function TalentTreeScreen:gamepadreleased(_, button)
+    stopHeldDpad(button)
+end
+
+local analogAxisMap = {
+    leftx = { slot = "horizontal" },
+    rightx = { slot = "horizontal" },
+    lefty = { slot = "vertical" },
+    righty = { slot = "vertical" },
+    [1] = { slot = "horizontal" },
+    [2] = { slot = "vertical" },
+}
+
+local analogActions = {
+    horizontal = {
+        negative = function()
+            moveFocusHorizontal(-1)
+        end,
+        positive = function()
+            moveFocusHorizontal(1)
+        end,
+    },
+    vertical = {
+        negative = function()
+            moveFocusVertical(-1)
+        end,
+        positive = function()
+            moveFocusVertical(1)
+        end,
+    },
+}
+
+local function handleAnalog(axis, value)
+    local mapping = analogAxisMap[axis]
+    if not mapping then
+        return
+    end
+
+    local direction
+    if value >= ANALOG_DEADZONE then
+        direction = "positive"
+    elseif value <= -ANALOG_DEADZONE then
+        direction = "negative"
+    end
+
+    if analogAxisDirections[mapping.slot] == direction then
+        return
+    end
+
+    analogAxisDirections[mapping.slot] = direction
+
+    if direction then
+        local action = analogActions[mapping.slot]
+        if action and action[direction] then
+            action[direction]()
+        end
+    end
+end
+
+function TalentTreeScreen:gamepadaxis(_, axis, value)
+    handleAnalog(axis, value)
+end
+
+function TalentTreeScreen:joystickaxis(_, axis, value)
+    handleAnalog(axis, value)
+end
+
+function TalentTreeScreen:joystickpressed(_, button)
+    return handleGamepadButton(button, true)
+end
+
+function TalentTreeScreen:joystickreleased(_, button)
+    stopHeldDpad(button)
+end
+
+function TalentTreeScreen:mousemoved(x, y)
+    hoveredIndex = nil
+    for index, button in ipairs(buttons) do
+        if button.type == "option" then
+            if UI.isHovered(button.x, button.y, button.w, button.h, x, y) then
+                hoveredIndex = index
+            end
+        elseif button.type == "back" then
+            if UI.isHovered(button.x, button.y, button.w, button.h, x, y) then
+                hoveredIndex = index
+            end
+        end
+    end
+
+    if hoveredIndex then
+        setFocus(hoveredIndex)
+    end
+end
+
+function TalentTreeScreen:mousepressed(x, y, button)
+    if button ~= 1 then
+        return
+    end
+
+    local id = UI:mousepressed(x, y, button)
+    if id then
+        pressedButtonId = id
+        for index, entry in ipairs(buttons) do
+            if entry.id == id then
+                setFocus(index)
+                break
+            end
+        end
+    end
+end
+
+function TalentTreeScreen:mousereleased(x, y, button)
+    if button ~= 1 then
+        return
+    end
+
+    local id = UI:mousereleased(x, y, button)
+    if id and pressedButtonId == id then
+        pressedButtonId = nil
+        for index, entry in ipairs(buttons) do
+            if entry.id == id then
+                setFocus(index)
+                local result = activateButton(entry)
+                if result then
+                    return result
+                end
+                break
+            end
+        end
+    else
+        pressedButtonId = nil
+    end
+end
+
+function TalentTreeScreen:wheelmoved(_, y)
+    if not y or y == 0 then
+        return
+    end
+
+    addScroll(y * SCROLL_SPEED)
+end
+
+return TalentTreeScreen


### PR DESCRIPTION
## Summary
- add a persistent four-tier talent system with saved selections and run-time modifiers
- build an interactive talent selection screen with scrolling, controller/mouse support, and a menu entry

## Testing
- not run (Love2D runtime not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68e2adbc735c832fa658505101b064cb