### PR TITLE
Reduce fruit collection border flare intensity

### DIFF
--- a/fruitevents.lua
+++ b/fruitevents.lua
@@ -327,9 +327,9 @@ function FruitEvents.handleConsumption(x, y)
 
     if Arena and Arena.triggerBorderFlare then
         local comboCount = FruitEvents.getComboCount and FruitEvents.getComboCount() or 0
-        local baseStrength = 0.45
-        local comboBoost = math.min(comboCount, 5) * 0.08
-        local duration = 0.8 + math.min(comboCount, 4) * 0.05
+        local baseStrength = 0.12
+        local comboBoost = math.min(comboCount, 5) * 0.02
+        local duration = 0.55 + math.min(comboCount, 4) * 0.03
         Arena:triggerBorderFlare(baseStrength + comboBoost, duration)
     end
 


### PR DESCRIPTION
## Summary
- lower the arena border flare base strength triggered by fruit collection
- reduce combo scaling and duration so the flash effect is significantly more subtle

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5a12f7960832fabb509a2265c026c