### PR TITLE
Remove snake body glow effect

### DIFF
--- a/snakedraw.lua
+++ b/snakedraw.lua
@@ -212,52 +212,6 @@ end
 
 local drawSoftGlow
 
-local function clamp01(value)
-  if value < 0 then return 0 end
-  if value > 1 then return 1 end
-  return value
-end
-
-local function applySkinGlow(trail, head, radius, config)
-  if not config then
-    return
-  end
-
-  local color = resolveColor(config.color, SnakeCosmetics:getGlowColor())
-  local bodyColor = SnakeCosmetics:getBodyColor()
-  local bodyR = bodyColor[1] or 0
-  local bodyG = bodyColor[2] or 0
-  local bodyB = bodyColor[3] or 0
-
-  local matchBody = config.matchBody
-  if matchBody == nil then
-    matchBody = true
-  end
-
-  if matchBody then
-    local blend = clamp01(config.bodyBlend or 1)
-    local inv = 1 - blend
-    color[1] = (color[1] or 0) * inv + bodyR * blend
-    color[2] = (color[2] or 0) * inv + bodyG * blend
-    color[3] = (color[3] or 0) * inv + bodyB * blend
-  end
-
-  local intensity = config.intensity or 0.5
-  local radiusMultiplier = config.radiusMultiplier or 1.4
-
-  local function drawGlowAt(x, y)
-    if not (x and y) then
-      return
-    end
-    drawSoftGlow(x, y, radius * radiusMultiplier, color[1], color[2], color[3], (color[4] or 1) * intensity, "alpha")
-  end
-
-  if head then
-    local hx, hy = ptXY(head)
-    drawGlowAt(hx, hy)
-  end
-end
-
 -- polyline coords {x1,y1,x2,y2,...}
 local function buildCoords(trail)
   local coords = {}
@@ -823,7 +777,6 @@ local function drawSnake(trail, segmentCount, SEGMENT_SIZE, popTimer, getHead, s
   local half      = thickness / 2
 
   local overlayEffect = SnakeCosmetics:getOverlayEffect()
-  local glowEffect = SnakeCosmetics:getGlowEffect()
 
   local coords = buildCoords(trail)
   local head = trail[1]
@@ -849,7 +802,6 @@ local function drawSnake(trail, segmentCount, SEGMENT_SIZE, popTimer, getHead, s
     renderSnakeToCanvas(trail, coords, head, half)
     love.graphics.setCanvas()
     presentSnakeCanvas(overlayEffect, ww, hh)
-    applySkinGlow(trail, head, half, glowEffect)
   elseif hx and hy then
     -- fallback: draw a simple disk when only the head is visible
     local bodyColor = SnakeCosmetics:getBodyColor()
@@ -875,7 +827,6 @@ local function drawSnake(trail, segmentCount, SEGMENT_SIZE, popTimer, getHead, s
     love.graphics.setCanvas()
 
     presentSnakeCanvas(overlayEffect, ww, hh)
-    applySkinGlow(trail, head, half, glowEffect)
   end
 
   if hx and hy and drawFace ~= false then


### PR DESCRIPTION
## Summary
- remove the snake body glow routine so skins no longer draw a soft highlight
- simplify the snake drawing flow now that the glow overlay is gone

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3432f1bf0832fa6f3639e0c51832b