### PR TITLE
Fix overlay application call in snake presentation

### DIFF
--- a/snakedraw.lua
+++ b/snakedraw.lua
@@ -13,6 +13,8 @@ local FRUIT_BULGE_SCALE = 1.25
 local snakeCanvas = nil
 local snakeOverlayCanvas = nil
 
+local applyOverlay
+
 local overlayShaderSources = {
   stripes = [[
     extern float time;
@@ -158,7 +160,7 @@ local function resolveColor(color, fallback)
   return {1, 1, 1, 1}
 end
 
-local function applyOverlay(canvas, config)
+applyOverlay = function(canvas, config)
   if not (canvas and config and config.type) then
     return false
   end


### PR DESCRIPTION
## Summary
- forward declare the overlay helper so it can be used when presenting the snake canvas
- convert the overlay helper definition to assign to the declared local function

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e33ecb6b80832f8cc925b7b67b477f