### PR TITLE
Polish achievements menu with progress summary

### DIFF
--- a/Languages/english.lua
+++ b/Languages/english.lua
@@ -170,6 +170,11 @@ local english = {
                 label = "${current}/${goal}",
                 unlocked = "Completed",
             },
+            summary = {
+                unlocked = "${unlocked}/${total} unlocked",
+                completion = "${percent}% complete",
+                hint = "Keep slithering to discover new achievements.",
+            },
             hidden = {
                 title = "Hidden Achievement",
                 description = "Unlock this secret to reveal its details.",

--- a/achievements.lua
+++ b/achievements.lua
@@ -657,6 +657,37 @@ function Achievements:getProgressRatio(def)
     return 0
 end
 
+function Achievements:getTotals()
+    self:_ensureInitialized()
+
+    local total = #self.definitionOrder
+    local unlocked = 0
+    local completion = 0
+
+    if total == 0 then
+        return {
+            total = 0,
+            unlocked = 0,
+            completion = 0,
+        }
+    end
+
+    for _, id in ipairs(self.definitionOrder) do
+        local def = self.definitions[id]
+        if def and def.unlocked then
+            unlocked = unlocked + 1
+        end
+    end
+
+    completion = unlocked / total
+
+    return {
+        total = total,
+        unlocked = unlocked,
+        completion = completion,
+    }
+end
+
 function Achievements:getDefinition(id)
     self:_ensureInitialized()
     return self.definitions[id]


### PR DESCRIPTION
## Summary
- add an aggregate achievements total helper for the menu
- refresh the achievements screen with a header summary, divider, and progress bar
- add localization strings for the new summary labels

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e604a55024832fb8de3b38f8b2fe97