### PR TITLE
Limit game modes to classic and hardcore

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -366,18 +366,8 @@ local english = {
             },
             hardcore = {
                 label = "Hardcore",
-                description = "Faster speed, tighter reflexes required.",
+                description = "Faster speed and zero margin for error — one hit ends the run.",
                 unlock_description = "Score 25 in Classic mode.",
-            },
-            timed = {
-                label = "Timed",
-                description = "60 seconds. Eat as many apples as you can.",
-                unlock_description = "Eat 50 apples total.",
-                timer_label = "Time: ${seconds}",
-            },
-            daily = {
-                label = "Daily Challenge",
-                description = "A new challenge each day — random effects, one shot.",
             },
         },
         upgrades = {

--- a/gamemodes.lua
+++ b/gamemodes.lua
@@ -8,10 +8,6 @@ local GameModes = {}
 -------------------------------------------------
 -- Shared assets (preloaded to avoid per-frame GC)
 -------------------------------------------------
-local FONTS = {
-    timer = UI.fonts.timerSmall or UI.fonts.button
-}
-
 -------------------------------------------------
 -- Internal constants
 -------------------------------------------------
@@ -59,67 +55,9 @@ GameModes.available = {
             end
         end,
     },
-
-    timed = {
-        labelKey = "gamemodes.timed.label",
-        descriptionKey = "gamemodes.timed.description",
-        speed = 0.06,
-        timed = true,
-        timeLimit = 60,
-        unlocked = false,
-        unlockCondition = {
-            type = "playerStat",
-            stat = "totalApplesEaten",
-            value = 50,
-        },
-        unlockDescriptionKey = "gamemodes.timed.unlock_description",
-        maxHealth = 3,
-
-        load = function(game)
-            game.timer = game.mode.timeLimit
-            game.timerExpired = false
-        end,
-
-        update = function(game, dt)
-            if game.timer and not game.timerExpired then
-                game.timer = game.timer - dt
-                if game.timer <= 0 then
-                    game.timer = 0
-                    game.timerExpired = true
-                    game.dead = true
-                end
-            end
-        end,
-
-        draw = function(game)
-            if game.timer and not game.gameOver then
-                local timeLeft = math.ceil(game.timer)
-                love.graphics.setColor(1, 1, 1, 0.9)
-                love.graphics.setFont(FONTS.timer)
-                local label = Localization:get("gamemodes.timed.timer_label", { seconds = timeLeft })
-                love.graphics.printf(label, 0, 16, love.graphics.getWidth(), "center")
-                love.graphics.setColor(1, 1, 1, 1) -- reset color
-            end
-        end,
-    },
-
-    daily = {
-        labelKey = "gamemodes.daily.label",
-        descriptionKey = "gamemodes.daily.description",
-        speed = 0.06,
-        timed = false,
-        timeLimit = nil,
-        unlocked = true,
-        daily = true,
-        maxHealth = 3,
-
-        load = function(game)
-            game.effects = GameModes:getDailyModifiers()
-        end,
-    },
 }
 
-GameModes.modeList = { "classic", "hardcore", "timed", "daily" }
+GameModes.modeList = { "classic", "hardcore" }
 GameModes.current = "classic"
 GameModes.unlockData = {}
 
@@ -138,37 +76,6 @@ end
 
 function GameModes:getCurrentName()
     return self.current
-end
-
--------------------------------------------------
--- Daily challenge utilities
--------------------------------------------------
-function GameModes:getDailySeed()
-    return tonumber(os.date("%Y%m%d"))
-end
-
-function GameModes:getDailyModifiers()
-    local seed = self:getDailySeed()
-    love.math.setRandomSeed(seed)
-
-    local possibleEffects = {
-        "reverseControls",
-        "scoreMultiplier",
-        "slowTime",
-        "speedBoost",
-    }
-
-    local chosen = {}
-    local count = 2 + love.math.random(0, 2) -- 2–4 effects
-
-    for i = 1, count do
-        if #possibleEffects == 0 then break end
-        local index = love.math.random(1, #possibleEffects)
-        table.insert(chosen, possibleEffects[index])
-        table.remove(possibleEffects, index)
-    end
-
-    return chosen
 end
 
 -------------------------------------------------


### PR DESCRIPTION
## Summary
- remove the timed and daily mode definitions so only classic and hardcore remain selectable
- update localization to describe hardcore as a one-hit death challenge

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3251237ec832f81ac461442ab1949