### PR TITLE
Hook up hardcore mode unlocking to run results

### DIFF
--- a/score.lua
+++ b/score.lua
@@ -217,7 +217,7 @@ function Score:handleGameOver(cause)
         PlayerStats:updateMax("longestFloorClearTime", slowestFloor)
     end
 
-    return {
+    local result = {
         score       = self.current,
         highScore   = self:getHighScore(mode),
         apples      = runApples,
@@ -229,6 +229,10 @@ function Score:handleGameOver(cause)
         cause = cause or "unknown",
         won = false,
     }
+
+    GameModes:checkUnlocks(result, mode)
+
+    return result
 end
 
 return Score


### PR DESCRIPTION
## Summary
- call the game mode unlock check when compiling the game over result so score-based modes unlock after qualifying runs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e361d12108832fa8dba0df037e4d2e