### PR TITLE
Ensure drawword snake lettering has sharp corners

### DIFF
--- a/drawword.lua
+++ b/drawword.lua
@@ -95,7 +95,10 @@ local function drawWord(word, ox, oy, cellSize, spacing)
 
       -- The menu draws the face manually so it sits at the end of the word.
       -- Disable the built-in face rendering here to avoid double faces.
-      drawSnake(letterTrail, #letterTrail, cellSize, nil, nil, nil, nil, nil, false)
+      drawSnake(letterTrail, #letterTrail, cellSize, nil, nil, nil, nil, nil, {
+        drawFace = false,
+        sharpCorners = true
+      })
 
       for _, p in ipairs(letterTrail) do table.insert(fullTrail, p) end
 


### PR DESCRIPTION
## Summary
- extend the snake renderer to accept options for sharp-corner rendering
- bypass curve smoothing when drawing static words so letters use clean 90° turns

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5f14996a4832f937136f58cf1accc