### PR TITLE
Speed up floor intro pacing

### DIFF
--- a/transitionmanager.lua
+++ b/transitionmanager.lua
@@ -117,7 +117,7 @@ function TransitionManager:startFloorIntro(duration, extra)
     self:mergeData(extra)
 
     local data = self.data
-    local introDuration = duration or data.transitionIntroDuration or 3.5
+    local introDuration = duration or data.transitionIntroDuration or 2.8
     data.transitionIntroDuration = introDuration
 
     if extra.transitionAwaitInput ~= nil then
@@ -129,7 +129,7 @@ function TransitionManager:startFloorIntro(duration, extra)
     if extra.transitionIntroPromptDelay ~= nil then
         data.transitionIntroPromptDelay = extra.transitionIntroPromptDelay or 0
     else
-        data.transitionIntroPromptDelay = 0.35
+        data.transitionIntroPromptDelay = 0.25
     end
 
     data.transitionIntroConfirmed = nil


### PR DESCRIPTION
## Summary
- reduce the default floor intro duration to tighten pacing
- shorten the floor intro prompt delay so players can continue sooner

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e58443d4ac832fbbaab3e329cf2edc