### PR TITLE
Use rounded corners when drawing word overlays

### DIFF
--- a/drawword.lua
+++ b/drawword.lua
@@ -96,9 +96,7 @@ local function drawWord(word, ox, oy, cellSize, spacing)
       -- The menu draws the face manually so it sits at the end of the word.
       -- Disable the built-in face rendering here to avoid double faces.
       drawSnake(letterTrail, #letterTrail, cellSize, nil, nil, nil, nil, nil, {
-        drawFace = false,
-        sharpCorners = true,
-        cornerCaps = true
+        drawFace = false
       })
 
       for _, p in ipairs(letterTrail) do table.insert(fullTrail, p) end


### PR DESCRIPTION
## Summary
- stop requesting sharp corner rendering when drawing word trails
- rely on default rounded corner handling from the snake renderer for smoother letter edges

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5f871b270832fb23a8fc1de323c78