### PR TITLE
Polish settings screen layout

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -127,6 +127,10 @@ local english = {
         },
         settings = {
             title = "Settings",
+            section_display = "Display",
+            section_audio = "Audio",
+            section_gameplay = "Gameplay",
+            section_interface = "Interface",
             display_mode = "Display Mode",
             display_mode_fullscreen = "Fullscreen",
             display_mode_windowed = "Windowed",

--- a/ui.lua
+++ b/ui.lua
@@ -398,18 +398,20 @@ UI.colors = {
 
 -- Spacing and layout constants
 UI.spacing = {
-    buttonWidth       = 260,
-    buttonHeight      = 56,
-    buttonRadius      = 14,
-    buttonSpacing     = 24,
-    panelRadius       = 16,
-    panelPadding      = 20,
-    shadowOffset      = 6,
-    sectionSpacing    = 28,
-    sliderHeight      = 68,
-    sliderTrackHeight = 10,
-    sliderHandleRadius= 12,
-    sliderPadding     = 22,
+    buttonWidth         = 260,
+    buttonHeight        = 56,
+    buttonRadius        = 14,
+    buttonSpacing       = 24,
+    panelRadius         = 16,
+    panelPadding        = 20,
+    shadowOffset        = 6,
+    sectionSpacing      = 28,
+    sectionHeaderHeight = UI.fonts.heading:getHeight() + 8,
+    sectionHeaderSpacing= 16,
+    sliderHeight        = 68,
+    sliderTrackHeight   = 10,
+    sliderHandleRadius  = 12,
+    sliderPadding       = 22,
 }
 
 -- Utility: set font


### PR DESCRIPTION
## Summary
- group settings options under display, audio, gameplay, and interface headers to improve readability
- update focus handling and scroll restoration to skip static headers and retain the selected option when the layout refreshes
- add localization strings and UI spacing for the new section styling

## Testing
- ⚠️ `luac -p settingsscreen.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e5fe36b41c832fbf4c092db2a51550