### PR TITLE
Delay gameplay until floor intro completes

### DIFF
--- a/transitionmanager.lua
+++ b/transitionmanager.lua
@@ -48,6 +48,10 @@ function TransitionManager:isGameplayBlocked()
 
     if phase == "floorintro" then
         local data = self.data or {}
+        local duration = self.duration or 0
+        if self.timer < duration then
+            return true
+        end
         return data.transitionAwaitInput and not data.transitionIntroConfirmed
     end
 


### PR DESCRIPTION
## Summary
- block gameplay during the floor intro phase until the name and description animations have fully finished

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5ecfb899c832f98a127d8dfe4543c