### PR TITLE
Expand talent tree with safeguard tier and improved summary

### DIFF
--- a/talenttree.lua
+++ b/talenttree.lua
@@ -153,6 +153,50 @@ local tiers = {
             },
         },
     },
+    {
+        id = "safeguards",
+        name = "Tier V — Safeguard Doctrine",
+        description = "Tune the run's fail-safes and contingencies for the long haul.",
+        options = {
+            {
+                id = "reinforced_scales",
+                name = "Reinforced Scales",
+                description = "Layer composite plating for extra protection, accepting a slight loss in glide.",
+                bonuses = { "Max health +1", "+1 crash shield" },
+                penalties = { "Snake speed x0.95" },
+                effects = {
+                    maxHealthBonus = 1,
+                    startingCrashShields = 1,
+                    snakeSpeedMultiplier = 0.95,
+                },
+                default = true,
+            },
+            {
+                id = "phase_inductor",
+                name = "Phase Inductor",
+                description = "Spool a phase core for aggressive maneuvers and razor-thin laser windows.",
+                bonuses = { "Snake speed x1.08", "Laser charge x0.85" },
+                penalties = { "Laser cooldown x0.90" },
+                effects = {
+                    snakeSpeedMultiplier = 1.08,
+                    laserChargeMultiplier = 0.85,
+                    laserCooldownMultiplier = 0.90,
+                },
+            },
+            {
+                id = "resupply_manifest",
+                name = "Resupply Manifest",
+                description = "Lean on logistics for richer hauls while trimming the market spread.",
+                bonuses = { "Fruit bonus +0.4", "+1 extra growth" },
+                penalties = { "Shop choices -1" },
+                effects = {
+                    fruitBonus = 0.4,
+                    extraGrowth = 1,
+                    extraShopChoices = -1,
+                },
+            },
+        },
+    },
 }
 
 local function copyTable(source)

--- a/talenttreescreen.lua
+++ b/talenttreescreen.lua
@@ -559,59 +559,66 @@ local function updateLayout()
     end
 end
 
+local function formatSignedLine(label, value, fmt, suffix)
+    local amount = value or 0
+    if math.abs(amount) <= 0.01 then
+        return nil
+    end
+
+    local format = fmt or "%+g"
+    local formatted = string.format(format, amount)
+    if suffix and suffix ~= "" then
+        formatted = formatted .. suffix
+    end
+
+    return string.format("%s %s", label, formatted)
+end
+
+local function formatMultiplierLine(label, multiplier, moreDescriptor, lessDescriptor)
+    multiplier = multiplier or 1
+    if math.abs(multiplier - 1) <= 0.01 then
+        return nil
+    end
+
+    local descriptor
+    if multiplier > 1 then
+        descriptor = moreDescriptor or "higher"
+    else
+        descriptor = lessDescriptor or "lower"
+    end
+
+    return string.format("%s x%.2f (%s)", label, multiplier, descriptor)
+end
+
+local function appendLine(lines, text)
+    if text and text ~= "" then
+        lines[#lines + 1] = text
+    end
+end
+
 local function getSummaryLines()
     local effects = TalentTree:calculateEffects(selections)
     local lines = {}
 
-    if math.abs(effects.maxHealthBonus or 0) > 0.01 then
-        lines[#lines + 1] = string.format("Max health %+g", effects.maxHealthBonus)
-    end
-
-    if math.abs(effects.startingCrashShields or 0) > 0.01 then
-        lines[#lines + 1] = string.format("Crash shields %+g", effects.startingCrashShields)
-    end
-
-    if math.abs((effects.fruitBonus or 0)) > 0.01 then
-        lines[#lines + 1] = string.format("Fruit bonus %+0.1f", effects.fruitBonus)
-    end
-
-    if math.abs((effects.comboMultiplier or 1) - 1) > 0.01 then
-        lines[#lines + 1] = string.format("Combo multiplier x%.2f", effects.comboMultiplier)
-    end
-
-    if math.abs((effects.snakeSpeedMultiplier or 1) - 1) > 0.01 then
-        lines[#lines + 1] = string.format("Snake speed x%.2f", effects.snakeSpeedMultiplier)
-    end
-
-    if math.abs((effects.extraGrowth or 0)) > 0.01 then
-        lines[#lines + 1] = string.format("Extra growth %+0.1f", effects.extraGrowth)
-    end
-
-    if math.abs((effects.rockSpawnMultiplier or 1) - 1) > 0.01 then
-        lines[#lines + 1] = string.format("Rock spawn x%.2f", effects.rockSpawnMultiplier)
-    end
-
-    if math.abs((effects.sawSpeedMultiplier or 1) - 1) > 0.01 then
-        lines[#lines + 1] = string.format("Saw speed x%.2f", effects.sawSpeedMultiplier)
-    end
-
-    if math.abs((effects.laserCooldownMultiplier or 1) - 1) > 0.01 then
-        lines[#lines + 1] = string.format("Laser cooldown x%.2f", effects.laserCooldownMultiplier)
-    end
-
-    if math.abs((effects.laserChargeMultiplier or 1) - 1) > 0.01 then
-        lines[#lines + 1] = string.format("Laser charge x%.2f", effects.laserChargeMultiplier)
-    end
-
-    if math.abs(effects.sawStallOnFruit or 0) > 0.01 then
-        lines[#lines + 1] = string.format("Saw stall on fruit %+0.1fs", effects.sawStallOnFruit)
-    end
+    appendLine(lines, formatSignedLine("Max health", effects.maxHealthBonus))
+    appendLine(lines, formatSignedLine("Crash shields", effects.startingCrashShields))
+    appendLine(lines, formatSignedLine("Fruit bonus", effects.fruitBonus, "%+0.1f"))
+    appendLine(lines, formatMultiplierLine("Combo multiplier", effects.comboMultiplier, "stronger", "weaker"))
+    appendLine(lines, formatMultiplierLine("Snake speed", effects.snakeSpeedMultiplier, "faster", "slower"))
+    appendLine(lines, formatSignedLine("Extra growth", effects.extraGrowth, "%+0.1f"))
+    appendLine(lines, formatMultiplierLine("Rock spawn", effects.rockSpawnMultiplier, "more frequent", "less frequent"))
+    appendLine(lines, formatMultiplierLine("Saw speed", effects.sawSpeedMultiplier, "faster", "slower"))
+    appendLine(lines, formatMultiplierLine("Laser cooldown", effects.laserCooldownMultiplier, "longer cycle", "faster cycle"))
+    appendLine(lines, formatMultiplierLine("Laser charge", effects.laserChargeMultiplier, "longer telegraph", "quicker telegraph"))
+    appendLine(lines, formatSignedLine("Saw stall on fruit", effects.sawStallOnFruit, "%+0.1f", "s"))
 
     if math.abs(effects.extraShopChoices or 0) > 0.01 then
         local raw = effects.extraShopChoices
         local rounded = raw >= 0 and math.floor(raw + 0.0001) or math.ceil(raw - 0.0001)
         if rounded ~= 0 then
-            lines[#lines + 1] = string.format("Shop choices %+d", rounded)
+            appendLine(lines, string.format("Shop choices %+d", rounded))
+        else
+            appendLine(lines, string.format("Shop choices %+0.1f", raw))
         end
     end
 


### PR DESCRIPTION
## Summary
- add a Tier V Safeguard Doctrine tier that introduces new survivability-focused talent trade-offs and penalties
- enhance the loadout summary with helper formatting so multipliers and signed bonuses read with clearer descriptors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e316c2eb4c832fb0af55706fd2be1b