### PR TITLE
Adjust draw word snake corners

### DIFF
--- a/drawword.lua
+++ b/drawword.lua
@@ -96,7 +96,9 @@ local function drawWord(word, ox, oy, cellSize, spacing)
       -- The menu draws the face manually so it sits at the end of the word.
       -- Disable the built-in face rendering here to avoid double faces.
       drawSnake(letterTrail, #letterTrail, cellSize, nil, nil, nil, nil, nil, {
-        drawFace = false
+        drawFace = false,
+        sharpCorners = true,
+        cornerCaps = true
       })
 
       for _, p in ipairs(letterTrail) do table.insert(fullTrail, p) end


### PR DESCRIPTION
## Summary
- render the word snake with sharp corners
- preserve corner caps for consistent turn styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6906e79d0832fb971f9a8cee9d275