### PR TITLE
Stop upscaling splash screen logo

### DIFF
--- a/splashscreen.lua
+++ b/splashscreen.lua
@@ -53,10 +53,8 @@ local function drawLogo(image, width, height)
 
     local maxWidth = width * 0.5
     local maxHeight = height * 0.5
-    local scale = math.min(maxWidth / imgWidth, maxHeight / imgHeight)
-    if scale > 1.75 then
-        scale = 1.75
-    elseif scale <= 0 then
+    local scale = math.min(maxWidth / imgWidth, maxHeight / imgHeight, 1)
+    if scale <= 0 then
         scale = 1
     end
 


### PR DESCRIPTION
## Summary
- clamp the splash screen logo scale so it never exceeds its native image size

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4485cc6f4832f96515c7f19f44915