### PR TITLE
Handle unavailable round line join

### DIFF
--- a/ui.lua
+++ b/ui.lua
@@ -265,7 +265,10 @@ local function drawHeartOutline(x, y, size, thickness)
 
     love.graphics.setLineWidth(thickness)
     if love.graphics.setLineJoin then
-        love.graphics.setLineJoin("round")
+        local ok = pcall(love.graphics.setLineJoin, "round")
+        if not ok then
+            pcall(love.graphics.setLineJoin, "bevel")
+        end
     end
     if love.graphics.setLineStyle then
         love.graphics.setLineStyle("smooth")


### PR DESCRIPTION
## Summary
- guard `love.graphics.setLineJoin` so we fall back when the engine rejects the `"round"` option

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e34ce8c114832fbbfdc673e33fcac8