### PR TITLE
Revamp talent tree layout and hazard modifiers

### DIFF
--- a/floorsetup.lua
+++ b/floorsetup.lua
@@ -7,6 +7,7 @@ local Rocks = require("rocks")
 local Saws = require("saws")
 local Lasers = require("lasers")
 local Darts = require("darts")
+local TalentTree = require("talenttree")
 local Movement = require("movement")
 local Particles = require("particles")
 local FloatingText = require("floatingtext")
@@ -474,6 +475,10 @@ function FloorSetup.prepare(floorNum, floorData)
     traitContext = adjustedContext or traitContext
 
     traitContext = Upgrades:modifyFloorContext(traitContext)
+
+    if TalentTree and TalentTree.applyFloorContextModifiers then
+        traitContext = TalentTree:applyFloorContextModifiers(traitContext)
+    end
     traitContext.laserCount = math.max(0, traitContext.laserCount or 0)
     traitContext.dartCount = math.max(0, traitContext.dartCount or 0)
 

--- a/shop.lua
+++ b/shop.lua
@@ -4,6 +4,7 @@ local Audio = require("audio")
 local MetaProgression = require("metaprogression")
 local Theme = require("theme")
 local Shaders = require("shaders")
+local TalentTree = require("talenttree")
 
 local Shop = {}
 
@@ -148,11 +149,24 @@ function Shop:refreshCards(options)
         metaBonus = math.max(0, MetaProgression:getShopBonusSlots() or 0)
     end
 
-    local extraChoices = upgradeBonus + metaBonus
+    local talentBonus = 0
+    if TalentTree and TalentTree.getAggregatedEffects then
+        local effects = TalentTree:getAggregatedEffects()
+        if effects and effects.extraShopChoices then
+            if effects.extraShopChoices >= 0 then
+                talentBonus = math.floor(effects.extraShopChoices + 0.0001)
+            else
+                talentBonus = math.ceil(effects.extraShopChoices - 0.0001)
+            end
+        end
+    end
+
+    local extraChoices = upgradeBonus + metaBonus + talentBonus
 
     self.baseChoices = baseChoices
     self.upgradeBonusChoices = upgradeBonus
     self.metaBonusChoices = metaBonus
+    self.talentBonusChoices = talentBonus
     self.extraChoices = extraChoices
 
     local cardCount = baseChoices + extraChoices


### PR DESCRIPTION
## Summary
- replace each talent tier with new hazard-focused perks that reshape snake speed, hazard cadence, and shop access
- apply talent hazard multipliers during floor setup and expand the shop draw count when bonuses are chosen
- rebuild the talent tree UI card layout to measure text dynamically and surface the new effect summaries

## Testing
- `luac -p talenttree.lua talenttreescreen.lua floorsetup.lua shop.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e305c70404832fb3abd3bc1db9f400