### PR TITLE
Fix talent tree summary layout initialization

### DIFF
--- a/talenttreescreen.lua
+++ b/talenttreescreen.lua
@@ -77,6 +77,8 @@ local summaryLayout = {
     lineHeight = 0,
 }
 
+local refreshSummaryLayout
+
 local function selectionsMatchDefaults()
     if not tiers or #tiers == 0 then
         return true
@@ -886,7 +888,7 @@ local function getSelectionSummaryLines()
     return lines
 end
 
-local function refreshSummaryLayout()
+refreshSummaryLayout = function()
     local loadoutLines = getSummaryLines()
     local picks = getSelectionSummaryLines()
 


### PR DESCRIPTION
## Summary
- forward declare the summary layout refresh helper so updateLayout can call it reliably
- assign the refresh function to the declared local to prevent nil global errors when entering the talent tree

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3e1e19fcc832f8a6524b4331675e5