### PR TITLE
Ensure snake renders above arena exit hole

### DIFF
--- a/game.lua
+++ b/game.lua
@@ -863,9 +863,13 @@ local function drawPlayfieldLayers(self, stateOverride)
     Lasers:draw()
     Darts:draw()
     Saws:draw()
-    Arena:drawExit()
 
-    if renderState == "descending" then
+    local isDescending = (renderState == "descending")
+    if not isDescending then
+        Arena:drawExit()
+    end
+
+    if isDescending then
         self:drawDescending()
     elseif renderState == "dying" then
         Death:draw()
@@ -1307,6 +1311,8 @@ function Game:drawStateTransition(direction, progress, eased, alpha)
 end
 
 function Game:drawDescending()
+    Arena:drawExit()
+
     if not self.hole then
         Snake:draw()
         return


### PR DESCRIPTION
## Summary
- only draw the arena exit in the main render loop when not descending
- render the arena exit as part of the descending draw path so the snake is painted afterwards

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e43edca094832f90654087c770a403