### PR TITLE
Refine snake body rendering

### DIFF
--- a/snakedraw.lua
+++ b/snakedraw.lua
@@ -6,7 +6,7 @@ local unpack = unpack
 -- tweakables
 local POP_DURATION   = 0.25
 local SHADOW_OFFSET  = 3
-local OUTLINE_SIZE   = 6
+local OUTLINE_SIZE   = 3
 local FRUIT_BULGE_SCALE = 1.25
 
 -- Canvas for single-pass shadow
@@ -217,42 +217,6 @@ local function buildCoords(trail)
   return coords
 end
 
-local function drawPolyline(coords)
-  if #coords >= 4 then
-    love.graphics.line(unpack(coords))
-  end
-end
-
-local function drawEndcaps(head, tail, radius)
-  local hx, hy = ptXY(head)
-  local tx, ty = ptXY(tail)
-  if hx and hy then love.graphics.circle("fill", hx, hy, radius) end
-  if tx and ty then love.graphics.circle("fill", tx, ty, radius) end
-end
-
--- draw a body-colored "plug" circle at each corner
-local function drawCornerPlugs(trail, radius)
-  for i = 2, #trail-1 do
-    local x0,y0 = ptXY(trail[i-1])
-    local x1,y1 = ptXY(trail[i])
-    local x2,y2 = ptXY(trail[i+1])
-    if x0 and y0 and x1 and y1 and x2 and y2 then
-      -- Only bother if it's actually a turn (angle change > tiny threshold)
-      local ux,uy = x1-x0, y1-y0
-      local vx,vy = x2-x1, y2-y1
-      local ul = math.sqrt(ux*ux + uy*uy)
-      local vl = math.sqrt(vx*vx + vy*vy)
-      if ul > 1e-3 and vl > 1e-3 then
-        local dot = (ux*vx + uy*vy) / (ul*vl)
-        if dot < 0.999 then -- not perfectly straight
-          love.graphics.circle("fill", x1, y1, radius)
-        end
-      end
-    end
-  end
-end
-
-
 local function drawFruitBulges(trail, head, radius)
   if not trail or radius <= 0 then return end
 
@@ -269,28 +233,58 @@ local function drawFruitBulges(trail, head, radius)
   end
 end
 
-local function renderSnakeToCanvas(trail, coords, head, tail, half, thickness)
+local function drawCapsuleSegment(mode, x1, y1, x2, y2, radius)
+  if not (x1 and y1 and x2 and y2) then return end
+
+  local dx, dy = x2 - x1, y2 - y1
+  local length = math.sqrt(dx * dx + dy * dy)
+  if length <= 1e-3 then
+    love.graphics.circle(mode, x1, y1, radius)
+    return
+  end
+
+  local angle
+  if math.atan2 then
+    angle = math.atan2(dy, dx)
+  else
+    angle = math.atan(dy, dx)
+  end
+
+  love.graphics.push()
+  love.graphics.translate(x1, y1)
+  love.graphics.rotate(angle)
+  love.graphics.rectangle(mode, 0, -radius, length, radius * 2, radius, radius)
+  love.graphics.pop()
+end
+
+local function drawCapsuleChain(coords, radius)
+  if #coords < 2 then
+    return
+  end
+
+  if #coords == 2 then
+    love.graphics.circle("fill", coords[1], coords[2], radius)
+    return
+  end
+
+  for i = 1, #coords - 2, 2 do
+    drawCapsuleSegment("fill", coords[i], coords[i + 1], coords[i + 2], coords[i + 3], radius)
+  end
+end
+
+local function renderSnakeToCanvas(trail, coords, head, half)
   local bodyColor = SnakeCosmetics:getBodyColor()
   local outlineColor = SnakeCosmetics:getOutlineColor()
   local bodyR, bodyG, bodyB, bodyA = bodyColor[1] or 0, bodyColor[2] or 0, bodyColor[3] or 0, bodyColor[4] or 1
   local outlineR, outlineG, outlineB, outlineA = outlineColor[1] or 0, outlineColor[2] or 0, outlineColor[3] or 0, outlineColor[4] or 1
-  -- OUTLINE
-  love.graphics.setColor(outlineR, outlineG, outlineB, outlineA)
-  love.graphics.setLineWidth(thickness + OUTLINE_SIZE)
-  drawPolyline(coords)
-  drawEndcaps(head, tail, half + OUTLINE_SIZE * 0.5)
-  drawCornerPlugs(trail, half + OUTLINE_SIZE*0.5)
   local bulgeRadius = half * FRUIT_BULGE_SCALE
-  drawFruitBulges(trail, head, bulgeRadius + OUTLINE_SIZE * 0.5)
 
-  -- BODY
-  love.graphics.setColor(bodyR, bodyG, bodyB, bodyA)
-  love.graphics.setLineWidth(thickness)
-  drawPolyline(coords)
-  drawEndcaps(head, tail, half)
+  love.graphics.setColor(outlineR, outlineG, outlineB, outlineA)
+  drawCapsuleChain(coords, half + OUTLINE_SIZE)
+  drawFruitBulges(trail, head, bulgeRadius + OUTLINE_SIZE)
 
   love.graphics.setColor(bodyR, bodyG, bodyB, bodyA)
-  drawCornerPlugs(trail, half)
+  drawCapsuleChain(coords, half)
   drawFruitBulges(trail, head, bulgeRadius)
 
 end
@@ -689,7 +683,6 @@ local function drawSnake(trail, segmentCount, SEGMENT_SIZE, popTimer, getHead, s
 
   local coords = buildCoords(trail)
   local head = trail[1]
-  local tail = trail[#trail]
 
   love.graphics.setLineStyle("smooth")
   love.graphics.setLineJoin("bevel") -- or "bevel" if you prefer fewer spikes
@@ -711,7 +704,7 @@ local function drawSnake(trail, segmentCount, SEGMENT_SIZE, popTimer, getHead, s
 
     love.graphics.setCanvas(snakeCanvas)
     love.graphics.clear(0,0,0,0)
-    renderSnakeToCanvas(trail, coords, head, tail, half, thickness)
+    renderSnakeToCanvas(trail, coords, head, half)
     love.graphics.setCanvas()
 
     -- single-pass drop shadow
@@ -755,8 +748,7 @@ local function drawSnake(trail, segmentCount, SEGMENT_SIZE, popTimer, getHead, s
     local bodyA = bodyColor[4] or 1
 
     love.graphics.setColor(outlineR, outlineG, outlineB, outlineA)
-    love.graphics.setLineWidth(OUTLINE_SIZE)
-    love.graphics.circle("line", hx, hy, half + OUTLINE_SIZE * 0.5)
+    love.graphics.circle("fill", hx, hy, half + OUTLINE_SIZE)
     love.graphics.setColor(bodyR, bodyG, bodyB, bodyA)
     love.graphics.circle("fill", hx, hy, half)
 


### PR DESCRIPTION
## Summary
- refactor the snake body rendering to use pill-shaped capsules with a consistent 3px outline and existing drop shadow pass
- update fruit bulge and fallback head rendering to match the simplified visuals

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68e3301fd464832f91d419e93608f07f