### PR TITLE
Add reactive feedback overlays and impact effects

### DIFF
--- a/shaders.lua
+++ b/shaders.lua
@@ -65,6 +65,8 @@ local EVENT_COLORS = {
     stallSaws = {0.65, 0.82, 1.0, 1},
     score = {1.0, 0.72, 0.36, 1},
     dragonfruit = {1.0, 0.45, 0.28, 1},
+    danger = {1.0, 0.38, 0.38, 1},
+    tension = {1.0, 0.67, 0.35, 1},
 }
 
 local function assignEventColor(color)


### PR DESCRIPTION
## Summary
- add a gameplay feedback state that powers impact flashes, surge pulses, and danger vignettes on top of the playfield
- trigger the new feedback hooks when scoring fruit or taking damage and expose additional shader colors for these events
- spawn dramatic particles and floating combat text when the snake gets hit or burns a shield charge

## Testing
- not run (lua interpreter not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e578b48ce8832fbdfc5d93dd50374f