### PR TITLE
Limit ambient lasers on early machine floors

### DIFF
--- a/floorsetup.lua
+++ b/floorsetup.lua
@@ -352,16 +352,30 @@ local function spawnRocks(numRocks, safeZone)
     end
 end
 
-local function getAmbientLaserPreference(floorData)
+local function getAmbientLaserPreference(traitContext, floorData)
     if not floorData then
         return 0
     end
 
-    if floorData.backgroundTheme == "machine" then
-        return 2
+    local floorIndex = traitContext and traitContext.floor
+
+    local function isMachineThemed()
+        if floorData.backgroundTheme == "machine" then
+            return true
+        end
+
+        if type(floorData.name) == "string" and floorData.name:lower():find("machin") then
+            return true
+        end
+
+        return false
     end
 
-    if type(floorData.name) == "string" and floorData.name:lower():find("machin") then
+    if isMachineThemed() then
+        if floorIndex and floorIndex <= 5 then
+            return 1
+        end
+
         return 2
     end
 
@@ -375,7 +389,7 @@ local function getDesiredLaserCount(traitContext, floorData)
         baseline = math.max(0, math.floor((traitContext.laserCount or 0) + 0.5))
     end
 
-    local ambient = getAmbientLaserPreference(floorData)
+    local ambient = getAmbientLaserPreference(traitContext, floorData)
 
     return math.max(baseline, ambient)
 end


### PR DESCRIPTION
## Summary
- adjust the ambient laser preference helper to consider the current floor index
- cap machine-themed ambient lasers to one on early floors so Ancient Ruins no longer spawns two

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5fb40ac1c832f8f16c6f7b689cff5