### PR TITLE
Prevent rock spawns in front of the snake

### DIFF
--- a/floorsetup.lua
+++ b/floorsetup.lua
@@ -331,7 +331,16 @@ end
 
 local function spawnRocks(numRocks, safeZone)
     for _ = 1, numRocks do
-        local fx, fy = SnakeUtils.getSafeSpawn(Snake:getSegments(), Fruit, Rocks, safeZone)
+        local fx, fy = SnakeUtils.getSafeSpawn(
+            Snake:getSegments(),
+            Fruit,
+            Rocks,
+            safeZone,
+            {
+                avoidFrontOfSnake = true,
+                direction = Snake:getDirection(),
+            }
+        )
         if fx then
             Rocks:spawn(fx, fy, "small")
             local col, row = Arena:getTileFromWorld(fx, fy)

--- a/fruitevents.lua
+++ b/fruitevents.lua
@@ -301,7 +301,16 @@ function FruitEvents.handleConsumption(x, y)
     end
 
     if love.math.random() < Rocks:getSpawnChance() then
-        local fx, fy, tileCol, tileRow = SnakeUtils.getSafeSpawn(Snake:getSegments(), Fruit, Rocks, safeZone)
+        local fx, fy, tileCol, tileRow = SnakeUtils.getSafeSpawn(
+            Snake:getSegments(),
+            Fruit,
+            Rocks,
+            safeZone,
+            {
+                avoidFrontOfSnake = true,
+                direction = Snake:getDirection(),
+            }
+        )
         if fx then
             Rocks:spawn(fx, fy, "small")
             SnakeUtils.setOccupied(tileCol, tileRow, true)


### PR DESCRIPTION
## Summary
- add an option to SnakeUtils.getSafeSpawn that blocks the tile directly in front of the snake
- use the new option when spawning rocks on floor load and from fruit events so they never appear ahead of the player

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e577612bc4832fa7d880d60e1bef36